### PR TITLE
Fix clippy warnings, and make CI pedantic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt -- --check
       - name: Run clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets -- -D warnings
       - name: Build docs
         run: cargo doc --no-deps --all-features
         env:
@@ -43,6 +43,9 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: v0-rust-nightly
       - name: Run miri
         run: cargo miri test
 
@@ -65,7 +68,7 @@ jobs:
     strategy:
       matrix:
         include:
-          #- rust: 1.68.0  # Update once MSRV != stable
+          #- rust: 1.69.0  # Update once MSRV != stable
           - rust: stable
             cache: true
           - rust: beta

--- a/src/algorithm/half_node.rs
+++ b/src/algorithm/half_node.rs
@@ -29,6 +29,7 @@ struct HalfNodeView<'a, H> {
 }
 
 impl<'a, H: HugrView> HalfNodeView<'a, H> {
+    #[allow(unused)]
     pub(crate) fn new(h: &'a H, cfg: CfgID) -> Self {
         let mut children = h.children(cfg.node());
         let entry = children.next().unwrap(); // Panic if malformed
@@ -70,7 +71,7 @@ impl<H: HugrView> CfgView<HalfNode> for HalfNodeView<'_, H> {
         assert!(self.bb_succs(self.exit).count() == 0);
         HalfNode::N(self.exit)
     }
-    fn predecessors<'a>(&'a self, h: HalfNode) -> Self::Iterator<'a> {
+    fn predecessors(&self, h: HalfNode) -> Self::Iterator<'_> {
         let mut ps = Vec::new();
         match h {
             HalfNode::N(ni) => ps.extend(self.bb_preds(ni).map(|n| self.resolve_out(n))),
@@ -81,7 +82,7 @@ impl<H: HugrView> CfgView<HalfNode> for HalfNodeView<'_, H> {
         }
         ps.into_iter()
     }
-    fn successors<'a>(&'a self, n: HalfNode) -> Self::Iterator<'a> {
+    fn successors(&self, n: HalfNode) -> Self::Iterator<'_> {
         let mut succs = Vec::new();
         match n {
             HalfNode::N(ni) if self.is_multi_node(ni) => succs.push(HalfNode::X(ni)),

--- a/src/algorithm/nest_cfgs.rs
+++ b/src/algorithm/nest_cfgs.rs
@@ -68,9 +68,9 @@ pub trait CfgView<T> {
     where
         Self: 'c;
     /// Returns an iterator over the successors of the specified basic block.
-    fn successors<'c>(&'c self, node: T) -> Self::Iterator<'c>;
+    fn successors(&self, node: T) -> Self::Iterator<'_>;
     /// Returns an iterator over the predecessors of the specified basic block.
-    fn predecessors<'c>(&'c self, node: T) -> Self::Iterator<'c>;
+    fn predecessors(&self, node: T) -> Self::Iterator<'_>;
 }
 
 /// Directed edges in a Cfg - i.e. along which control flows from first to second only.
@@ -156,11 +156,11 @@ impl<H: HugrView> CfgView<Node> for SimpleCfgView<'_, H> {
     where
         Self: 'c;
 
-    fn successors<'c>(&'c self, node: Node) -> Self::Iterator<'c> {
+    fn successors(&self, node: Node) -> Self::Iterator<'_> {
         self.h.neighbours(node, Direction::Outgoing)
     }
 
-    fn predecessors<'c>(&'c self, node: Node) -> Self::Iterator<'c> {
+    fn predecessors(&self, node: Node) -> Self::Iterator<'_> {
         self.h.neighbours(node, Direction::Incoming)
     }
 }
@@ -258,7 +258,7 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash> BracketList<T> {
     pub fn concat(&mut self, other: BracketList<T>) {
         let BracketList { mut items, size } = other;
         self.items.append(&mut items);
-        assert!(items.len() == 0);
+        assert!(items.is_empty());
         self.size += size;
     }
 
@@ -384,7 +384,7 @@ impl<T: Copy + Clone + PartialEq + Eq + Hash> EdgeClassifier<T> {
         // Now calculate edge classes
         let class = bs.tag(&self.deleted_backedges);
         if let Some((Bracket::Real(e), 1)) = &class {
-            self.edge_classes.insert(e.clone(), class.clone());
+            self.edge_classes.insert(*e, class.clone());
         }
         if let Some(parent_edge) = tree.dfs_parents.get(&n) {
             self.edge_classes.insert(cfg_edge(n, *parent_edge), class);


### PR DESCRIPTION
Drive-by: Enable cache for miri step in CI.