### PR TITLE
test: ignore serialisation tests when using miri

### DIFF
--- a/hugr/src/hugr/serialize.rs
+++ b/hugr/src/hugr/serialize.rs
@@ -261,6 +261,9 @@ impl TryFrom<SerHugrV1> for Hugr {
 }
 
 #[cfg(test)]
+#[cfg_attr(miri, ignore = "miri does not support 'life before main'")]
+// Miri doesn't run the extension registration required by `typetag` for
+// registering `CustomConst`s.  https://github.com/rust-lang/miri/issues/450
 pub mod test {
 
     use super::*;
@@ -547,9 +550,6 @@ pub mod test {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore = "Extension ops cannot be used with miri.")]
-    // Miri doesn't run the extension registration required by `typetag` for registering `CustomConst`s.
-    // https://github.com/rust-lang/miri/issues/450
     fn constants_roundtrip() -> Result<(), Box<dyn std::error::Error>> {
         let mut builder = DFGBuilder::new(FunctionType::new(vec![], vec![FLOAT64_TYPE])).unwrap();
         let w = builder.add_load_value(ConstF64::new(0.5));

--- a/hugr/src/hugr/validate.rs
+++ b/hugr/src/hugr/validate.rs
@@ -105,6 +105,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
         // in-tree schema. For now, our serialized hugr does not match the
         // schema. When this is fixed we should pass true below.
         #[cfg(test)]
+        #[cfg_attr(miri, ignore = "miri does not support 'life before main'")]
         crate::hugr::serialize::test::check_hugr_roundtrip(self.hugr, false);
 
         Ok(())


### PR DESCRIPTION
Fixes #969.

This solution is an over approximation because many serialisation tests(in which I include comprehensive coverage which does not yet exist) would not trigger the problem. This would be easy to remove if miri grows support. The most recent activity on the ticket is positive.