### PR TITLE
refactor(linking.rs)!: (tiny) avoid type_complexity

### DIFF
--- a/hugr-core/src/hugr/linking.rs
+++ b/hugr-core/src/hugr/linking.rs
@@ -32,13 +32,12 @@ pub trait HugrLinking: HugrMut {
     /// # Panics
     ///
     /// If `parent` is `Some` but not in the graph.
-    #[allow(clippy::type_complexity)]
-    fn insert_link_view_by_node<H: HugrView>(
+    fn insert_link_view_by_node<HN: HugrNode>(
         &mut self,
         parent: Option<Self::Node>,
-        other: &H,
-        children: NodeLinkingDirectives<H::Node, Self::Node>,
-    ) -> Result<InsertedForest<H::Node, Self::Node>, NodeLinkingError<H::Node, Self::Node>> {
+        other: &impl HugrView<Node = HN>,
+        children: NodeLinkingDirectives<HN, Self::Node>,
+    ) -> Result<InsertedForest<HN, Self::Node>, NodeLinkingError<HN, Self::Node>> {
         let transfers = check_directives(other, parent, &children)?;
         let nodes =
             parent


### PR DESCRIPTION
This is breaking in that if you called `insert_link_view_by_node::<SomeHugrViewType>` you would need to change that to instead specify the Node type of the view. That is a small enough breakage that semver-checks doesn't spot it....but I think we can roll into the 0.25.0 breaking release.

BREAKING CHANGE: `insert_link_view_by_node` parametric over type of Node not HugrView