### PR TITLE
feat: Add a `NodeTemplate::call_to_function` helper

### DIFF
--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -160,7 +160,6 @@ pub enum BuildError {
     BasicBlockTooComplex,
     /// Node was expected to have a certain type but was found to not.
     #[error("Node with index {node} does not have type {op_desc} as expected.")]
-    #[allow(missing_docs)]
     UnexpectedType {
         /// Index of node where error occurred.
         node: Node,


### PR DESCRIPTION
A helper to create a node template with a call node to some user-defined function.

See https://github.com/Quantinuum/tket2/pull/1341 for a usecase.