### PR TITLE
chore: Ignore new clippy warning on rust 1.94

### DIFF
--- a/hugr-core/src/hugr/serialize.rs
+++ b/hugr-core/src/hugr/serialize.rs
@@ -285,7 +285,8 @@ impl TryFrom<SerHugrLatest> for Hugr {
             }
         }
 
-        #[expect(clippy::result_large_err)]
+        // TODO: Change to `expect` if updating the MSRV above 1.94
+        #[allow(clippy::result_large_err)]
         let unwrap_offset = |node: Node, offset, dir, hugr: &Hugr| -> Result<usize, Self::Error> {
             if !hugr.graph.contains_node(node.into_portgraph()) {
                 return Err(HUGRSerializationError::UnknownEdgeNode { node });


### PR DESCRIPTION
```bash
error: the `Err`-variant returned from this closure is very large
   --> hugr-core/src/hugr/serialize.rs:288:71
    |
123 | /     MissingPortOffset {
124 | |         /// The node that has the port without offset.
125 | |         node: Node,
126 | |         /// The direction of the port without an offset
...   |
129 | |         op_type: OpType,
130 | |     },
    | |_____- the largest variant contains at least 157 bytes
...
288 |           let unwrap_offset = |node: Node, offset, dir, hugr: &Hugr| -> Result<usize, Self::Error> {
    |                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

The proper fix for this (boxing the `Optype` or changing it to a string) is a breaking change. See #2912.