### PR TITLE
feat(hugr-py): Allow providing visibility when building function definitions

### DIFF
--- a/hugr-py/src/hugr/build/function.py
+++ b/hugr-py/src/hugr/build/function.py
@@ -72,7 +72,6 @@ class Module(DefinitionBuilder[ops.Module]):
         Args:
             name: The name of the function.
             signature: The (polymorphic) signature of the function.
-            visibility: The visibility of the function.
 
         Returns:
             The node representing the function declaration.


### PR DESCRIPTION
Allows providing a visibility when constructing function definitions, for purposes of allowing annotation of these in `guppylang`.

Related to https://github.com/Quantinuum/guppylang/issues/1482.