### PR TITLE
fix: Model import should perform extension resolution

### DIFF
--- a/hugr-core/tests/snapshots/model__roundtrip_add.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_add.snap
@@ -1,29 +1,41 @@
 ---
 source: hugr-core/tests/model.rs
-expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-add.edn\"))"
+expression: ast
 ---
 (hugr 0)
 
 (mod)
 
+(import core.meta.description)
+
+(import core.nat)
+
 (import core.fn)
 
-(import arithmetic.int.iadd)
-
 (import arithmetic.int.types.int)
+
+(declare-operation
+  arithmetic.int.iadd
+  (param ?0 core.nat)
+  (core.fn
+    [(arithmetic.int.types.int ?0) (arithmetic.int.types.int ?0)]
+    [(arithmetic.int.types.int ?0)])
+  (meta
+    (core.meta.description
+      "addition modulo 2^N (signed and unsigned versions are the same op)")))
 
 (define-func
   example.add
   (core.fn
-    [arithmetic.int.types.int arithmetic.int.types.int]
-    [arithmetic.int.types.int])
+    [(arithmetic.int.types.int 6) (arithmetic.int.types.int 6)]
+    [(arithmetic.int.types.int 6)])
   (dfg [%0 %1] [%2]
     (signature
       (core.fn
-        [arithmetic.int.types.int arithmetic.int.types.int]
-        [arithmetic.int.types.int]))
-    (arithmetic.int.iadd [%0 %1] [%2]
+        [(arithmetic.int.types.int 6) (arithmetic.int.types.int 6)]
+        [(arithmetic.int.types.int 6)]))
+    ((arithmetic.int.iadd 6) [%0 %1] [%2]
       (signature
         (core.fn
-          [arithmetic.int.types.int arithmetic.int.types.int]
-          [arithmetic.int.types.int])))))
+          [(arithmetic.int.types.int 6) (arithmetic.int.types.int 6)]
+          [(arithmetic.int.types.int 6)])))))

--- a/hugr-core/tests/snapshots/model__roundtrip_cond.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_cond.snap
@@ -1,10 +1,14 @@
 ---
 source: hugr-core/tests/model.rs
-expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cond.edn\"))"
+expression: ast
 ---
 (hugr 0)
 
 (mod)
+
+(import core.meta.description)
+
+(import core.nat)
 
 (import core.fn)
 
@@ -12,31 +16,41 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-cond
 
 (import arithmetic.int.types.int)
 
-(import arithmetic.int.ineg)
+(declare-operation
+  arithmetic.int.ineg
+  (param ?0 core.nat)
+  (core.fn [(arithmetic.int.types.int ?0)] [(arithmetic.int.types.int ?0)])
+  (meta
+    (core.meta.description
+      "negation modulo 2^N (signed and unsigned versions are the same op)")))
 
 (define-func
   example.cond
   (core.fn
-    [(core.adt [[] []]) arithmetic.int.types.int]
-    [arithmetic.int.types.int])
+    [(core.adt [[] []]) (arithmetic.int.types.int 6)]
+    [(arithmetic.int.types.int 6)])
   (dfg [%0 %1] [%2]
     (signature
       (core.fn
-        [(core.adt [[] []]) arithmetic.int.types.int]
-        [arithmetic.int.types.int]))
+        [(core.adt [[] []]) (arithmetic.int.types.int 6)]
+        [(arithmetic.int.types.int 6)]))
     (cond [%0 %1] [%2]
       (signature
         (core.fn
-          [(core.adt [[] []]) arithmetic.int.types.int]
-          [arithmetic.int.types.int]))
+          [(core.adt [[] []]) (arithmetic.int.types.int 6)]
+          [(arithmetic.int.types.int 6)]))
       (dfg [%3] [%3]
         (signature
-          (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))
+          (core.fn
+            [(arithmetic.int.types.int 6)]
+            [(arithmetic.int.types.int 6)])))
       (dfg [%4] [%5]
         (signature
-          (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
-        (arithmetic.int.ineg [%4] [%5]
+          (core.fn
+            [(arithmetic.int.types.int 6)]
+            [(arithmetic.int.types.int 6)]))
+        ((arithmetic.int.ineg 6) [%4] [%5]
           (signature
             (core.fn
-              [arithmetic.int.types.int]
-              [arithmetic.int.types.int])))))))
+              [(arithmetic.int.types.int 6)]
+              [(arithmetic.int.types.int 6)])))))))

--- a/hugr-core/tests/snapshots/model__roundtrip_order.snap
+++ b/hugr-core/tests/snapshots/model__roundtrip_order.snap
@@ -1,10 +1,14 @@
 ---
 source: hugr-core/tests/model.rs
-expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-order.edn\"))"
+expression: ast
 ---
 (hugr 0)
 
 (mod)
+
+(import core.meta.description)
+
+(import core.nat)
 
 (import core.order_hint.key)
 
@@ -14,47 +18,53 @@ expression: "roundtrip(include_str!(\"../../hugr-model/tests/fixtures/model-orde
 
 (import arithmetic.int.types.int)
 
-(import arithmetic.int.ineg)
+(declare-operation
+  arithmetic.int.ineg
+  (param ?0 core.nat)
+  (core.fn [(arithmetic.int.types.int ?0)] [(arithmetic.int.types.int ?0)])
+  (meta
+    (core.meta.description
+      "negation modulo 2^N (signed and unsigned versions are the same op)")))
 
 (define-func
   main
   (core.fn
-    [arithmetic.int.types.int
-     arithmetic.int.types.int
-     arithmetic.int.types.int
-     arithmetic.int.types.int]
-    [arithmetic.int.types.int
-     arithmetic.int.types.int
-     arithmetic.int.types.int
-     arithmetic.int.types.int])
+    [(arithmetic.int.types.int 6)
+     (arithmetic.int.types.int 6)
+     (arithmetic.int.types.int 6)
+     (arithmetic.int.types.int 6)]
+    [(arithmetic.int.types.int 6)
+     (arithmetic.int.types.int 6)
+     (arithmetic.int.types.int 6)
+     (arithmetic.int.types.int 6)])
   (dfg [%0 %1 %2 %3] [%4 %5 %6 %7]
     (signature
       (core.fn
-        [arithmetic.int.types.int
-         arithmetic.int.types.int
-         arithmetic.int.types.int
-         arithmetic.int.types.int]
-        [arithmetic.int.types.int
-         arithmetic.int.types.int
-         arithmetic.int.types.int
-         arithmetic.int.types.int]))
+        [(arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)]
+        [(arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)]))
     (meta (core.order_hint.order 4 7))
     (meta (core.order_hint.order 5 6))
     (meta (core.order_hint.order 5 4))
     (meta (core.order_hint.order 6 7))
-    (arithmetic.int.ineg [%0] [%4]
+    ((arithmetic.int.ineg 6) [%0] [%4]
       (signature
-        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+        (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
       (meta (core.order_hint.key 4)))
-    (arithmetic.int.ineg [%1] [%5]
+    ((arithmetic.int.ineg 6) [%1] [%5]
       (signature
-        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+        (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
       (meta (core.order_hint.key 5)))
-    (arithmetic.int.ineg [%2] [%6]
+    ((arithmetic.int.ineg 6) [%2] [%6]
       (signature
-        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+        (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
       (meta (core.order_hint.key 6)))
-    (arithmetic.int.ineg [%3] [%7]
+    ((arithmetic.int.ineg 6) [%3] [%7]
       (signature
-        (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+        (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
       (meta (core.order_hint.key 7)))))

--- a/hugr-model/tests/fixtures/model-add.edn
+++ b/hugr-model/tests/fixtures/model-add.edn
@@ -2,14 +2,18 @@
 
 (mod)
 
-(define-func example.add
+(define-func
+  example.add
   (core.fn
-   [arithmetic.int.types.int arithmetic.int.types.int]
-   [arithmetic.int.types.int])
-  (dfg
-   [%0 %1]
-   [%2]
-   (signature (core.fn [arithmetic.int.types.int arithmetic.int.types.int] [arithmetic.int.types.int]))
-   (arithmetic.int.iadd
-    [%0 %1] [%2]
-    (signature (core.fn [arithmetic.int.types.int arithmetic.int.types.int] [arithmetic.int.types.int])))))
+    [(arithmetic.int.types.int 6) (arithmetic.int.types.int 6)]
+    [(arithmetic.int.types.int 6)])
+  (dfg [%0 %1] [%2]
+    (signature
+      (core.fn
+        [(arithmetic.int.types.int 6) (arithmetic.int.types.int 6)]
+        [(arithmetic.int.types.int 6)]))
+    ((arithmetic.int.iadd 6) [%0 %1] [%2]
+      (signature
+        (core.fn
+          [(arithmetic.int.types.int 6) (arithmetic.int.types.int 6)]
+          [(arithmetic.int.types.int 6)])))))

--- a/hugr-model/tests/fixtures/model-cond.edn
+++ b/hugr-model/tests/fixtures/model-cond.edn
@@ -2,16 +2,29 @@
 
 (mod)
 
-(define-func example.cond
-  (core.fn [(core.adt [[] []]) arithmetic.int.types.int]
-           [arithmetic.int.types.int])
+(define-func
+  example.cond
+  (core.fn
+    [(core.adt [[] []]) (arithmetic.int.types.int 6)]
+    [(arithmetic.int.types.int 6)])
   (dfg [%0 %1] [%2]
-       (signature (core.fn [(core.adt [[] []]) arithmetic.int.types.int] [arithmetic.int.types.int]))
-       (cond [%0 %1] [%2]
-             (signature (core.fn [(core.adt [[] []]) arithmetic.int.types.int] [arithmetic.int.types.int]))
-             (dfg [%3] [%3]
-                  (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))
-             (dfg [%4] [%5]
-                  (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
-                  (arithmetic.int.ineg [%4] [%5]
-                                       (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int])))))))
+    (signature
+      (core.fn
+        [(core.adt [[] []]) (arithmetic.int.types.int 6)]
+        [(arithmetic.int.types.int 6)]))
+    (cond [%0 %1] [%2]
+      (signature
+        (core.fn
+          [(core.adt [[] []]) (arithmetic.int.types.int 6)]
+          [(arithmetic.int.types.int 6)]))
+      (dfg [%3] [%3]
+        (signature
+          (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)])))
+      (dfg [%4] [%5]
+        (signature
+          (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
+        ((arithmetic.int.ineg 6) [%4] [%5]
+          (signature
+            (core.fn
+              [(arithmetic.int.types.int 6)]
+              [(arithmetic.int.types.int 6)])))))))

--- a/hugr-model/tests/fixtures/model-order.edn
+++ b/hugr-model/tests/fixtures/model-order.edn
@@ -4,47 +4,47 @@
 
 (define-func main
   (core.fn
-    [arithmetic.int.types.int
-      arithmetic.int.types.int
-      arithmetic.int.types.int
-      arithmetic.int.types.int]
-    [arithmetic.int.types.int
-      arithmetic.int.types.int
-      arithmetic.int.types.int
-      arithmetic.int.types.int])
+    [(arithmetic.int.types.int 6)
+      (arithmetic.int.types.int 6)
+      (arithmetic.int.types.int 6)
+      (arithmetic.int.types.int 6)]
+    [(arithmetic.int.types.int 6)
+      (arithmetic.int.types.int 6)
+      (arithmetic.int.types.int 6)
+      (arithmetic.int.types.int 6)])
   (dfg [%0 %1 %2 %3] [%4 %5 %6 %7]
     (signature
       (core.fn
-        [arithmetic.int.types.int
-         arithmetic.int.types.int
-         arithmetic.int.types.int
-         arithmetic.int.types.int]
-        [arithmetic.int.types.int
-         arithmetic.int.types.int
-         arithmetic.int.types.int
-         arithmetic.int.types.int]))
+        [(arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)]
+        [(arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)
+         (arithmetic.int.types.int 6)]))
 
     (meta (core.order_hint.order 1 2))
     (meta (core.order_hint.order 1 0))
     (meta (core.order_hint.order 2 3))
     (meta (core.order_hint.order 0 3))
 
-    (arithmetic.int.ineg
+    ((arithmetic.int.ineg 6)
       [%0] [%4]
-      (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (signature (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
       (meta (core.order_hint.key 0)))
 
-    (arithmetic.int.ineg
+    ((arithmetic.int.ineg 6)
       [%1] [%5]
-      (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (signature (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
       (meta (core.order_hint.key 1)))
 
-    (arithmetic.int.ineg
+    ((arithmetic.int.ineg 6)
       [%2] [%6]
-      (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (signature (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
       (meta (core.order_hint.key 2)))
 
-    (arithmetic.int.ineg
+    ((arithmetic.int.ineg 6)
       [%3] [%7]
-      (signature (core.fn [arithmetic.int.types.int] [arithmetic.int.types.int]))
+      (signature (core.fn [(arithmetic.int.types.int 6)] [(arithmetic.int.types.int 6)]))
       (meta (core.order_hint.key 3)))))


### PR DESCRIPTION
This PR adds extension resolution to Rust model import.

Closes #2320.