### PR TITLE
chore: Fix issue template emoji and unused dependabot label

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,4 +1,4 @@
-name: "� Feature Request"
+name: "💡 Feature Request"
 description: Suggest a new feature or enhancement
 title: "[Feature]: "
 labels: ["C-feature-request", "S-needs-triage"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,6 @@ updates:
         versions: [">=0.3.4"] # Requires rustc 1.89
     labels:
       - "X-dependabot"
-      - "C-dependencies"
       - "A-rust"
 
   - package-ecosystem: "uv"


### PR DESCRIPTION
- The _Feature Request_ issue used an unsupported emoji
- The dependabot config had an non-existing label in the config. This was just ignored.