### PR TITLE
feat: Add ptr extension and cleanup `hugr.std` module

### DIFF
--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -24,7 +24,7 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
 
     from hugr.hugr import Hugr
     from hugr.tys import ExtensionId
@@ -441,6 +441,11 @@ class ExtensionRegistry:
 
         extension_id: ExtensionId
 
+    @classmethod
+    def from_extensions(cls, extensions: Iterable[Extension]) -> ExtensionRegistry:
+        """Create an extension registry from a list of extensions."""
+        return cls(extensions={extension.name: extension for extension in extensions})
+
     def ids(self) -> set[ExtensionId]:
         """Get the set of extension IDs in the registry.
 
@@ -511,6 +516,9 @@ class ExtensionRegistry:
 
     def __str__(self) -> str:
         return "ExtensionRegistry(" + ", ".join(self.extensions.keys()) + ")"
+
+    def __contains__(self, name: ExtensionId) -> bool:
+        return name in self.extensions
 
 
 @dataclass

--- a/hugr-py/src/hugr/std/__init__.py
+++ b/hugr-py/src/hugr/std/__init__.py
@@ -1,16 +1,28 @@
 """Types and operations from the standard extension set."""
 
-import pkgutil
+from hugr.ext import Extension, ExtensionRegistry
 
-from hugr._serialization.extension import Extension as PdExtension
-from hugr.ext import Extension
+from . import collections, float, int, logic, prelude, ptr
 
+__all__ = ["PRELUDE", "collections", "float", "int", "logic", "prelude", "ptr"]
 
-def _load_extension(name: str) -> Extension:
-    replacement = name.replace(".", "/")
-    json_str = pkgutil.get_data(__name__, f"_json_defs/{replacement}.json")
-    assert json_str is not None
-    return PdExtension.model_validate_json(json_str).deserialize()
+PRELUDE: Extension = prelude.PRELUDE_EXTENSION
 
 
-PRELUDE = _load_extension("prelude")
+def _std_extensions() -> ExtensionRegistry:
+    return ExtensionRegistry.from_extensions(
+        [
+            PRELUDE,
+            int.CONVERSIONS_EXTENSION,
+            int.INT_TYPES_EXTENSION,
+            int.INT_OPS_EXTENSION,
+            float.FLOAT_OPS_EXTENSION,
+            float.FLOAT_TYPES_EXTENSION,
+            logic.EXTENSION,
+            ptr.EXTENSION,
+            collections.array.EXTENSION,
+            collections.borrow_array.EXTENSION,
+            collections.list.EXTENSION,
+            collections.static_array.EXTENSION,
+        ]
+    )

--- a/hugr-py/src/hugr/std/_util.py
+++ b/hugr-py/src/hugr/std/_util.py
@@ -1,0 +1,13 @@
+"""Extension loading utilities."""
+
+import pkgutil
+
+from hugr._serialization.extension import Extension as PdExtension
+from hugr.ext import Extension
+
+
+def _load_extension(name: str) -> Extension:
+    replacement = name.replace(".", "/")
+    json_str = pkgutil.get_data(__name__, f"_json_defs/{replacement}.json")
+    assert json_str is not None
+    return PdExtension.model_validate_json(json_str).deserialize()

--- a/hugr-py/src/hugr/std/collections/__init__.py
+++ b/hugr-py/src/hugr/std/collections/__init__.py
@@ -1,1 +1,5 @@
 """Standard extensions for collection types and operations."""
+
+from . import array, borrow_array, list, static_array
+
+__all__ = ["array", "borrow_array", "list", "static_array"]

--- a/hugr-py/src/hugr/std/collections/array.py
+++ b/hugr-py/src/hugr/std/collections/array.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 import hugr.model as model
 from hugr import tys, val
-from hugr.std import _load_extension
+from hugr.std._util import _load_extension
 from hugr.utils import comma_sep_str
 
 if TYPE_CHECKING:

--- a/hugr-py/src/hugr/std/collections/borrow_array.py
+++ b/hugr-py/src/hugr/std/collections/borrow_array.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, cast
 
 import hugr.model as model
 from hugr import tys, val
-from hugr.std import _load_extension
+from hugr.std._util import _load_extension
 from hugr.utils import comma_sep_str
 
 if TYPE_CHECKING:

--- a/hugr-py/src/hugr/std/collections/list.py
+++ b/hugr-py/src/hugr/std/collections/list.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import hugr.tys as tys
 from hugr import val
-from hugr.std import _load_extension
+from hugr.std._util import _load_extension
 from hugr.utils import comma_sep_str
 
 if TYPE_CHECKING:

--- a/hugr-py/src/hugr/std/collections/static_array.py
+++ b/hugr-py/src/hugr/std/collections/static_array.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from hugr import tys, val
-from hugr.std import _load_extension
+from hugr.std._util import _load_extension
 from hugr.utils import comma_sep_str
 
 if TYPE_CHECKING:

--- a/hugr-py/src/hugr/std/float.py
+++ b/hugr-py/src/hugr/std/float.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 
 import hugr.model as model
 from hugr import ext, val
-from hugr.std import _load_extension
+from hugr.std._util import _load_extension
 
 FLOAT_TYPES_EXTENSION = _load_extension("arithmetic.float.types")
 

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -10,7 +10,7 @@ from typing_extensions import Self
 import hugr.model as model
 from hugr import ext, tys, val
 from hugr.ops import AsExtOp, DataflowOp, ExtOp, RegisteredOp
-from hugr.std import _load_extension
+from hugr.std._util import _load_extension
 
 if TYPE_CHECKING:
     from hugr.ops import Command, ComWire

--- a/hugr-py/src/hugr/std/logic.py
+++ b/hugr-py/src/hugr/std/logic.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
 from hugr.ops import Command, DataflowOp, RegisteredOp
-from hugr.std import _load_extension
+from hugr.std._util import _load_extension
 
 if TYPE_CHECKING:
     from hugr import ext

--- a/hugr-py/src/hugr/std/prelude.py
+++ b/hugr-py/src/hugr/std/prelude.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from hugr import val
-from hugr.std import _load_extension
+from hugr.std._util import _load_extension
 
 PRELUDE_EXTENSION = _load_extension("prelude")
 

--- a/hugr-py/src/hugr/std/ptr.py
+++ b/hugr-py/src/hugr/std/ptr.py
@@ -1,0 +1,51 @@
+"""HUGR pointer operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from hugr import tys
+from hugr.std._util import _load_extension
+
+if TYPE_CHECKING:
+    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
+
+EXTENSION = _load_extension("ptr")
+
+PTR_T_DEF = EXTENSION.types["ptr"]
+
+
+@dataclass(eq=False)
+class Ptr(tys.ExtType):
+    """Pointer type with a fixed element type."""
+
+    def __init__(self, ty: tys.Type) -> None:
+        ty_arg = tys.TypeTypeArg(ty)
+
+        self.type_def = EXTENSION.types["ptr"]
+        self.args = [ty_arg]
+
+    @property
+    def ty(self) -> tys.Type:
+        """Returns the type of the pointer."""
+        assert isinstance(
+            self.args[0], tys.TypeTypeArg
+        ), "Pointer elements must have a valid type"
+        return self.args[0].ty
+
+    def _resolve_used_extensions(
+        self, registry: ExtensionRegistry | None = None
+    ) -> tuple[Ptr, ExtensionResolutionResult]:
+        ext_type, result = super()._resolve_used_extensions(registry)
+
+        assert isinstance(
+            ext_type, tys.ExtType
+        ), "HUGR internal error, expected resolved type to be extension type."
+        assert (
+            ext_type.type_def == EXTENSION.types["ptr"]
+        ), "HUGR internal error, expected resolved type to be pointer."
+
+        ptr = Ptr(tys.Unit)
+        ptr.args = ext_type.args
+        return ptr, result


### PR DESCRIPTION
Adds the missing `ptr` extension to `hugr.std`, cleanups the exports, and some other drive-bys:

- Adds a `ExtensionRegistry.from_extensions(Iterable[Extension]) -> Self` helper and `__contains__` method.
- Adds a `std._std_extensions` method listing all extensions. We'll use this for #2841.
- Moves the extension loader utility method to `hugr.std._util`, so we can list the extension submodules in `__all__`, making them easier to access.