### PR TITLE
[refactor] Remove never-called OpDef::instantiate_opaque

### DIFF
--- a/src/extension/op_def.rs
+++ b/src/extension/op_def.rs
@@ -195,29 +195,6 @@ impl OpDef {
         self.check_concrete_impl(opaque)
     }
 
-    /// Instantiate a concrete [`OpaqueOp`] by providing type arguments.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the provided arguments are not
-    /// valid instances of the type parameters.
-    pub fn instantiate_opaque(
-        &self,
-        args: impl Into<Vec<TypeArg>>,
-    ) -> Result<OpaqueOp, SignatureError> {
-        let args = args.into();
-        self.check_args(&args)?;
-
-        Ok(OpaqueOp::new(
-            self.extension().clone(),
-            self.name().clone(),
-            // TODO add description
-            "".to_string(),
-            args,
-            None,
-        ))
-    }
-
     /// Computes the signature of a node, i.e. an instantiation of this
     /// OpDef with statically-provided [TypeArg]s.
     pub fn compute_signature(


### PR DESCRIPTION
`Extension::instantiate_extension_op` is the main user-facing entry point, and already calls ExtensionOp::new(), as it should.