### PR TITLE
refactor(ReplaceTypes): [tiny] correct computation of containing_func

### DIFF
--- a/hugr-passes/src/replace_types.rs
+++ b/hugr-passes/src/replace_types.rs
@@ -181,7 +181,9 @@ impl NodeTemplate {
                 // before linking, as otherwise they'll signature conflict with other,
                 // already-recursively-processed, functions with which they might be linked.
                 let mut containing_func = h.entrypoint();
-                while let Some(parent) = h.get_parent(containing_func) {
+                while let Some(parent) = h.get_parent(containing_func)
+                    && !h.get_optype(parent).is_module()
+                {
                     containing_func = parent;
                 }
 


### PR DESCRIPTION
Guess I hit merge on #2800 slightly too soon, although in practice it makes no difference: the old code would have computed `containing_func` as being the module root, and so recursively processed ("replace_with_opts") the entrypoint-subtree twice (once before and once after insertion); however, the second would have done nothing. So perhaps this is a small performance optimization ;), but mostly for correctness-of-variable-name and readability!