### PR TITLE
feat(hugr-py): Implement a custom `TypeBound.__repr__()`.

### DIFF
--- a/hugr-py/src/hugr/_serialization/tys.py
+++ b/hugr-py/src/hugr/_serialization/tys.py
@@ -441,6 +441,9 @@ class TypeBound(Enum):
             case TypeBound.Linear:
                 return "Linear"
 
+    def __repr__(self) -> str:
+        return f"TypeBound.{self}"
+
 
 class Opaque(BaseType):
     """An opaque Type that can be downcasted by the extensions that define it."""

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -37,7 +37,7 @@ class ExplicitBound:
 
     Examples:
         >>> ExplicitBound(tys.TypeBound.Copyable)
-        ExplicitBound(bound=<TypeBound.Copyable: 'C'>)
+        ExplicitBound(bound=TypeBound.Copyable)
     """
 
     bound: tys.TypeBound

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -67,9 +67,9 @@ class Type(Protocol):
 
         Example:
             >>> Tuple(Bool, Bool).type_bound()
-            <TypeBound.Copyable: 'C'>
+            TypeBound.Copyable
             >>> Tuple(Qubit, Bool).type_bound()
-            <TypeBound.Linear: 'A'>
+            TypeBound.Linear
         """
         ...  # pragma: no cover
 


### PR DESCRIPTION
The way `TypeBound`s are represented in string representations such as
```
"FuncDefn(f_name='__neg__', inputs=[Tuple(Opaque(id='float64', bound=<TypeBound.Copyable: 'C'>, args=[], extension='arithmetic.float.types'),)], params=[], visibility='Private')"
```
is somewhat annoying. This PR implements a custom `__repr__()`  that makes it `eval()`-able.