### PR TITLE
docs(spec): clean up exception handling

### DIFF
--- a/specification/hugr.md
+++ b/specification/hugr.md
@@ -1594,7 +1594,7 @@ so must be supported by all third-party tooling.
 
 | Name              | Inputs       | Outputs       | Meaning                                                                                                                                                                                                            |
 |-------------------|--------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `print`           | `string`     | -             | Append the string to the program's output stream[^1] (atomically)                                                                                                                                                  |
+| `print`           | `string`     | -             | Append the string to the program's output stream[^1] (atomically).                                                                                                                                                 |
 | `new_array<N, T>` | `T` x N      | `array<N, T>` | Create an array from all the inputs.                                                                                                                                                                               |
 | `panic`           | `error`, ... | ...           | Immediately end execution and pass contents of error to context. Inputs following the `error`, and all outputs, are arbitrary; these only exist so that structural constraints such as linearity can be satisfied. |
 


### PR DESCRIPTION
- Removes the `catch` node reference (since it is only a prospective implementation reference and does not describe any current implemented concepts).
- Removes `ErrorType` as the spec prelude contains `error` (which is also contained in the real prelude as the typename) and thus replaces all usages with `error`.
- Cleans up related typos and punctuation.

Closes #2740