### PR TITLE
feat: Add non-generic `with_scope` method for composable passes

### DIFF
--- a/hugr-passes/src/composable.rs
+++ b/hugr-passes/src/composable.rs
@@ -18,7 +18,7 @@ use itertools::Either;
 /// idempotent (i.e. such that after running a pass, rerunning it immediately has
 /// no further effect). However this is *not* a requirement, e.g. a sequence of
 /// idempotent passes created by [ComposablePass::then] may not be idempotent itself.
-pub trait ComposablePass<H: HugrMut = Hugr>: Sized {
+pub trait ComposablePass<H: HugrMut>: Sized {
     /// Error thrown by this pass.
     type Error: Error;
     /// Result returned by this pass.


### PR DESCRIPTION
Adds a non-generic extension trait for `ComposablePass` so we can call `with_scope` without having to specify the hugr generic being used.

Renames `ComposablePass::with_scope` to `ComposablePass::with_scope_internal`. This is **not** a breaking change, since the method has not been published yet.