### PR TITLE
Move the internal hugr API to a pub(crate) trait

### DIFF
--- a/src/builder/build_traits.rs
+++ b/src/builder/build_traits.rs
@@ -1,5 +1,5 @@
 use crate::{
-    hugr::{validate::InterGraphEdgeError, ValidationError},
+    hugr::{internal::HugrView, validate::InterGraphEdgeError, ValidationError},
     ops::controlflow::{ConditionalSignature, TailLoopSignature},
 };
 
@@ -470,7 +470,8 @@ pub trait Dataflow: Container {
         function: &FuncID<DEFINED>,
         input_wires: impl IntoIterator<Item = Wire>,
     ) -> Result<BuildHandle<DataflowOpID>, BuildError> {
-        let def_op: Result<&ModuleOp, ()> = self.hugr().get_optype(function.node()).try_into();
+        let hugr = self.hugr();
+        let def_op: Result<&ModuleOp, ()> = hugr.get_optype(function.node()).try_into();
         let signature = match def_op {
             Ok(ModuleOp::Def { signature } | ModuleOp::Declare { signature }) => signature.clone(),
             _ => {

--- a/src/builder/cfg.rs
+++ b/src/builder/cfg.rs
@@ -4,7 +4,7 @@ use super::{
     BasicBlockID, BuildError, CfgID, Container, Dataflow, Wire,
 };
 
-use crate::{type_row, types::SimpleType};
+use crate::{hugr::internal::HugrView, type_row, types::SimpleType};
 
 use crate::ops::handle::NodeHandle;
 use crate::ops::{BasicBlockOp, OpType};

--- a/src/builder/conditional.rs
+++ b/src/builder/conditional.rs
@@ -1,3 +1,4 @@
+use crate::hugr::internal::HugrView;
 use crate::types::Signature;
 
 use crate::ops::handle::CaseID;

--- a/src/builder/module_builder.rs
+++ b/src/builder/module_builder.rs
@@ -3,7 +3,7 @@ use super::{
     BuildError, Container,
 };
 
-use crate::types::SimpleType;
+use crate::{hugr::internal::HugrView, types::SimpleType};
 
 use crate::ops::handle::{AliasID, ConstID, FuncID, NodeHandle};
 use crate::ops::{ConstValue, ModuleOp, OpType};

--- a/src/builder/tail_loop.rs
+++ b/src/builder/tail_loop.rs
@@ -1,6 +1,7 @@
 use crate::ops::controlflow::TailLoopSignature;
 use crate::ops::{controlflow::ControlFlowOp, DataflowOp, OpType};
 
+use crate::hugr::internal::HugrView;
 use crate::types::TypeRow;
 
 use super::handle::BuildHandle;
@@ -57,11 +58,9 @@ impl<'b> TailLoopBuilder<'b> {
     /// Get a reference to the [`crate::ops::controlflow::TailLoopSignature`]
     /// that defines the signature of the TailLoop
     pub fn loop_signature(&self) -> Result<&TailLoopSignature, BuildError> {
-        let hugr = self.hugr();
-
         if let OpType::Dataflow(DataflowOp::ControlFlow {
             op: ControlFlowOp::TailLoop(tail_sig),
-        }) = hugr.get_optype(self.container_node())
+        }) = self.hugr().get_optype(self.container_node())
         {
             Ok(tail_sig)
         } else {

--- a/src/hugr/hugrmut.rs
+++ b/src/hugr/hugrmut.rs
@@ -2,6 +2,7 @@
 
 use std::ops::Range;
 
+use derive_more::{Deref, DerefMut};
 use itertools::Itertools;
 use portgraph::{Direction, NodeIndex, PortOffset};
 
@@ -12,7 +13,7 @@ use crate::{
 };
 
 /// A low-level builder for a HUGR.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Deref, DerefMut)]
 pub struct HugrMut {
     /// The partial HUGR being built.
     hugr: Hugr,

--- a/src/hugr/internal.rs
+++ b/src/hugr/internal.rs
@@ -1,0 +1,93 @@
+//! Internal API for HUGRs, not intended for use by users.
+
+use std::ops::Deref;
+
+use portgraph::hierarchy::Children;
+use portgraph::portgraph::NodePorts;
+use portgraph::{NodeIndex, PortOffset};
+
+use super::Hugr;
+use crate::ops::OpType;
+
+/// Internal API for HUGRs, not intended for use by users.
+///
+/// TODO: Wraps the underlying graph and hierarchy, producing a view where
+/// non-linear ports can be connected to multiple nodes via implicit copies
+/// (which correspond to copy nodes in the internal graph).
+pub(crate) trait HugrView: DerefHugr {
+    /// Returns the parent of a node.
+    #[inline]
+    fn get_parent(&self, node: NodeIndex) -> Option<NodeIndex> {
+        self.hugr().hierarchy.parent(node)
+    }
+
+    /// Returns the operation type of a node.
+    #[inline]
+    fn get_optype(&self, node: NodeIndex) -> &OpType {
+        self.hugr().op_types.get(node)
+    }
+
+    /// Iterator over outputs of node.
+    #[inline]
+    fn node_outputs(&self, node: NodeIndex) -> NodePorts {
+        self.hugr().graph.outputs(node)
+    }
+
+    /// Iterator over inputs of node.
+    #[inline]
+    fn node_inputs(&self, node: NodeIndex) -> NodePorts {
+        self.hugr().graph.inputs(node)
+    }
+
+    /// Return node and port connected to provided port, if not connected return None.
+    #[inline]
+    fn linked_port(&self, node: NodeIndex, offset: PortOffset) -> Option<(NodeIndex, PortOffset)> {
+        let raw = self.hugr();
+        let port = raw.graph.port_index(node, offset)?;
+        let link = raw.graph.port_link(port)?;
+        Some((raw.graph.port_node(link)?, raw.graph.port_offset(port)?))
+    }
+
+    /// Number of inputs to node.
+    #[inline]
+    fn num_inputs(&self, node: NodeIndex) -> usize {
+        self.hugr().graph.num_inputs(node)
+    }
+
+    /// Number of outputs to node.
+    #[inline]
+    fn num_outputs(&self, node: NodeIndex) -> usize {
+        self.hugr().graph.num_outputs(node)
+    }
+
+    /// Return iterator over children of node.
+    #[inline]
+    fn children(&self, node: NodeIndex) -> Children<'_> {
+        self.hugr().hierarchy.children(node)
+    }
+}
+
+impl<T> HugrView for T where T: DerefHugr {}
+
+/// Trait for converting a reference to a Hugr into a RawHugr.
+///
+/// This is equivalent to `Deref<Target=Hugr>`, but we use a local definition to
+/// be able to write blanket implementations.
+pub(crate) trait DerefHugr: Sized {
+    fn hugr(&self) -> &Hugr;
+}
+
+impl DerefHugr for Hugr {
+    fn hugr(&self) -> &Hugr {
+        self
+    }
+}
+
+impl<T> DerefHugr for T
+where
+    T: Deref<Target = Hugr>,
+{
+    fn hugr(&self) -> &Hugr {
+        self.deref()
+    }
+}

--- a/src/hugr/validate.rs
+++ b/src/hugr/validate.rs
@@ -14,6 +14,8 @@ use crate::ops::{ControlFlowOp, DataflowOp, LeafOp, ModuleOp, OpType};
 use crate::types::{EdgeKind, SimpleType};
 use crate::Hugr;
 
+use super::internal::HugrView;
+
 /// Structure keeping track of pre-computed information used in the validation
 /// process.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,15 +20,6 @@ pub mod types;
 mod utils;
 
 pub use crate::hugr::Hugr;
-pub use portgraph::{NodeIndex, PortIndex};
-pub use resource::Resource;
-pub use rewrite::{Rewrite, RewriteError};
-
-#[cfg(test)]
-mod test {
-    // Example test
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+pub use crate::resource::Resource;
+pub use crate::rewrite::{Rewrite, RewriteError};
+pub use portgraph::{Direction, NodeIndex, PortIndex};

--- a/src/rewrite/rewrite.rs
+++ b/src/rewrite/rewrite.rs
@@ -53,19 +53,21 @@ impl OpenHugr {
     /// The returned Hugr will have no graph information.
     pub fn into_parts(self) -> (OpenGraph, Hugr) {
         let OpenHugr {
-            mut hugr,
+            hugr,
             dangling_inputs,
             dangling_outputs,
         } = self;
-        let graph = std::mem::take(&mut hugr.graph);
-        (
-            OpenGraph {
-                graph,
-                dangling_inputs,
-                dangling_outputs,
-            },
-            hugr,
-        )
+        let _ = (hugr, dangling_inputs, dangling_outputs);
+        todo!("The internal graph of a hugr cannot be accessed directly. This needs updating.");
+        //let graph = std::mem::take(&mut hugr.graph);
+        //(
+        //    OpenGraph {
+        //        graph,
+        //        dangling_inputs,
+        //        dangling_outputs,
+        //    },
+        //    hugr,
+        //)
     }
 }
 


### PR DESCRIPTION
This PR is mostly moving code around, to avoid noise in future PRs modifying the internal Hugr API.

- Moves the `pub(crate)` API from Hugr to an internal submodule.
- Uses a `HugrView` trait so that we can also call those from things that can be _Deref_erenced into a hugr.
  - This could be used on the builders, but it may be clearer to leave them as is.
  - I intended to call the future public view api `RegionView`, so this name does not collide with that.
- Since we remove the `pub(crate)` from the portgraph in the hugr, the Rewrite API is broken. I just left a TODO since we are planning to overhaul it.