### PR TITLE
fix!: Fix panic in model resolver when variable is used outside of symbol.

### DIFF
--- a/hugr-model/src/v0/ast/resolve.rs
+++ b/hugr-model/src/v0/ast/resolve.rs
@@ -388,3 +388,18 @@ fn try_alloc_slice<T, E>(
     }
     Ok(vec.into_bump_slice())
 }
+
+#[cfg(test)]
+mod test {
+    use crate::v0::ast;
+    use bumpalo::Bump;
+    use std::str::FromStr as _;
+
+    #[test]
+    fn vars_in_root_scope() {
+        let text = "(hugr 0) (mod) (meta ?x)";
+        let ast = ast::Package::from_str(text).unwrap();
+        let bump = Bump::new();
+        assert!(ast.resolve(&bump).is_err());
+    }
+}


### PR DESCRIPTION
Closes #2312.

BREAKING CHANGE: `UnknownVarError` in `hugr-model` is changed into an enum with two cases.