### PR TITLE
fix: Missing token when uploading wheels to release assets

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -309,5 +309,7 @@ jobs:
           # Pypi doesn't support wasm wheels, so we skip them here.
           args: --non-interactive --skip-existing wheels-linux-*/* wheels-musllinux-*/* wheels-windows-*/* wheels-macos-*/* wheels-sdist/*
       - name: Upload wheels to the release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          gh release upload ${{ github.ref }} wheels-*/*
+          gh release upload ${{ github.ref_name }} wheels-*/*


### PR DESCRIPTION
This failed for the last release
https://github.com/Quantinuum/hugr/actions/runs/21757230379/job/62773390844#step:5:13

Also changes `github.ref` to `github.ref_name`, since `gh release upload` expects just the tag name without a `refs/tags/` prefix.