### PR TITLE
test: really ignore tests which depend on typetag when cfg(miri)

### DIFF
--- a/hugr/src/ops/constant.rs
+++ b/hugr/src/ops/constant.rs
@@ -156,7 +156,8 @@ pub enum Value {
 /// is another `CustomSerialized` we do not attempt to recurse. This behaviour
 /// may change in future.
 ///
-/// ```rust
+#[cfg_attr(not(miri), doc = "```")] // this doctest depends on typetag, so fails with miri
+#[cfg_attr(miri, doc = "```ignore")]
 /// use serde::{Serialize,Deserialize};
 /// use hugr::{
 ///   types::Type,ops::constant::{OpaqueValue, ValueName, CustomConst, CustomSerialized},

--- a/hugr/src/ops/constant/custom.rs
+++ b/hugr/src/ops/constant/custom.rs
@@ -29,7 +29,8 @@ use super::ValueName;
 /// be serialized with two attributes, `"c"`  the tag and `"v"` the
 /// `CustomConst`:
 ///
-/// ```rust
+#[cfg_attr(not(miri), doc = "```")] // this doctest depends on typetag, so fails with miri
+#[cfg_attr(miri, doc = "```ignore")]
 /// use serde::{Serialize,Deserialize};
 /// use hugr::{
 ///   types::Type,ops::constant::{OpaqueValue, ValueName, CustomConst},
@@ -51,7 +52,7 @@ use super::ValueName;
 ///   "c": "CC",
 ///   "v": 2
 /// }));
-/// ````
+/// ```
 #[typetag::serde(tag = "c", content = "v")]
 pub trait CustomConst:
     Send + Sync + std::fmt::Debug + CustomConstBoxClone + Any + Downcast


### PR DESCRIPTION
Previous fix failed because the `#[ignore]` attribute only applies to the first `#[case]`.