### PR TITLE
refactor(types.rs): rm incorrect comment and unnecessary allow-unused

### DIFF
--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -25,8 +25,6 @@ use smol_str::SmolStr;
 pub use type_param::TypeArg;
 pub use type_row::{TypeRow, TypeRowRV};
 
-// Unused in --no-features
-#[allow(unused_imports)]
 pub(crate) use poly_func::PolyFuncTypeBase;
 
 use itertools::FoldWhile::{Continue, Done};


### PR DESCRIPTION
These are misleading; it's now used by hugr-core import/export, which seems fine.