### PR TITLE
fix: stringify metadata before escaping in renderer

### DIFF
--- a/hugr-py/src/hugr/hugr/render.py
+++ b/hugr-py/src/hugr/hugr/render.py
@@ -103,7 +103,7 @@ class DotRenderer:
             "bgcolor": self.config.palette.background,
         }
         if name := hugr[hugr.module_root].metadata.get("name", None):
-            name = html.escape(name)
+            name = html.escape(str(name))
         else:
             name = ""
 
@@ -218,7 +218,7 @@ class DotRenderer:
         meta = hugr[node].metadata
         if len(meta) > 0:
             data = "<BR/><BR/>" + "<BR/>".join(
-                html.escape(key) + ": " + html.escape(value)
+                html.escape(key) + ": " + html.escape(str(value))
                 for key, value in meta.items()
             )
         else:

--- a/hugr-py/tests/__snapshots__/test_hugr_build.ambr
+++ b/hugr-py/tests/__snapshots__/test_hugr_build.ambr
@@ -1198,7 +1198,7 @@
           <TD>
           <TABLE BORDER="0" CELLBORDER="0">
               <TR><TD><FONT POINT-SIZE="11.0" FACE="monospace"
-                  COLOR="black"><B><b>[FuncDefn(&lt;jupyter-notebook&gt;)]</b></B><BR/><BR/>label: &lt;b&gt;Bold Label&lt;/b&gt;<BR/>&lt;other-label&gt;: &lt;i&gt;Italic Label&lt;/i&gt;</FONT></TD></TR>
+                  COLOR="black"><B><b>[FuncDefn(&lt;jupyter-notebook&gt;)]</b></B><BR/><BR/>label: &lt;b&gt;Bold Label&lt;/b&gt;<BR/>&lt;other-label&gt;: &lt;i&gt;Italic Label&lt;/i&gt;<BR/>meta_can_be_anything: [42, &#x27;string&#x27;, 3.14, True]</FONT></TD></TR>
           </TABLE>
           </TD>
       </TR>

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -457,6 +457,7 @@ def test_html_labels(snapshot) -> None:
     )
     f.metadata["label"] = "<b>Bold Label</b>"
     f.metadata["<other-label>"] = "<i>Italic Label</i>"
+    f.metadata["meta_can_be_anything"] = [42, "string", 3.14, True]
 
     f.hugr[f.hugr.module_root].metadata["name"] = "<i>Module Root</i>"
 


### PR DESCRIPTION
Made sure to `str()` the `Any` values before html-escaping