### PR TITLE
ci: Print cargo target directory sizes

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -260,6 +260,7 @@ jobs:
         run: cargo minimal-versions --direct test -p hugr-llvm --verbose --features llvm${{ env.LLVM_FEATURE_NAME }}
       - name: List cargo `target` directory size after tests
         run: |
+          echo "Target directory size:"
           du -h -d3 target
 
   # Ensure that serialized extensions match rust implementation


### PR DESCRIPTION
Adds some debug information to track cargo's `target` directory size in some steps that were running out of disk space.

It seems that just disabling the cache reduces the `test-nightly` step from 12Gb to 9Gb, so I may do a cache purge.

[Some sources](https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow) recommend disabling incremental builds to reduce space, but that actually caused out-of-space errors in the normal jobs (like `test-stable-*`) that currently take 7Gb...

drive-by: Split and organize the `test-nightly` job, to better track the panics if they appear again.