### PR TITLE
refactor!: consistent inout order in borrow array

### DIFF
--- a/hugr-py/src/hugr/std/_json_defs/collections/borrow_arr.json
+++ b/hugr-py/src/hugr/std/_json_defs/collections/borrow_arr.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.2.0",
   "name": "collections.borrow_arr",
   "types": {
     "borrow_array": {
@@ -70,11 +70,6 @@
           ],
           "output": [
             {
-              "t": "V",
-              "i": 1,
-              "b": "A"
-            },
-            {
               "t": "Opaque",
               "extension": "collections.borrow_arr",
               "id": "borrow_array",
@@ -97,6 +92,11 @@
                 }
               ],
               "bound": "A"
+            },
+            {
+              "t": "V",
+              "i": 1,
+              "b": "A"
             }
           ]
         }
@@ -540,11 +540,6 @@
           ],
           "output": [
             {
-              "t": "Sum",
-              "s": "Unit",
-              "size": 2
-            },
-            {
               "t": "Opaque",
               "extension": "collections.borrow_arr",
               "id": "borrow_array",
@@ -567,6 +562,11 @@
                 }
               ],
               "bound": "A"
+            },
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
             }
           ]
         }

--- a/specification/std_extensions/collections/borrow_arr.json
+++ b/specification/std_extensions/collections/borrow_arr.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.2.0",
   "name": "collections.borrow_arr",
   "types": {
     "borrow_array": {
@@ -70,11 +70,6 @@
           ],
           "output": [
             {
-              "t": "V",
-              "i": 1,
-              "b": "A"
-            },
-            {
               "t": "Opaque",
               "extension": "collections.borrow_arr",
               "id": "borrow_array",
@@ -97,6 +92,11 @@
                 }
               ],
               "bound": "A"
+            },
+            {
+              "t": "V",
+              "i": 1,
+              "b": "A"
             }
           ]
         }
@@ -540,11 +540,6 @@
           ],
           "output": [
             {
-              "t": "Sum",
-              "s": "Unit",
-              "size": 2
-            },
-            {
               "t": "Opaque",
               "extension": "collections.borrow_arr",
               "id": "borrow_array",
@@ -567,6 +562,11 @@
                 }
               ],
               "bound": "A"
+            },
+            {
+              "t": "Sum",
+              "s": "Unit",
+              "size": 2
             }
           ]
         }


### PR DESCRIPTION
BorrowArray::{borrow, is_borrowed} have had their return types switched such that the array itself is first, matching the input signature. This is more consistent with other ops that both take and return a type.


BREAKING CHANGE: BorrowArray::{borrow, is_borrowed} return types have been swapped such that the array is first. 