### PR TITLE
docs: Split specification into files

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,5 +10,5 @@ contact_links:
     url: https://quantinuum.github.io/hugr/
     about: Read the API documentation for the Python library
   - name: 📖 Specification
-    url: https://github.com/Quantinuum/hugr/blob/main/specification/index.md
+    url: https://github.com/Quantinuum/hugr/blob/main/specification/hugr.md
     about: Read the HUGR specification

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -32,7 +32,7 @@ body:
       description: Where is the documentation issue?
       placeholder: |
         - URL: https://...
-        - File: docs/spec/index.md
+        - File: docs/spec/hugr.md
         - API docs for: hugr::ops::OpType
 
   - type: textarea

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ title: "HUGR: A Quantum-Classical Intermediate Representation"
 message: >-
   HUGR can be cited as below. For an up-to-date definition
   of the specification, see the [HUGR
-  specification](https://github.com/quantinuum/hugr/blob/main/specification/index.md)
+  specification](https://github.com/quantinuum/hugr/blob/main/specification/hugr.md)
 keywords:
   - quantum computing
   - compilers

--- a/hugr-core/src/extension/declarative.rs
+++ b/hugr-core/src/extension/declarative.rs
@@ -21,7 +21,7 @@
 //! load_extensions(DECLARATIVE_YAML, &mut reg).unwrap();
 //! ```
 //!
-//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/index.md#declarative-format
+//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 
 mod ops;
 mod signature;

--- a/hugr-core/src/extension/declarative/ops.rs
+++ b/hugr-core/src/extension/declarative/ops.rs
@@ -4,7 +4,7 @@
 //!
 //! See the [specification] and [`ExtensionSetDeclaration`] for more details.
 //!
-//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/index.md#declarative-format
+//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 //! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
 
 use std::collections::HashMap;

--- a/hugr-core/src/extension/declarative/signature.rs
+++ b/hugr-core/src/extension/declarative/signature.rs
@@ -4,7 +4,7 @@
 //!
 //! See the [specification] and [`ExtensionSetDeclaration`] for more details.
 //!
-//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/index.md#declarative-format
+//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 //! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
 
 use itertools::Itertools;

--- a/hugr-core/src/extension/declarative/types.rs
+++ b/hugr-core/src/extension/declarative/types.rs
@@ -4,7 +4,7 @@
 //!
 //! See the [specification] and [`ExtensionSetDeclaration`] for more details.
 //!
-//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/index.md#declarative-format
+//! [specification]: https://github.com/CQCL/hugr/blob/main/specification/hugr.md#declarative-format
 //! [`ExtensionSetDeclaration`]: super::ExtensionSetDeclaration
 
 use std::sync::Weak;

--- a/hugr-passes/README.md
+++ b/hugr-passes/README.md
@@ -14,7 +14,7 @@ ecosystem.
 It provides a high-fidelity representation of operations, that facilitates
 compilation and encodes runnable programs.
 
-The HUGR specification is [here](https://github.com/quantinuum/hugr/blob/main/specification/index.md).
+The HUGR specification is [here](https://github.com/quantinuum/hugr/blob/main/specification/hugr.md).
 
 This crate provides compilation passes that act on HUGR programs.
 

--- a/hugr-persistent/README.md
+++ b/hugr-persistent/README.md
@@ -14,7 +14,7 @@ ecosystem.
 It provides a high-fidelity representation of operations, that facilitates
 compilation and encodes runnable programs.
 
-The HUGR specification is [here](https://github.com/quantinuum/hugr/blob/main/specification/index.md).
+The HUGR specification is [here](https://github.com/quantinuum/hugr/blob/main/specification/hugr.md).
 
 ## Overview
 

--- a/hugr-py/README.md
+++ b/hugr-py/README.md
@@ -16,7 +16,7 @@ The API documentation for this package is [here](https://quantinuum.github.io/hu
 This library is intended to be used as a dependency for other high-level tools.
 See [`guppylang`][] and [`tket2`][] for examples of such tools.
 
-The HUGR specification is [here](https://github.com/quantinuum/hugr/blob/main/specification/index.md).
+The HUGR specification is [here](https://github.com/quantinuum/hugr/blob/main/specification/hugr.md).
 
   [`guppylang`]: https://pypi.org/project/guppylang/
   [`tket2`]: https://github.com/quantinuum/tket2

--- a/hugr-py/docs/api-docs/index.rst
+++ b/hugr-py/docs/api-docs/index.rst
@@ -14,7 +14,7 @@ This is the API documentation for the HUGR Python package.
 .. toctree::
 
    Github <https://github.com/quantinuum/hugr>
-   HUGR Specification <https://github.com/quantinuum/hugr/blob/main/specification/index.md>
+   HUGR Specification <https://github.com/quantinuum/hugr/blob/main/specification/hugr.md>
    pypi <https://pypi.org/project/hugr/>
 
 

--- a/hugr/README.md
+++ b/hugr/README.md
@@ -14,7 +14,7 @@ ecosystem.
 It provides a high-fidelity representation of operations, that facilitates
 compilation and encodes runnable programs.
 
-The HUGR specification is [here](https://github.com/quantinuum/hugr/blob/main/specification/index.md).
+The HUGR specification is [here](https://github.com/quantinuum/hugr/blob/main/specification/hugr.md).
 
 ## Usage
 

--- a/hugr/src/lib.rs
+++ b/hugr/src/lib.rs
@@ -10,7 +10,7 @@
 //! that is not a direct descendent (subject to causality constraints).
 //!
 //! The specification can be found
-//! [here](https://github.com/CQCL/hugr/blob/main/specification/index.md).
+//! [here](https://github.com/CQCL/hugr/blob/main/specification/hugr.md).
 //!
 //! This crate provides a Rust implementation of HUGR and the standard extensions defined in the
 //! specification.


### PR DESCRIPTION
Closes #2896 

Splits `hugr.md` into smaller topical files, to help ease of reading.

`index.md` is the new landing file, containing the motivation and a ToC (#2893).
No content has been modified, asides from section titles and some normalization of header levels.

From here it shouldn't take too much work to include these files in the sphinx-generated docs website: https://quantinuum.github.io/hugr/, so I try adding back-links to the index file here.