### PR TITLE
Validation tests

### DIFF
--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -83,14 +83,12 @@ impl HugrMut {
         port: usize,
         direction: Direction,
     ) -> Result<(), HugrError> {
+        let offset = PortOffset::new(direction, port);
         let port = self
             .hugr
             .graph
-            .port_index(node, PortOffset::new(direction, port))
-            .ok_or(portgraph::LinkError::UnknownOffset {
-                node,
-                offset: PortOffset::new_outgoing(port),
-            })?;
+            .port_index(node, offset)
+            .ok_or(portgraph::LinkError::UnknownOffset { node, offset })?;
         self.hugr.graph.unlink_port(port);
         Ok(())
     }

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -671,7 +671,7 @@ mod test {
     use crate::hugr::HugrMut;
     use crate::ops::{BasicBlockOp, ConstValue, ModuleOp, OpType};
     use crate::type_row;
-    use crate::types::{ClassicType, LinearType, Signature, TypeRow};
+    use crate::types::{ClassicType, LinearType, Signature};
 
     const B: SimpleType = SimpleType::Classic(ClassicType::bit());
     const Q: SimpleType = SimpleType::Linear(LinearType::Qubit);
@@ -746,7 +746,7 @@ mod test {
         parent: NodeIndex,
         predicate_size: usize,
     ) -> (NodeIndex, NodeIndex, NodeIndex, NodeIndex) {
-        let tag_variants: TypeRow = vec![SimpleType::new_unit(); predicate_size].into();
+        let const_op = ModuleOp::Const(ConstValue::predicate(0, predicate_size));
         let tag_type = SimpleType::new_predicate(predicate_size);
 
         let input = b
@@ -757,16 +757,7 @@ mod test {
                 },
             )
             .unwrap();
-        let tag_def = b
-            .add_op_with_parent(
-                b.root(),
-                ModuleOp::Const(crate::ops::ConstValue::Sum {
-                    tag: 0,
-                    variants: tag_variants,
-                    val: Box::new(ConstValue::Tuple(vec![])),
-                }),
-            )
-            .unwrap();
+        let tag_def = b.add_op_with_parent(b.root(), const_op).unwrap();
         let tag = b
             .add_op_with_parent(
                 parent,


### PR DESCRIPTION
Adds multiple negative tests for the validation checks.
This does not cover everything, but tries to trigger every kind of error at least once.
It's missing inter-graph edge errors as hand-coding test cases that only trigger requires a lot of code.