### PR TITLE
ci: Enable `hugr-cli` release, don't create tags

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,7 +25,7 @@ release = true
 
 # Disabled until the first version is manually published
 publish = false
-git_release_enable = false
+git_tag_enable = false
 
 [[package]]
 name = "hugr-passes"
@@ -33,12 +33,12 @@ release = true
 
 # Disabled until the first version is manually published
 publish = false
-git_release_enable = false
-
+git_tag_enable = false
 
 [[package]]
 name = "hugr-cli"
+release = true
 
 # Disabled until the first version is manually published
 publish = false
-git_release_enable = false
+git_tag_enable = false


### PR DESCRIPTION
(Hopefully) the last one of these.

- Sets `release = true` for `hugr-cli`, so it gets processed by `release-plz`.

- Sets `git_tag_enable = false` instead of `_release`.

  - So no tag gets created. Otherwise the following runs fail due to the unpublished tags
    ```
    package `hugr-core` not found in the registry, but the git tag hugr-core-v0.0.0 exists. Consider running `cargo publish` manually to publish this package.
    ```
    https://github.com/CQCL/hugr/actions/runs/9271530632/job/25507136576#step:4:231

  - This also implies the `_release` flag, since that requires a tag