### PR TITLE
Add an element-size variant to type_row!

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -47,7 +47,10 @@ pub(crate) use impl_box_clone;
 /// const B: SimpleType = SimpleType::Classic(ClassicType::bit());
 /// let static_row: TypeRow = type_row![B, B];
 /// let dynamic_row: TypeRow = vec![B, B, B].into();
-/// let sig: Signature = Signature::new_df(static_row, dynamic_row);
+/// let sig: Signature = Signature::new_df(static_row.clone(), dynamic_row);
+///
+/// let repeated_row: TypeRow = type_row![B; 2];
+/// assert_eq!(repeated_row, static_row);
 /// ```
 #[allow(unused_macros)]
 #[macro_export]
@@ -56,6 +59,14 @@ macro_rules! type_row {
         {
             use $crate::types;
             static ROW: &[types::SimpleType] = &[$($t),*];
+            let row: types::TypeRow = ROW.into();
+            row
+        }
+    };
+    ($t:ident; $n:expr) => {
+        {
+            use $crate::types;
+            static ROW: &[types::SimpleType] = &[$t; $n];
             let row: types::TypeRow = ROW.into();
             row
         }


### PR DESCRIPTION
Adds the option to use `type_row![T; 42]` to define an static type row with repeated elements.