### PR TITLE
Fix latex markup.

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1417,7 +1417,7 @@ Semantics are defined by the operations. There are three possible
 interpretations of a value:
 
   - as a bit string $(a_{N-1}, a_{N-2}, \ldots, a_0)$ where
-    $a_i \in \{0,1\}$;
+    $a_i \in \\{0,1\\}$;
 
   - as an unsigned integer $\sum_{i \lt N} 2^i a_i$;
 


### PR DESCRIPTION
Except that I can't seem to get the braces in `{0,1}` to be displayed. Don't think it matters too much in this case.

Also fix a typo in one of the expressions.

Fixes #95 .