### PR TITLE
Use portgraph's toposort to check dags

### DIFF
--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -239,7 +239,7 @@ impl Hugr {
         Ok(())
     }
 
-    /// A filter function por internal dataflow edges.
+    /// A filter function for internal dataflow edges.
     ///
     /// Returns `true` for ports that connect to a sibling node with a value or
     /// state order edge.


### PR DESCRIPTION
Now it doesn't allow other sources and sinks outside the input and output nodes respectively. This detected the bug from #33 .