### PR TITLE
feat(llvm)!: upgrade to inkwell 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1612,23 +1612,22 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67349bd7578d4afebbe15eaa642a80b884e8623db74b1716611b131feb1deef"
+checksum = "9600fe514cef87530b1ccea444dce1a6defab027c55c023a1466302694ffa439"
 dependencies = [
- "either",
  "inkwell_internals",
  "libc",
  "llvm-sys",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f365c8de536236cfdebd0ba2130de22acefed18b1fb99c32783b3840aec5fb46"
+checksum = "ad9a7dd586b00f2b20e0b9ae3c6faa351fbfd56d15d63bbce35b13bece682eda"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -25,7 +25,7 @@ llvm14-0 = ["inkwell/llvm14-0"]
 workspace = true
 
 [dependencies]
-inkwell = { version = "0.6.0", default-features = false }
+inkwell = { version = "0.7", default-features = false }
 hugr-core = { path = "../hugr-core", version = "0.24.3" }
 anyhow.workspace = true
 itertools.workspace = true

--- a/hugr-llvm/src/emit/func.rs
+++ b/hugr-llvm/src/emit/func.rs
@@ -418,7 +418,7 @@ pub fn get_or_make_function<'c, H: HugrView<Node = Node>, const N: usize>(
     let call_site =
         ctx.builder()
             .build_call(func, &args.iter().map(|&a| a.into()).collect_vec(), "")?;
-    let result = call_site.try_as_basic_value().left();
+    let result = call_site.try_as_basic_value().basic();
     Ok(result)
 }
 

--- a/hugr-llvm/src/emit/libc.rs
+++ b/hugr-llvm/src/emit/libc.rs
@@ -45,7 +45,7 @@ pub fn emit_libc_malloc<'c, H: HugrView<Node = Node>>(
         .builder()
         .build_call(malloc, &[size], "")?
         .try_as_basic_value()
-        .unwrap_left();
+        .unwrap_basic();
     Ok(res)
 }
 

--- a/hugr-llvm/src/extension/collections/array.rs
+++ b/hugr-llvm/src/extension/collections/array.rs
@@ -836,7 +836,7 @@ pub fn emit_repeat_op<'c, H: HugrView<Node = Node>>(
         let v = builder
             .build_call(func_ptr, &[], "")?
             .try_as_basic_value()
-            .left()
+            .basic()
             .ok_or(anyhow!("ArrayOpDef::repeat function must return a value"))?;
         let elem_addr = unsafe { builder.build_in_bounds_gep(ptr, &[idx], "")? };
         builder.build_store(elem_addr, v)?;

--- a/hugr-llvm/src/extension/collections/borrow_array.rs
+++ b/hugr-llvm/src/extension/collections/borrow_array.rs
@@ -1470,7 +1470,7 @@ pub fn emit_repeat_op<'c, H: HugrView<Node = Node>>(
         let v = builder
             .build_call(func_ptr, &[], "")?
             .try_as_basic_value()
-            .left()
+            .basic()
             .ok_or(anyhow!("BArrayOpDef::repeat function must return a value"))?;
         let elem_addr = unsafe { builder.build_in_bounds_gep(ptr, &[idx], "")? };
         builder.build_store(elem_addr, v)?;

--- a/hugr-llvm/src/extension/collections/list.rs
+++ b/hugr-llvm/src/extension/collections/list.rs
@@ -225,7 +225,7 @@ fn emit_list_op<'c, H: HugrView<Node = Node>>(
                 .builder()
                 .build_call(func, &[list.into(), out_ptr.into()], "")?
                 .try_as_basic_value()
-                .unwrap_left()
+                .unwrap_basic()
                 .into_int_value();
             let elem = build_load_i8_ptr(ctx, out_ptr, elem_ty)?;
             let elem_opt = build_option(ctx, ok, elem, hugr_elem_ty)?;
@@ -238,7 +238,7 @@ fn emit_list_op<'c, H: HugrView<Node = Node>>(
                 .builder()
                 .build_call(func, &[list.into(), idx.into(), out_ptr.into()], "")?
                 .try_as_basic_value()
-                .unwrap_left()
+                .unwrap_basic()
                 .into_int_value();
             let elem = build_load_i8_ptr(ctx, out_ptr, elem_ty)?;
             let elem_opt = build_option(ctx, ok, elem, hugr_elem_ty)?;
@@ -251,7 +251,7 @@ fn emit_list_op<'c, H: HugrView<Node = Node>>(
                 .builder()
                 .build_call(func, &[list.into(), idx.into(), elem_ptr.into()], "")?
                 .try_as_basic_value()
-                .unwrap_left()
+                .unwrap_basic()
                 .into_int_value();
             let old_elem = build_load_i8_ptr(ctx, elem_ptr, elem.get_type())?;
             let ok_or =
@@ -265,7 +265,7 @@ fn emit_list_op<'c, H: HugrView<Node = Node>>(
                 .builder()
                 .build_call(func, &[list.into(), idx.into(), elem_ptr.into()], "")?
                 .try_as_basic_value()
-                .unwrap_left()
+                .unwrap_basic()
                 .into_int_value();
             let unit =
                 ctx.llvm_sum_type(SumType::new_unary(1))?
@@ -279,7 +279,7 @@ fn emit_list_op<'c, H: HugrView<Node = Node>>(
                 .builder()
                 .build_call(func, &[list.into()], "")?
                 .try_as_basic_value()
-                .unwrap_left()
+                .unwrap_basic()
                 .into_int_value();
             args.outputs
                 .finish(ctx.builder(), vec![list, length.into()])?;
@@ -316,7 +316,7 @@ fn emit_list_value<'c, H: HugrView<Node = Node>>(
             "",
         )?
         .try_as_basic_value()
-        .unwrap_left();
+        .unwrap_basic();
     // Push elements onto the list
     let rt_push = ListRtFunc::Push.get_extern(ctx, ccg)?;
     for v in val.get_contents() {

--- a/hugr-llvm/src/extension/collections/stack_array.rs
+++ b/hugr-llvm/src/extension/collections/stack_array.rs
@@ -666,7 +666,7 @@ fn emit_repeat_op<'c, H: HugrView<Node = Node>>(
         let v = builder
             .build_call(func_ptr, &[], "")?
             .try_as_basic_value()
-            .left()
+            .basic()
             .ok_or(anyhow!("ArrayOpDef::repeat function must return a value"))?;
         let elem_addr = unsafe { builder.build_in_bounds_gep(ptr, &[idx], "")? };
         builder.build_store(elem_addr, v)?;

--- a/hugr-llvm/src/extension/float.rs
+++ b/hugr-llvm/src/extension/float.rs
@@ -99,7 +99,7 @@ fn emit_float_op<'c, H: HugrView<Node = Node>>(
                 ctx.builder()
                     .build_call(func, &[lhs.into(), rhs.into()], "")?
                     .try_as_basic_value()
-                    .unwrap_left()
+                    .unwrap_basic()
                     .as_basic_value_enum(),
             ])
         }),

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -523,7 +523,7 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                 .builder()
                 .build_call(intr, &[arg.into_int_value().into(), true_.into()], "")?
                 .try_as_basic_value()
-                .unwrap_left();
+                .unwrap_basic();
             Ok(vec![r])
         }),
         IntOpDef::imax_s => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
@@ -540,7 +540,7 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                     "",
                 )?
                 .try_as_basic_value()
-                .unwrap_left();
+                .unwrap_basic();
             Ok(vec![r])
         }),
         IntOpDef::imax_u => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
@@ -557,7 +557,7 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                     "",
                 )?
                 .try_as_basic_value()
-                .unwrap_left();
+                .unwrap_basic();
             Ok(vec![r])
         }),
         IntOpDef::imin_s => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
@@ -574,7 +574,7 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                     "",
                 )?
                 .try_as_basic_value()
-                .unwrap_left();
+                .unwrap_basic();
             Ok(vec![r])
         }),
         IntOpDef::imin_u => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
@@ -591,7 +591,7 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                     "",
                 )?
                 .try_as_basic_value()
-                .unwrap_left();
+                .unwrap_basic();
             Ok(vec![r])
         }),
         IntOpDef::ishl => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {


### PR DESCRIPTION
Supercedes #2693 

BREAKING CHANGE: exported inkwell upgraded to 0.7, some methods no longer return Either.