### PR TITLE
ci: Use actions/attest instead of actions/attest-build-provenance and update to v4.

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -313,7 +313,7 @@ jobs:
           fi
       - uses: actions/download-artifact@v7
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest@v4
         with:
           subject-path: "wheels-*/*"
       - name: Publish to PyPI


### PR DESCRIPTION
See https://github.com/actions/attest-build-provenance/releases/tag/v4.0.0 .