### PR TITLE
fix(hugr-passes): Recursive replacement on NodeTemplate::LinkedHugr

### DIFF
--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -1564,22 +1564,7 @@ mod test {
             );
         }
         lw.run(&mut h).unwrap();
-        let r = h.validate();
-        if i64_to_usize {
-            // OOOPS - turns out that recursive replacement *IS* applied to the Call node (inserted entrypoint),
-            // but *NOT* to the linked functions that are also added outside the node-being-replaced.
-            match r {
-                Err(ValidationError::IncompatiblePorts {
-                    from_kind, to_kind, ..
-                }) => assert!(
-                    matches!(*from_kind, EdgeKind::Function(_))
-                        && matches!(*to_kind, EdgeKind::Function(_))
-                ),
-                _ => panic!(),
-            };
-        } else {
-            r.unwrap();
-        }
+        h.validate().unwrap();
 
         assert_eq!(
             h.entry_descendants()


### PR DESCRIPTION
Yet another problem from #2749.

LinkedHugr did not respect the "recursive replacement" option (on for all non-deprecated, set_replace_xxx, methods), where the replacement is processed by the same ReplaceTypes. Only the entrypoint-subtree of the inserted/linked-in hugr was recursively processed; other functions (outside the entrypoint, but pulled in with it) were not.