### PR TITLE
chore: Update label names in configs

### DIFF
--- a/.github/actions/check-changes/action.yml
+++ b/.github/actions/check-changes/action.yml
@@ -46,7 +46,7 @@ runs:
           echo "out=true" >> $GITHUB_OUTPUT
         fi
       env:
-        OVERRIDE_LABEL: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'run-ci-checks') }}
+        OVERRIDE_LABEL: ${{ github.event_name == 'pull_request' && contains( github.event.pull_request.labels.*.name, 'X-run-thorough-ci-tests') }}
         DEFAULT_BRANCH: ${{ github.ref_name == github.event.repository.default_branch }}
     - if: steps.override.outputs.out != 'true'
       uses: dorny/paths-filter@v3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
     ignore:
       - dependency-name: "smol_str:*"
         versions: [">=0.3.4"] # Requires rustc 1.89
+    labels:
+      - "X-dependabot"
+      - "C-dependencies"
+      - "A-rust"
 
   - package-ecosystem: "uv"
     directories: # Location of package manifests
@@ -43,6 +47,9 @@ updates:
       minor:
         update-types: ["minor"]
       # Major updates still generate individual PRs
+    labels:
+      - "X-dependabot"
+      - "A-python"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -54,3 +61,6 @@ updates:
     commit-message:
       # Use a conventional commit tag
       prefix: "ci(deps)"
+    labels:
+      - "X-dependabot"
+      - "A-ci"

--- a/.github/workflows/unsoundness.yml
+++ b/.github/workflows/unsoundness.yml
@@ -96,5 +96,5 @@ jobs:
         The unsoundness check for `quantinuum/hugr` failed.
 
         [Please investigate](https://github.com/quantinuum/hugr/actions/runs/${{ github.run_id }}).
-      unique-label: "unsoundness-checks"
-      other-labels: "bug"
+      unique-label: "X-unsoundness-checks"
+      other-labels: "C-bugfix, A-rust"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -92,7 +92,7 @@ Run `just` to see all available commands.
 
 Any breaking change in the public Rust APIs will cause the next release to be a
 major version bump. You can check the next release version [draft release
-PR](https://github.com/quantinuum/hugr/pulls?q=is%3Aopen+is%3Apr+label%3Arelease) on
+PR](https://github.com/quantinuum/hugr/pulls?q=is%3Aopen+is%3Apr+label%3AX-release) on
 github.
 
 Use `cargo semver-checks` to alert you of any problematic changes.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "initial-version": "0.0.0",
-    "extra-label": "release",
+    "extra-label": "X-release",
     "packages": {
         "hugr-py": {
             "release-type": "python",

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,7 +12,7 @@ pr_draft = true
 git_tag_name = "{{ package }}-v{{ version }}"
 git_release_name = "{{ package }}: v{{ version }}"
 git_release_latest = false
-pr_labels = ["release"]
+pr_labels = ["X-release", "A-rust"]
 
 # Only create releases / push to crates.io after merging a release-please PR.
 # This lets merge new crates to `main` without worrying about accidentally creating


### PR DESCRIPTION
I organized the [project labels](https://github.com/Quantinuum/hugr/labels) for the new project flow.

This PR updates the internal configs that referenced the old labels.