### PR TITLE
chore: Add #2195 to git blame ignore list

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,8 @@
+# Commits to ignore in blame output
+#
+# To configure git to use this file, run:
+# > git config blame.ignoreRevsFile .git-blame-ignore-revs
+
 # Bump to rust edition 2024, and a bunch of automated lint fixes
 # https://github.com/CQCL/hugr/pull/2195
 16903a65294aede245a4c8bb2a07a4692a619769


### PR DESCRIPTION
Prevents the noisy automated changes of #2195 from polluting the blame history.

This needs local configuration to be picked up by git:
```bash
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

But it's [automatically read by github](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view).