### PR TITLE
Container handles, differentiate decls from defs

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -92,7 +92,7 @@ mod test {
 
     pub(super) fn build_main(
         signature: Signature,
-        f: impl FnOnce(FunctionBuilder) -> Result<BuildHandle<FuncID>, BuildError>,
+        f: impl FnOnce(FunctionBuilder<true>) -> Result<BuildHandle<FuncID<true>>, BuildError>,
     ) -> Result<Hugr, BuildError> {
         let mut module_builder = ModuleBuilder::new();
         let f_builder = module_builder.declare_and_def("main", signature)?;

--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -465,9 +465,9 @@ pub trait Dataflow: Container {
     /// This function will return an error if there is an error adding the Call
     /// node, or if `function` does not refer to a [`ModuleOp::Declare`] or
     /// [`ModuleOp::Def`] node.
-    fn call(
+    fn call<const DEFINED: bool>(
         &mut self,
-        function: &FuncID,
+        function: &FuncID<DEFINED>,
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
         let def_op: Result<&ModuleOp, ()> = self.hugr().get_optype(function.node()).try_into();

--- a/src/builder/dataflow.rs
+++ b/src/builder/dataflow.rs
@@ -86,7 +86,10 @@ impl<'f> Dataflow for DFGBuilder<'f> {
 pub struct DFGWrapper<'b, T>(DFGBuilder<'b>, PhantomData<T>);
 
 /// Builder for a [`crate::ops::module::ModuleOp::Def`] node
-pub type FunctionBuilder<'b> = DFGWrapper<'b, BuildHandle<FuncID>>;
+///
+/// The `DEF` const generic is used to indicate whether the function is
+/// defined or just declared.
+pub type FunctionBuilder<'b, const DEF: bool> = DFGWrapper<'b, BuildHandle<FuncID<DEF>>>;
 
 impl<'b, T> DFGWrapper<'b, T> {
     pub(super) fn new(db: DFGBuilder<'b>) -> Self {
@@ -179,7 +182,7 @@ mod test {
     // Scaffolding for copy insertion tests
     fn copy_scaffold<F>(f: F, msg: &'static str) -> Result<(), BuildError>
     where
-        F: FnOnce(FunctionBuilder) -> Result<BuildHandle<FuncID>, BuildError>,
+        F: FnOnce(FunctionBuilder<true>) -> Result<BuildHandle<FuncID<true>>, BuildError>,
     {
         let build_result = {
             let mut module_builder = ModuleBuilder::new();

--- a/src/builder/handle.rs
+++ b/src/builder/handle.rs
@@ -71,7 +71,7 @@ impl<T: NodeHandle> BuildHandle<T> {
     }
 }
 
-impl From<BuildHandle<DfgID>> for BuildHandle<FuncID> {
+impl From<BuildHandle<DfgID>> for BuildHandle<FuncID<true>> {
     #[inline]
     fn from(value: BuildHandle<DfgID>) -> Self {
         Self {

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -62,8 +62,8 @@ impl ModuleBuilder {
     /// This function will return an error if there is an error in adding the node.
     pub fn define_function<'a: 'b, 'b>(
         &'a mut self,
-        f_id: &FuncID,
-    ) -> Result<FunctionBuilder<'b>, BuildError> {
+        f_id: &FuncID<false>,
+    ) -> Result<FunctionBuilder<'b, true>, BuildError> {
         let f_node = f_id.node();
         let (inputs, outputs) = if let OpType::Module(ModuleOp::Declare { signature }) =
             self.hugr().get_optype(f_node)
@@ -97,7 +97,7 @@ impl ModuleBuilder {
         &'a mut self,
         _name: impl Into<String>,
         signature: Signature,
-    ) -> Result<FunctionBuilder<'b>, BuildError> {
+    ) -> Result<FunctionBuilder<'b, true>, BuildError> {
         let fid = self.declare(_name, signature)?;
         self.define_function(&fid)
     }
@@ -112,7 +112,7 @@ impl ModuleBuilder {
         &mut self,
         _name: impl Into<String>,
         signature: Signature,
-    ) -> Result<FuncID, BuildError> {
+    ) -> Result<FuncID<false>, BuildError> {
         // TODO add name and param names to metadata
         let declare_n = self.add_child_op(ModuleOp::Declare { signature })?;
 
@@ -137,7 +137,7 @@ impl ModuleBuilder {
         &mut self,
         name: impl Into<SmolStr>,
         typ: SimpleType,
-    ) -> Result<AliasID, BuildError> {
+    ) -> Result<AliasID<true>, BuildError> {
         let name: SmolStr = name.into();
         let linear = typ.is_linear();
         let node = self.add_child_op(ModuleOp::AliasDef {
@@ -153,7 +153,7 @@ impl ModuleBuilder {
         &mut self,
         name: impl Into<SmolStr>,
         linear: bool,
-    ) -> Result<AliasID, BuildError> {
+    ) -> Result<AliasID<false>, BuildError> {
         let name: SmolStr = name.into();
         let node = self.add_child_op(ModuleOp::AliasDeclare {
             name: name.clone(),


### PR DESCRIPTION
- Adds a `ContainerHandle` to relate `NodeHandle`s to their children handles.
- Adds a const generic to function and alias handles to indicate whether they are a definition or just a declaration.
- Adds missing `NodeHandle` implementation for `CaseID`.