### PR TITLE
refactor!: rename `crate::ops::constant::ExtensionValue` => `OpaqueValue`

### DIFF
--- a/hugr/src/ops/constant/custom.rs
+++ b/hugr/src/ops/constant/custom.rs
@@ -32,7 +32,7 @@ use super::ValueName;
 /// ```rust
 /// use serde::{Serialize,Deserialize};
 /// use hugr::{
-///   types::Type,ops::constant::{ExtensionValue, ValueName, CustomConst},
+///   types::Type,ops::constant::{OpaqueValue, ValueName, CustomConst},
 ///   extension::ExtensionSet, std_extensions::arithmetic::int_types};
 /// use serde_json::json;
 ///
@@ -264,7 +264,7 @@ impl CustomConst for CustomSerialized {
     }
 }
 
-/// This module is used by the serde annotations on `super::ExtensionValue`
+/// This module is used by the serde annotations on `super::OpaqueValue`
 pub(super) mod serde_extension_value {
     use serde::{Deserializer, Serializer};
 
@@ -323,7 +323,7 @@ mod test {
         std_extensions::collections::ListValue,
     };
 
-    use super::{super::ExtensionValue, CustomConst, CustomConstBoxClone, CustomSerialized};
+    use super::{super::OpaqueValue, CustomConst, CustomConstBoxClone, CustomSerialized};
 
     struct SerializeCustomConstExample<CC: CustomConst + serde::Serialize + 'static> {
         cc: CC,
@@ -407,8 +407,8 @@ mod test {
                 .unwrap()
         );
 
-        // check ExtensionValue serializes/deserializes as a CustomSerialized
-        let ev: ExtensionValue = example.cc.clone().into();
+        // check OpaqueValue serializes/deserializes as a CustomSerialized
+        let ev: OpaqueValue = example.cc.clone().into();
         let ev_val = serde_yaml::to_value(&ev).unwrap();
         assert_eq!(
             &ev_val,
@@ -465,10 +465,10 @@ mod test {
         assert_eq!(&inner.clone_box(), &cs.clone().into_custom_const_box());
         assert_eq!(&inner, &cs.clone().try_into_custom_const().unwrap());
 
-        let ev: ExtensionValue = cs.clone().into();
-        // A serialisation round-trip results in an ExtensionValue with the value of inner
+        let ev: OpaqueValue = cs.clone().into();
+        // A serialisation round-trip results in an OpaqueValue with the value of inner
         assert_eq!(
-            ExtensionValue::new(inner),
+            OpaqueValue::new(inner),
             serde_yaml::from_value(serde_yaml::to_value(&ev).unwrap()).unwrap()
         );
     }


### PR DESCRIPTION
Fixes #989.

The name `ExtensionValue` clashed with `crate::extension::ExtensionValue`

Note that we have chosen not to rename the corresponding element of the serialization schema.

BREAKING CHANGE: rename `crate::ops::constant::ExtensionValue` => `OpaqueValue`