### PR TITLE
feat: Optype iterators over value ports

### DIFF
--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -261,6 +261,31 @@ impl OpType {
             .map(|p| p.as_outgoing().unwrap())
     }
 
+    /// Return the dataflow value ports for the given direction.
+    ///
+    /// See [`OpType::value_input_ports`] and [`OpType::value_output_ports`].
+    #[inline]
+    #[must_use]
+    pub fn value_ports(&self, dir: Direction) -> impl DoubleEndedIterator<Item = Port> {
+        (0..self.value_port_count(dir)).map(move |i| Port::new(dir, i))
+    }
+
+    /// Return the dataflow value input ports for the given direction.
+    #[inline]
+    #[must_use]
+    pub fn value_input_ports(&self) -> impl DoubleEndedIterator<Item = IncomingPort> {
+        self.value_ports(Direction::Incoming)
+            .map(|p| p.as_incoming().unwrap())
+    }
+
+    /// Return the dataflow value output ports for the given direction.
+    #[inline]
+    #[must_use]
+    pub fn value_output_ports(&self) -> impl DoubleEndedIterator<Item = OutgoingPort> {
+        self.value_ports(Direction::Outgoing)
+            .map(|p| p.as_outgoing().unwrap())
+    }
+
     /// The number of Value ports in given direction.
     #[inline]
     #[must_use]

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -381,11 +381,11 @@ mod test {
 
     use ops::OpType;
 
-    use crate::Node;
     use crate::extension::ExtensionRegistry;
     use crate::extension::resolution::resolve_op_extensions;
     use crate::std_extensions::STD_REG;
     use crate::std_extensions::arithmetic::conversions::{self};
+    use crate::types::Type;
     use crate::{
         Extension,
         extension::{
@@ -395,6 +395,7 @@ mod test {
         std_extensions::arithmetic::int_types::INT_TYPES,
         types::FuncValueType,
     };
+    use crate::{Node, OutgoingPort};
 
     use super::*;
 
@@ -415,12 +416,22 @@ mod test {
         assert_eq!(op.name(), "OpaqueOp:res.op");
         assert_eq!(op.args(), &[usize_t().into()]);
         assert_eq!(op.signature().as_ref(), &sig);
+
+        let optype: OpType = op.into();
+        assert_eq!(
+            optype.value_input_ports().collect_vec(),
+            vec![IncomingPort::from(0)]
+        );
+        assert_eq!(
+            optype.value_output_ports().collect_vec(),
+            vec![OutgoingPort::from(0)]
+        );
     }
 
     #[test]
     fn resolve_opaque_op() {
         let registry = &STD_REG;
-        let i0 = &INT_TYPES[0];
+        let i0: &Type = &INT_TYPES[0];
         let opaque = OpaqueOp::new(
             conversions::EXTENSION_ID,
             "itobool",


### PR DESCRIPTION
`Optype` had helpers to get the `other_port` and the `static_port` of a node, but was missing a way to iterate over the value ports.

(We had to instantiate a `Signature` to get this before)