### PR TITLE
chore: Add python 3.14 classifier to pyproject

### DIFF
--- a/hugr-py/pyproject.toml
+++ b/hugr-py/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
These get listed on the sidebar in https://pypi.org/project/hugr/