### PR TITLE
chore(CI): Skip slow miri tests

### DIFF
--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -50,6 +50,8 @@ jobs:
             --skip "extension::simple_op::test::check_ext_id_wellformed" \
             --skip "extension::test::test_register_update" \
             --skip "extension::type_def::test::test_instantiate_typedef" \
+            --skip "envelope::reader::test::test_decode_model_ast_with_packaged_extensions" \
+            --skip "envelope::reader::test::test_handle_resolution_error" \
             --skip "hugr::ident::test::proptest::arbitrary_identlist_valid" \
             --skip "hugr::ident::test::test_idents" \
             --skip "hugr::patch::inline_call::test::test_recursion" \


### PR DESCRIPTION
The two skipped tests were the cause of several recent unsoundness check failures due to timing out (ordered from most recent to least recent):

1. https://github.com/Quantinuum/hugr/actions/runs/20421597846/job/58674355306
2. https://github.com/Quantinuum/hugr/actions/runs/20220314698/job/58040970352
3. https://github.com/Quantinuum/hugr/actions/runs/19811142725/job/56753848194
4. https://github.com/Quantinuum/hugr/actions/runs/19623076094/job/56186949238

We decided (similar in spirit to earlier decisions with 50a2bacdcd8c296cc5385183fe49928a136eaf10 and 228ee585ac84c612a2fc416c4cd6d5d8a6163e36) to entirely skip them, since miri is expected to be several orders of magnitude slower than regular Rust execution. The change was tested locally.

Closes #2773
Closes #2758
Closes #2724
Closes #2706