### PR TITLE
feat: Auto-embed extensions in stored hugrs

### DIFF
--- a/hugr-py/src/hugr/envelope.py
+++ b/hugr-py/src/hugr/envelope.py
@@ -38,6 +38,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, ClassVar
 
 import pyzstd
+from typing_extensions import deprecated
 
 import hugr._hugr.model as rust
 
@@ -55,7 +56,17 @@ _DEFAULT_FLAGS = 0b0100_0000
 _ZSTD_FLAG = 0b0000_0001
 
 
-def make_envelope(package: Package, config: EnvelopeConfig) -> bytes:
+@deprecated("Use Package/Hugr.to_bytes() instead.")
+def make_envelope(package: Package | Hugr, config: EnvelopeConfig) -> bytes:
+    """Encode a Package into an envelope, using the given configuration."""
+    from hugr.hugr.base import Hugr
+
+    if isinstance(package, Hugr):
+        package = package.to_package()
+    return _make_envelope(package, config)
+
+
+def _make_envelope(package: Package, config: EnvelopeConfig) -> bytes:
     """Encode a Package into an envelope, using the given configuration."""
     envelope = bytearray(config._make_header().to_bytes())
 
@@ -85,7 +96,17 @@ def make_envelope(package: Package, config: EnvelopeConfig) -> bytes:
     return bytes(envelope)
 
 
-def make_envelope_str(package: Package, config: EnvelopeConfig) -> str:
+@deprecated("Use Package/Hugr.to_str() instead.")
+def make_envelope_str(package: Package | Hugr, config: EnvelopeConfig) -> str:
+    """Encode a Package into an envelope, using the given configuration."""
+    from hugr.hugr.base import Hugr
+
+    if isinstance(package, Hugr):
+        package = package.to_package()
+    return _make_envelope_str(package, config)
+
+
+def _make_envelope_str(package: Package, config: EnvelopeConfig) -> str:
     """Encode a Package into an envelope, using the given configuration."""
     if not config.format.ascii_printable():
         msg = "Only ascii-printable envelope formats can be encoded into a string."

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -23,8 +23,8 @@ from hugr._serialization.ops import OpType as SerialOp
 from hugr._serialization.serial_hugr import SerialHugr
 from hugr.envelope import (
     EnvelopeConfig,
-    make_envelope,
-    make_envelope_str,
+    _make_envelope,
+    _make_envelope_str,
     read_envelope_hugr,
     read_envelope_hugr_str,
 )
@@ -1150,7 +1150,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
                 Standard extensions are ignored.
         """
         config = config or EnvelopeConfig.BINARY
-        return make_envelope(self.to_package(include_extensions), config)
+        return _make_envelope(self.to_package(include_extensions), config)
 
     def to_str(
         self,
@@ -1171,7 +1171,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
                 Standard extensions are ignored.
         """
         config = config or EnvelopeConfig.TEXT
-        return make_envelope_str(self.to_package(include_extensions), config)
+        return _make_envelope_str(self.to_package(include_extensions), config)
 
     @deprecated("Use HUGR envelopes instead. See the `to_bytes` and `to_str` methods.")
     def to_json(self) -> str:

--- a/hugr-py/src/hugr/package.py
+++ b/hugr-py/src/hugr/package.py
@@ -11,8 +11,8 @@ import hugr._serialization.extension as ext_s
 import hugr.model as model
 from hugr.envelope import (
     EnvelopeConfig,
-    make_envelope,
-    make_envelope_str,
+    _make_envelope,
+    _make_envelope_str,
     read_envelope,
     read_envelope_str,
 )
@@ -110,7 +110,7 @@ class Package:
         Some envelope formats can be encoded into a string. See :meth:`to_str`.
         """
         config = config or EnvelopeConfig.BINARY
-        return make_envelope(self, config)
+        return _make_envelope(self, config)
 
     def to_str(self, config: EnvelopeConfig | None = None) -> str:
         """Serialize the package to a HUGR envelope string.
@@ -119,7 +119,7 @@ class Package:
         See :meth:`to_bytes` for a more general method.
         """
         config = config or EnvelopeConfig.TEXT
-        return make_envelope_str(self, config)
+        return _make_envelope_str(self, config)
 
     @deprecated("Use HUGR envelopes instead. See the `to_bytes` and `to_str` methods.")
     def to_json(self) -> str:


### PR DESCRIPTION
Closes #2841. See that issue for more details.

- Adds `include_extensions` parameters to `Hugr.to_bytes` and `to_str`.
- Adds a `to_package(self, include_extensions: ExtensionRegistry | None = None) -> Package` method to Hugr.

When the registry is `None` for any of those, we compute them using `Hugr.used_extensions`.