### PR TITLE
fix(hugr-py): solved graph rendering with `Const` nodes after applying`NormalizeGuppy`

### DIFF
--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -351,7 +351,7 @@ class Extension(Value):
         type = cast(model.Term, self.typ.to_model())
         json = sops.CustomConst(c=self.name, v=self.val).model_dump_json()
         return model.Apply("compat.const_json", [type, model.Literal(json)])
-    
+
     def __str__(self) -> str:
         return f"{self.name}({self.val})"
 


### PR DESCRIPTION
Solve issue [Improve Python graph rendering for Const nodes #2726](https://github.com/Quantinuum/hugr/issues/2726).

"When drawing the hugr in Python with DotRenderer the Const nodes take up an unreasonable amount of space which makes the HUGR hard to navigate. (This happens after applying the NormalizeGuppy pass to a HUGR containing parameterized gates)."

Defined the method `__str__` to the `Extension(Value)` class in [`hugr-py/src/hugr/val.py`](https://github.com/Quantinuum/hugr/blob/4f021a733c4ffc0c4f19a1df19f2a1076f5373b9/hugr-py/src/hugr/val.py)