### PR TITLE
fix: set `[build-system]` in `hugr-py/pyproject.toml`

### DIFF
--- a/hugr-py/pyproject.toml
+++ b/hugr-py/pyproject.toml
@@ -30,3 +30,7 @@ pydantic = "~2.7.0"
 [tool.pytest.ini_options]
 # Lark throws deprecation warnings for `src_parse` and `src_constants`.
 filterwarnings = "ignore::DeprecationWarning:lark.*"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This is required for the sdist to work