### PR TITLE
feat(hugr-core): Add `impl Hash for Type`

### DIFF
--- a/hugr-core/src/ops/module.rs
+++ b/hugr-core/src/ops/module.rs
@@ -138,7 +138,7 @@ impl OpTrait for AliasDefn {
 }
 
 /// A type alias declaration. Resolved at link time.
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 pub struct AliasDecl {
     /// Alias name

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -121,7 +121,7 @@ pub(crate) fn least_upper_bound(mut tags: impl Iterator<Item = TypeBound>) -> Ty
     .into_inner()
 }
 
-#[derive(Clone, PartialEq, Debug, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Debug, Eq, Hash, Serialize, Deserialize)]
 #[serde(tag = "s")]
 #[non_exhaustive]
 /// Representation of a Sum type.
@@ -213,7 +213,7 @@ impl<RV: MaybeRV> From<SumType> for TypeBase<RV> {
     }
 }
 
-#[derive(Clone, Debug, Eq, derive_more::Display)]
+#[derive(Clone, Debug, Eq, Hash, derive_more::Display)]
 /// Core types
 pub enum TypeEnum<RV: MaybeRV> {
     // TODO optimise with Box<CustomType> ?
@@ -257,7 +257,7 @@ impl<RV: MaybeRV> TypeEnum<RV> {
     }
 }
 
-#[derive(Clone, Debug, Eq, derive_more::Display, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, derive_more::Display, serde::Serialize, serde::Deserialize)]
 #[display(fmt = "{}", "_0")]
 #[serde(
     into = "serialize::SerSimpleType",

--- a/hugr-core/src/types/custom.rs
+++ b/hugr-core/src/types/custom.rs
@@ -12,7 +12,7 @@ use super::{
 use super::{Type, TypeName};
 
 /// An opaque type element. Contains the unique identifier of its definition.
-#[derive(Debug, PartialEq, Eq, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CustomType {
     extension: ExtensionId,
     /// Unique identifier of the opaque type.

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -20,7 +20,7 @@ use super::{signature::FuncTypeBase, MaybeRV, NoRV, RowVariable};
 /// [FuncDefn]: crate::ops::module::FuncDefn
 /// [OpDef]: crate::extension::OpDef
 #[derive(
-    Clone, PartialEq, Debug, Eq, derive_more::Display, serde::Serialize, serde::Deserialize,
+    Clone, PartialEq, Debug, Eq, Hash, derive_more::Display, serde::Serialize, serde::Deserialize,
 )]
 #[cfg_attr(test, derive(Arbitrary), proptest(params = "RecursionDepth"))]
 #[display(

--- a/hugr-core/src/types/row_var.rs
+++ b/hugr-core/src/types/row_var.rs
@@ -11,7 +11,7 @@ use proptest::prelude::{any, BoxedStrategy, Strategy};
 // The serde derives here are not used except as markers
 // so that other types containing this can also #derive-serde the same way.
 #[derive(
-    Clone, Debug, Eq, PartialEq, derive_more::Display, serde::Serialize, serde::Deserialize,
+    Clone, Debug, Eq, Hash, PartialEq, derive_more::Display, serde::Serialize, serde::Deserialize,
 )]
 #[display(fmt = "{}", "_0")]
 pub struct RowVariable(pub usize, pub TypeBound);
@@ -50,7 +50,7 @@ pub trait MaybeRV:
 // The serde derives here are not used except as markers
 // so that other types containing this can also #derive-serde the same way.
 #[derive(
-    Clone, Debug, Eq, PartialEq, derive_more::Display, serde::Serialize, serde::Deserialize,
+    Clone, Debug, Eq, PartialEq, Hash, derive_more::Display, serde::Serialize, serde::Deserialize,
 )]
 pub enum NoRV {}
 

--- a/hugr-core/src/types/signature.rs
+++ b/hugr-core/src/types/signature.rs
@@ -15,7 +15,7 @@ use crate::{Direction, IncomingPort, OutgoingPort, Port};
 #[cfg(test)]
 use {crate::proptest::RecursionDepth, ::proptest::prelude::*, proptest_derive::Arbitrary};
 
-#[derive(Clone, Debug, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(test, derive(Arbitrary), proptest(params = "RecursionDepth"))]
 /// Describes the edges required to/from a node or inside a [FuncDefn] (when ROWVARS=[NoRV]);
 /// or (when ROWVARS=[RowVariable]) the type of a higher-order [function value] or the inputs/outputs from an OpDef

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -19,7 +19,7 @@ use crate::extension::SignatureError;
 /// The upper non-inclusive bound of a [`TypeParam::BoundedNat`]
 // A None inner value implies the maximum bound: u64::MAX + 1 (all u64 values valid)
 #[derive(
-    Clone, Debug, PartialEq, Eq, derive_more::Display, serde::Deserialize, serde::Serialize,
+    Clone, Debug, PartialEq, Eq, Hash, derive_more::Display, serde::Deserialize, serde::Serialize,
 )]
 #[display(fmt = "{}", "_0.map(|i|i.to_string()).unwrap_or(\"-\".to_string())")]
 #[cfg_attr(test, derive(Arbitrary))]
@@ -52,7 +52,7 @@ impl UpperBound {
 /// [PolyFuncType]: super::PolyFuncType
 /// [PolyFuncTypeRV]: super::PolyFuncTypeRV
 #[derive(
-    Clone, Debug, PartialEq, Eq, derive_more::Display, serde::Deserialize, serde::Serialize,
+    Clone, Debug, PartialEq, Eq, Hash, derive_more::Display, serde::Deserialize, serde::Serialize,
 )]
 #[non_exhaustive]
 #[serde(tag = "tp")]
@@ -139,7 +139,7 @@ impl From<UpperBound> for TypeParam {
 }
 
 /// A statically-known argument value to an operation.
-#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 #[serde(tag = "tya")]
 pub enum TypeArg {
@@ -215,7 +215,7 @@ impl From<ExtensionSet> for TypeArg {
 /// Variable in a TypeArg, that is neither a [TypeArg::Extensions]
 /// nor a single [TypeArg::Type] (i.e. not a [Type::new_var_use]
 /// - it might be a [Type::new_row_var_use]).
-#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
 pub struct TypeArgVariable {
     idx: usize,
     cached_decl: TypeParam,

--- a/hugr-core/src/types/type_row.rs
+++ b/hugr-core/src/types/type_row.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 
 /// List of types, used for function signatures.
 /// The `ROWVARS` parameter controls whether this may contain [RowVariable]s
-#[derive(Clone, Eq, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Eq, Debug, Hash, serde::Serialize, serde::Deserialize)]
 #[non_exhaustive]
 #[serde(transparent)]
 pub struct TypeRowBase<ROWVARS: MaybeRV> {


### PR DESCRIPTION
Note that I have made a choice here to include `PolyFuncType` and `TypeParam`. We could exclude `TypeParam` by not including `TypeArgVariable::cached_decl` in the `Hash` (and `PartialEq`, `Eq`, which would be a change of behaviour).