### PR TITLE
Add versions to the serialization format (closes #63)

### DIFF
--- a/src/hugr/serialize.rs
+++ b/src/hugr/serialize.rs
@@ -22,14 +22,14 @@ use serde::{Deserialize, Deserializer, Serialize};
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "version", rename_all = "lowercase")]
 enum Versioned {
-    /// First version of the HUGR serialization format.
+    /// Version 0 of the HUGR serialization format.
     V0(SerHugrV0),
 
     #[serde(other)]
     Unsupported,
 }
 
-/// First version of the HUGR serialization format.
+/// Version 0 of the HUGR serialization format.
 #[derive(Serialize, Deserialize)]
 struct SerHugrV0 {
     nodes: Vec<(NodeIndex, usize, usize)>,


### PR DESCRIPTION
Adds a "version" internal field to the encoded hugr (with value `v0`).

With this we will be able to update the serialization format, hopefully coding some fallback if we encounter older versions.