### PR TITLE
ci: Mark python releases as `draft` while the wheels are being built

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -10,11 +10,18 @@ name: Python wheels 🐍
 
 on:
   push:
+    # Run when a release tag is created,
+    # and push the wheels to pypi
+    tags:
+      - "hugr-py-v**"
+    # Run the build process on pushes to main,
+    # skip the publish step
     branches:
       - main
-  release:
-    types:
-      - published
+  # Allow manual runs
+  #
+  # If the target is a release tag,
+  # publish the wheels to pypi
   workflow_dispatch:
 
 permissions:
@@ -43,7 +50,7 @@ jobs:
         run: |
           echo "run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         env:
-          SHOULD_RUN: ${{ github.event_name != 'release' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/hugr-py-v') ) }}
+          SHOULD_RUN: ${{ github.ref_type != 'tag' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/hugr-py-v') ) }}
 
   linux:
     needs: check-tag
@@ -286,7 +293,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [linux, musllinux, windows, macos, sdist, wasm]
-    if: ${{ (github.event_name == 'release' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/hugr-py-v') ) || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/hugr-py-v') ) }}
+    if: ${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/hugr-py-v') }}
     permissions:
       # Use to sign the release artifacts
       id-token: write
@@ -296,6 +303,14 @@ jobs:
       attestations: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Check if the tag has an associated release
+        run: |
+          gh release view ${{ github.ref_name }}
+          if [ $? -ne 0 ]; then
+            echo "No release found for tag ${{ github.ref_name }}"
+            exit 1
+          fi
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v3
@@ -309,8 +324,11 @@ jobs:
           command: upload
           # Pypi doesn't support wasm wheels, so we skip them here.
           args: --non-interactive --skip-existing wheels-linux-*/* wheels-musllinux-*/* wheels-windows-*/* wheels-macos-*/* wheels-sdist/*
-      - name: Upload wheels to the release assets
+      - name: Upload wheels to the release and un-draft it
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Upload wheels to the release assets
           gh release upload ${{ github.ref_name }} wheels-*/*
+          # Un-draft the release on GitHub now that the package has been published to PyPI
+          gh release edit ${{ github.ref_name }} --draft=false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
             "component": "hugr-py",
             "package-name": "hugr",
             "include-component-in-tag": true,
-            "draft": false,
+            "draft": true,
             "prerelease": false,
             "draft-pull-request": true,
             "extra-files": [


### PR DESCRIPTION
It normally takes ~20 minutes to build all the python wheels.

It may be confusing seeing a new `hugr-py` release in github while the package is still not available in pypi.

This will also help avoiding faulty releases once we start using github's [new immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).
An error in the wheel building process would abort the workflow, allowing us to delete and fix the draft release before it's inscribed in stone.

I had to change the trigger for the wheel-building workflow from `release: published` to `push: tags`, since apparently draft releases do not trigger workflows (https://github.com/orgs/community/discussions/7118) 🫠 