### PR TITLE
ci: Fix missing repo when uploading release assets

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -295,6 +295,7 @@ jobs:
       # Used to generate artifact attestation
       attestations: write
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3


### PR DESCRIPTION
Another missing config when attaching wheels to the release assets 

Fixes: https://github.com/Quantinuum/hugr/actions/runs/21824034782/job/62965967967#step:5:14