### PR TITLE
Swap out `open` dependency for `webbrowser`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ rstest = "0.17.0"
 portgraph = { version = "0.2.0", features = ["proptest"] }
 proptest = "1.1.0"
 rmp-serde = "1.1.1"
-open = "4.1.0"
+webbrowser = "0.8.10"
 url-escape = "0.1.1"
 cool_asserts = "2.0.3"
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,6 @@ pub(crate) mod test {
     pub(crate) fn viz_dotstr(dotstr: &str) {
         let mut base: String = "https://dreampuf.github.io/GraphvizOnline/#".into();
         url_escape::encode_query_to_string(dotstr, &mut base);
-        open::that(&base).unwrap();
+        webbrowser::open(&base).unwrap();
     }
 }


### PR DESCRIPTION
For graphviz debugging, open a browser window with `webbrowser` instead of `open`.

On macos, `open` calls out to a tool (also called `open`) which doesn't recognise URLs with dot files encoded in them as valid. Regardless of what program you tell it to open, it searches for a *file* (called "https://..."), doesn't find it, and returns an error.

On my machine (macos), this opens a new tab in my running instance of firefox 