### PR TITLE
ci: support releases from release/* branches

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - release/*
 
 permissions:
   contents: write
@@ -21,3 +22,4 @@ jobs:
             # Using a personal access token so releases created by this workflow can trigger the deployment workflow
             token: ${{ secrets.HUGRBOT_PAT }}
             config-file: release-please-config.json
+            target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
Following https://github.com/googleapis/release-please-action?tab=readme-ov-file#supporting-multiple-release-branches