### PR TITLE
feat(hugr-cli): CliError::validate helper

### DIFF
--- a/hugr-cli/src/lib.rs
+++ b/hugr-cli/src/lib.rs
@@ -136,3 +136,17 @@ pub enum CliError {
         generator: Box<String>,
     },
 }
+
+impl CliError {
+    /// Returns a validation error, with an optional generator.
+    pub fn validation(generator: Option<String>, val_err: PackageValidationError) -> Self {
+        if let Some(g) = generator {
+            Self::ValidateKnownGenerator {
+                inner: val_err,
+                generator: Box::new(g.to_string()),
+            }
+        } else {
+            Self::Validate(val_err)
+        }
+    }
+}

--- a/hugr-cli/src/mermaid.rs
+++ b/hugr-cli/src/mermaid.rs
@@ -44,9 +44,12 @@ impl MermaidArgs {
     /// Write the mermaid diagram for a HUGR envelope.
     pub fn run_print_envelope(&mut self) -> Result<()> {
         let package = self.input_args.get_package()?;
+        let generator = hugr::envelope::get_generator(&package.modules);
 
         if self.validate {
-            package.validate().map_err(CliError::Validate)?;
+            package
+                .validate()
+                .map_err(|val_err| CliError::validation(generator, val_err))?;
         }
 
         for hugr in package.modules {

--- a/hugr-cli/src/validate.rs
+++ b/hugr-cli/src/validate.rs
@@ -34,28 +34,17 @@ impl ValArgs {
 
             hugr.validate()
                 .map_err(PackageValidationError::Validation)
-                .map_err(|val_err| wrap_generator(generator, val_err))?;
+                .map_err(|val_err| CliError::validation(generator, val_err))?;
         } else {
             let package = self.input_args.get_package()?;
             let generator = hugr::envelope::get_generator(&package.modules);
             package
                 .validate()
-                .map_err(|val_err| wrap_generator(generator, val_err))?;
+                .map_err(|val_err| CliError::validation(generator, val_err))?;
         };
 
         info!("{VALID_PRINT}");
 
         Ok(())
-    }
-}
-
-fn wrap_generator(generator: Option<String>, val_err: PackageValidationError) -> CliError {
-    if let Some(g) = generator {
-        CliError::ValidateKnownGenerator {
-            inner: val_err,
-            generator: Box::new(g.to_string()),
-        }
-    } else {
-        CliError::Validate(val_err)
     }
 }


### PR DESCRIPTION
Makes the helper public, so other libraries don't have to re-create.

drive-by: Add generator data to validation errors in `hugr mermaid`.