### PR TITLE
fix: disable serialisation tests when miri is active

### DIFF
--- a/hugr/src/hugr/validate.rs
+++ b/hugr/src/hugr/validate.rs
@@ -104,8 +104,7 @@ impl<'a, 'b> ValidationContext<'a, 'b> {
         // TODO: We should also verify that the serialized hugr matches the
         // in-tree schema. For now, our serialized hugr does not match the
         // schema. When this is fixed we should pass true below.
-        #[cfg(test)]
-        #[cfg_attr(miri, ignore = "miri does not support 'life before main'")]
+        #[cfg(all(test, not(miri)))]
         crate::hugr::serialize::test::check_hugr_roundtrip(self.hugr, false);
 
         Ok(())

--- a/hugr/src/types/serialize.rs
+++ b/hugr/src/types/serialize.rs
@@ -54,31 +54,3 @@ impl From<SerSimpleType> for Type {
         }
     }
 }
-
-#[cfg(test)]
-mod test {
-    use crate::extension::prelude::USIZE_T;
-    use crate::hugr::serialize::test::ser_roundtrip;
-    use crate::std_extensions::arithmetic::float_types::FLOAT64_TYPE;
-    use crate::type_row;
-    use crate::types::FunctionType;
-    use crate::types::Type;
-
-    #[test]
-    fn serialize_types_roundtrip() {
-        let g: Type = Type::new_function(FunctionType::new_endo(vec![]));
-
-        assert_eq!(ser_roundtrip(&g), g);
-
-        // A Simple tuple
-        let t = Type::new_tuple(vec![USIZE_T, g]);
-        assert_eq!(ser_roundtrip(&t), t);
-
-        // A Classic sum
-        let t = Type::new_sum([type_row![USIZE_T], type_row![FLOAT64_TYPE]]);
-        assert_eq!(ser_roundtrip(&t), t);
-
-        let t = Type::new_unit_sum(4);
-        assert_eq!(ser_roundtrip(&t), t);
-    }
-}


### PR DESCRIPTION
We move the `serialize_types_roundtrip` test to put it under the new cfg flag
