### PR TITLE
Get portgraph from crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ description = "Hierarchical Unified Graph Representation"
 #categories = [] # TODO
 
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.69"
 
 [lib]
 # Using different names for the lib and for the package is supported, but may be confusing.
@@ -24,7 +24,7 @@ path = "src/lib.rs"
 
 [dependencies]
 thiserror = "1.0.28"
-portgraph = { git = "http://github.com/CQCL/portgraph", features = ["serde"] }
+portgraph = { version = "0.2.0", features = ["serde"] }
 pyo3 = { version = "0.18.1", optional = true, features = [
     "multiple-pymethods",
 ] }
@@ -44,11 +44,11 @@ pyo3 = ["dep:pyo3"]
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
-rstest = "0.16.0"
-portgraph = { git = "http://github.com/CQCL/portgraph", features = ["proptest"] }
+rstest = "0.17.0"
+portgraph = { version = "0.2.0", features = ["proptest"] }
 proptest = "1.1.0"
 rmp-serde = "1.1.1"
-open = "4.0.2"
+open = "4.1.0"
 url-escape = "0.1.1"
 cool_asserts = "2.0.3"
 

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ compilation and encodes runnable programs.
 This project is licensed under Apache License, Version 2.0 ([LICENSE][] or http://www.apache.org/licenses/LICENSE-2.0).
 
   [build_status]: https://github.com/CQCL/portgraph/workflows/Continuous%20integration/badge.svg?branch=main
-  [msrv]: https://img.shields.io/badge/rust-1.68.0%2B-blue.svg?maxAge=3600
+  [msrv]: https://img.shields.io/badge/rust-1.69.0%2B-blue.svg?maxAge=3600
   [LICENSE]: LICENCE


### PR DESCRIPTION
Use the published version for portgraph. Updates the msrv to match.