### PR TITLE
fix: SiblingSubgraph::try_from_nodes not including disconnected components

### DIFF
--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -333,7 +333,7 @@ impl<N: HugrNode> SiblingSubgraph<N> {
 
         let mut subgraph = Self::try_new_with_checker(inputs, outputs, hugr, checker)?;
 
-        // If some nodes formed a fully component, they won't be included in the subgraph generated from the boundaries.
+        // If some nodes formed a fully connected component, they won't be included in the subgraph generated from the boundaries.
         // We re-add them here.
         if subgraph.node_count() < num_nodes {
             subgraph.nodes = nodes;


### PR DESCRIPTION
- When given a set of nodes with no outside boundaries, `SiblingSubgraph::try_from_nodes` selected the whole region instead.
- When given a mixed set, with some boundary nodes and some disconnected subgraph component, `SiblingSubgraph::try_from_nodes` did not include the disconnected nodes.