### PR TITLE
feat: Standarize the string formating of sum types and values

### DIFF
--- a/hugr-py/src/hugr/utils.py
+++ b/hugr-py/src/hugr/utils.py
@@ -215,3 +215,27 @@ def comma_sep_str(items: Iterable[T]) -> str:
 def comma_sep_repr(items: Iterable[T]) -> str:
     """Join items with commas and repr."""
     return ", ".join(map(repr, items))
+
+
+def comma_sep_str_paren(items: Iterable[T]) -> str:
+    """Join items with commas and str, wrapping them in parentheses if more than one."""
+    items = list(items)
+    if len(items) == 0:
+        return "()"
+    elif len(items) == 1:
+        return f"{items[0]}"
+    else:
+        return f"({comma_sep_str(items)})"
+
+
+def comma_sep_repr_paren(items: Iterable[T]) -> str:
+    """Join items with commas and repr, wrapping them in parentheses if more
+    than one.
+    """
+    items = list(items)
+    if len(items) == 0:
+        return "()"
+    elif len(items) == 1:
+        return f"{items[0]}"
+    else:
+        return f"({comma_sep_repr(items)})"

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -45,8 +45,8 @@ class Sum(Value):
     """Sum-of-product value.
 
     Example:
-        >>> Sum(0, tys.Sum([[tys.Bool], [tys.Unit]]), [TRUE])
-        Sum(tag=0, typ=Sum([[Bool], [Unit]]), vals=[TRUE])
+        >>> Sum(0, tys.Sum([[tys.Bool], [tys.Unit], [tys.Bool]]), [TRUE])
+        Sum(tag=0, typ=Sum([[Bool], [Unit], [Bool]]), vals=[TRUE])
     """
 
     #: Tag identifying the variant.
@@ -69,6 +69,59 @@ class Sum(Value):
             typ=stys.SumType(root=self.type_()._to_serial()),
             vs=ser_it(self.vals),
         )
+
+    def __repr__(self) -> str:
+        if self == TRUE:
+            return "TRUE"
+        elif self == FALSE:
+            return "FALSE"
+        elif self == Unit:
+            return "Unit"
+        elif all(len(row) == 0 for row in self.typ.variant_rows):
+            return f"UnitSum({self.tag}, {self.n_variants})"
+        elif len(self.typ.variant_rows) == 1:
+            return f"Tuple({comma_sep_repr(self.vals)})"
+        elif len(self.typ.variant_rows) == 2 and len(self.typ.variant_rows[0]) == 0:
+            # Option
+            if self.tag == 0:
+                return f"None({comma_sep_str(self.typ.variant_rows[1])})"
+            else:
+                return f"Some({comma_sep_repr(self.vals)})"
+        elif len(self.typ.variant_rows) == 2:
+            # Either
+            left_typ, right_typ = self.typ.variant_rows
+            if self.tag == 0:
+                return f"Left(vals={self.vals}, right_typ={list(right_typ)})"
+            else:
+                return f"Right(left_typ={list(left_typ)}, vals={self.vals})"
+        else:
+            return f"Sum(tag={self.tag}, typ={self.typ}, vals={self.vals})"
+
+    def __str__(self) -> str:
+        if self == TRUE:
+            return "TRUE"
+        elif self == FALSE:
+            return "FALSE"
+        elif self == Unit:
+            return "Unit"
+        elif all(len(row) == 0 for row in self.typ.variant_rows):
+            return f"UnitSum({self.tag}, {self.n_variants})"
+        elif len(self.typ.variant_rows) == 1:
+            return f"Tuple({comma_sep_str(self.vals)})"
+        elif len(self.typ.variant_rows) == 2 and len(self.typ.variant_rows[0]) == 0:
+            # Option
+            if self.tag == 0:
+                return "None"
+            else:
+                return f"Some({comma_sep_str(self.vals)})"
+        elif len(self.typ.variant_rows) == 2:
+            # Either
+            if self.tag == 0:
+                return f"Left({comma_sep_str(self.vals)})"
+            else:
+                return f"Right({comma_sep_str(self.vals)})"
+        else:
+            return f"Sum({self.tag}, {self.typ}, {self.vals})"
 
     def __eq__(self, other: object) -> bool:
         return (
@@ -100,6 +153,7 @@ class Sum(Value):
         )
 
 
+@dataclass(eq=False, repr=False)
 class UnitSum(Sum):
     """Simple :class:`Sum` with each variant being an empty row.
 
@@ -118,15 +172,6 @@ class UnitSum(Sum):
             typ=tys.UnitSum(size),
             vals=[],
         )
-
-    def __repr__(self) -> str:
-        if self == TRUE:
-            return "TRUE"
-        if self == FALSE:
-            return "FALSE"
-        if self == Unit:
-            return "Unit"
-        return f"UnitSum({self.tag}, {self.n_variants})"
 
 
 def bool_value(b: bool) -> UnitSum:
@@ -149,7 +194,7 @@ TRUE = bool_value(True)
 FALSE = bool_value(False)
 
 
-@dataclass(eq=False)
+@dataclass(eq=False, repr=False)
 class Tuple(Sum):
     """Tuple or product value, defined by a list of values.
     Internally a :class:`Sum` with a single variant row.
@@ -177,10 +222,10 @@ class Tuple(Sum):
         )
 
     def __repr__(self) -> str:
-        return f"Tuple({comma_sep_repr(self.vals)})"
+        return super().__repr__()
 
 
-@dataclass(eq=False)
+@dataclass(eq=False, repr=False)
 class Some(Sum):
     """Optional tuple of value, containing a list of values.
 
@@ -199,11 +244,8 @@ class Some(Sum):
             tag=1, typ=tys.Option(*(v.type_() for v in val_list)), vals=val_list
         )
 
-    def __repr__(self) -> str:
-        return f"Some({comma_sep_repr(self.vals)})"
 
-
-@dataclass(eq=False)
+@dataclass(eq=False, repr=False)
 class None_(Sum):
     """Optional tuple of value, containing no values.
 
@@ -219,14 +261,8 @@ class None_(Sum):
     def __init__(self, *types: tys.Type):
         super().__init__(tag=0, typ=tys.Option(*types), vals=[])
 
-    def __repr__(self) -> str:
-        return f"None({comma_sep_str(self.typ.variant_rows[1])})"
 
-    def __str__(self) -> str:
-        return "None"
-
-
-@dataclass(eq=False)
+@dataclass(eq=False, repr=False)
 class Left(Sum):
     """Left variant of a :class:`tys.Either` type, containing a list of values.
 
@@ -248,15 +284,8 @@ class Left(Sum):
             vals=val_list,
         )
 
-    def __repr__(self) -> str:
-        _, right_typ = self.typ.variant_rows
-        return f"Left(vals={self.vals}, right_typ={list(right_typ)})"
 
-    def __str__(self) -> str:
-        return f"Left({comma_sep_str(self.vals)})"
-
-
-@dataclass(eq=False)
+@dataclass(eq=False, repr=False)
 class Right(Sum):
     """Right variant of a :class:`tys.Either` type, containing a list of values.
 
@@ -279,13 +308,6 @@ class Right(Sum):
             typ=tys.Either(left_typ, [v.type_() for v in val_list]),
             vals=val_list,
         )
-
-    def __repr__(self) -> str:
-        left_typ, _ = self.typ.variant_rows
-        return f"Right(left_typ={list(left_typ)}, vals={self.vals})"
-
-    def __str__(self) -> str:
-        return f"Right({comma_sep_str(self.vals)})"
 
 
 @dataclass

--- a/hugr-py/tests/test_val.py
+++ b/hugr-py/tests/test_val.py
@@ -14,7 +14,6 @@ from hugr.val import (
     Sum,
     Tuple,
     UnitSum,
-    Value,
     bool_value,
 )
 
@@ -44,9 +43,9 @@ def test_sums():
     ("value", "string", "repr_str"),
     [
         (
-            Sum(0, tys.Sum([[tys.Bool], [tys.Qubit]]), [TRUE, FALSE]),
-            "Sum(tag=0, typ=Sum([[Bool], [Qubit]]), vals=[TRUE, FALSE])",
-            "Sum(tag=0, typ=Sum([[Bool], [Qubit]]), vals=[TRUE, FALSE])",
+            Sum(0, tys.Sum([[tys.Bool], [tys.Qubit], [tys.Bool]]), [TRUE]),
+            "Sum(0, Sum([[Bool], [Qubit], [Bool]]), [TRUE])",
+            "Sum(tag=0, typ=Sum([[Bool], [Qubit], [Bool]]), vals=[TRUE])",
         ),
         (UnitSum(0, size=1), "Unit", "Unit"),
         (UnitSum(0, size=2), "FALSE", "FALSE"),
@@ -67,9 +66,14 @@ def test_sums():
         ),
     ],
 )
-def test_val_sum_str(value: Value, string: str, repr_str: str):
+def test_val_sum_str(value: Sum, string: str, repr_str: str):
     assert str(value) == string
     assert repr(value) == repr_str
+
+    # Make sure the corresponding `Sum` also renders the same
+    sum_val = Sum(value.tag, value.typ, value.vals)
+    assert str(sum_val) == string
+    assert repr(sum_val) == repr_str
 
 
 def test_val_static_array():


### PR DESCRIPTION
The Sum value and type helpers get coerced back into `val.Sum` and `tys.Sum` after a serialization roundtrip. This used to change the rendering of the values, falling back to the verbose `Sum(tag=#, typ=[..., ...], vals=[...,...])`.

This PR centralizes the str/repr definition, so equivalent values and types are always rendered in the same way. (I needed this for roundtrip checks).