### PR TITLE
feat: add to_qir functions

### DIFF
--- a/hugr-py/src/hugr/package.py
+++ b/hugr-py/src/hugr/package.py
@@ -108,6 +108,9 @@ class Package:
     def to_qir_str(self, *, validate_qir: bool = True) -> str:
         """Converts hugr package to qir str.
 
+        This functions requires hugr-qir to be installed.
+        It can be installed for example via `pip install hugr-qir`
+
         :param validate_qir: Whether to validate the created QIR
         :type validate_qir: bool
         :return: QIR corresponding to the HUGR input as str
@@ -132,6 +135,9 @@ class Package:
 
     def to_qir_bytes(self, *, validate_qir: bool = True) -> bytes:
         """Converts hugr package to qir bytes.
+
+        This functions requires hugr-qir to be installed.
+        It can be installed for example via `pip install hugr-qir`
 
         :param validate_qir: Whether to validate the created QIR
         :type validate_qir: bool


### PR DESCRIPTION
This PR adds `hugr.to_qir_bytes()` and `hugr.to_qir_str()`  methods for direct QIR conversion to the hugr package.

They will only work if hugr-qir is installed, for that reason I would suggest to not do any testing here and only test this in the hugr-qir repo. 

The other option would be to add hugr-qir as an optional dependency on hugr-py and always install it on the CI for testing.