### PR TITLE
feat: Add error context when lowering hugrs to LLVM

### DIFF
--- a/hugr-llvm/src/emit.rs
+++ b/hugr-llvm/src/emit.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use delegate::delegate;
 use hugr_core::{
     HugrView, Node, Visibility,
@@ -301,7 +301,12 @@ impl<'c, 'a, H: HugrView<Node = Node>> EmitHugr<'c, 'a, H> {
                     node.hugr().get_optype(next_node)
                 )
             };
-            let (new_self, new_tasks) = self.emit_func_impl(func)?;
+            let (new_self, new_tasks) = self.emit_func_impl(func).with_context(|| {
+                format!(
+                    "Failed to emit LLVM for function {} at node {next_node}",
+                    func.func_name()
+                )
+            })?;
             self = new_self;
             worklist.extend(new_tasks.into_iter());
         }

--- a/hugr-llvm/src/emit/ops.rs
+++ b/hugr-llvm/src/emit/ops.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use hugr_core::Node;
 use hugr_core::hugr::internal::PortgraphNodeMap;
 use hugr_core::ops::{
@@ -385,6 +385,12 @@ fn emit_optype<'c, H: HugrView<Node = Node>>(
         OpType::TailLoop(x) => emit_tail_loop(context, args.into_ot(x)),
         _ => Err(anyhow!("Invalid child for Dataflow Parent: {node}")),
     }
+    .with_context(|| {
+        format!(
+            "Failed to emit LLVM for node {node} with optype {}",
+            node.as_ref()
+        )
+    })
 }
 
 /// Emit a custom operation with a single input.


### PR DESCRIPTION
Because 
```
thread 'emit::test::test_fns::tail_loop_exec::case_1' (101506913) panicked at hugr-llvm/src/test.rs:173:92:
called `Result::unwrap()` on an `Err` value: Unknown type: int(6)
```
is a useless error when it happens deeply nested inside some other workflow.

This PR adds some anyhow contexts, so the error now shows
```
thread 'emit::test::test_fns::tail_loop_exec::case_1' (101503258) panicked at hugr-llvm/src/test.rs:173:92:
called `Result::unwrap()` on an `Err` value: Failed to emit LLVM for function 'main' at node Node(1)

Caused by:
    No mapping found for type: int(6)
```

See https://github.com/Quantinuum/hugr-qir/issues/218 for an example happening in the wild.