### PR TITLE
fix(py): Load and resolve lower_funcs in extensions

### DIFF
--- a/hugr-py/src/hugr/_serialization/extension.py
+++ b/hugr-py/src/hugr/_serialization/extension.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import pydantic as pd
@@ -77,15 +78,10 @@ class FixedHugr(ConfiguredBaseModel):
     hugr: str
 
     def deserialize(self) -> ext.FixedHugr:
-        # Loading fixed HUGRs requires reading hugr-model envelopes,
-        # which is not currently supported in Python.
-        # TODO: Add support for loading fixed HUGRs in Python.
-        # https://github.com/CQCL/hugr/issues/2287
-        msg = (
-            "Loading extensions with operation lowering functions is not "
-            + "supported in Python"
+        return ext.FixedHugr(
+            extensions=self.extensions,
+            hugr=Hugr.from_bytes(base64.b64decode(self.hugr)),
         )
-        raise NotImplementedError(msg)
 
 
 class OpDef(ConfiguredBaseModel, populate_by_name=True):
@@ -105,13 +101,7 @@ class OpDef(ConfiguredBaseModel, populate_by_name=True):
             self.binary,
         )
 
-        # Loading fixed HUGRs requires reading hugr-model envelopes,
-        # which is not currently supported in Python.
-        # We currently ignore any lower functions instead of raising an error.
-        #
-        # TODO: Add support for loading fixed HUGRs in Python.
-        # https://github.com/CQCL/hugr/issues/2287
-        lower_funcs: list[ext.FixedHugr] = []
+        lower_funcs: list[ext.FixedHugr] = [f.deserialize() for f in self.lower_funcs]
 
         return extension.add_op_def(
             ext.OpDef(

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -351,6 +351,10 @@ class Extension:
             _, sig_result = poly_func._resolve_used_extensions(registry)
             result.extend(sig_result)
 
+            for lower_func in op_def.lower_funcs:
+                lower_result = lower_func.hugr.used_extensions(registry)
+                result.extend(lower_result)
+
         return result
 
     @dataclass

--- a/hugr-py/src/hugr/package.py
+++ b/hugr-py/src/hugr/package.py
@@ -9,6 +9,7 @@ from typing_extensions import deprecated
 
 import hugr._serialization.extension as ext_s
 import hugr.model as model
+from hugr import ext
 from hugr.envelope import (
     EnvelopeConfig,
     _make_envelope,
@@ -71,9 +72,7 @@ class Package:
         """
         package = read_envelope(envelope)
         if extensions is not None:
-            # TODO: This can be done during deserialization
-            for module in package.modules:
-                module.resolve_extensions(extensions)
+            package.used_extensions(extensions)
         return package
 
     @staticmethod
@@ -93,9 +92,7 @@ class Package:
         """
         package = read_envelope_str(envelope)
         if extensions is not None:
-            # TODO: This can be done during deserialization
-            for module in package.modules:
-                module.resolve_extensions(extensions)
+            package.used_extensions(extensions)
         return package
 
     @staticmethod
@@ -147,6 +144,49 @@ class Package:
         At the moment this does not yet contain the extensions.
         """
         return model.Package([module.to_model() for module in self.modules])
+
+    def used_extensions(
+        self, resolve_from: ext.ExtensionRegistry | None = None
+    ) -> ext.ExtensionResolutionResult:
+        """Get the extensions used by this Package, optionally resolving unresolved
+        types and operations.
+
+        This method modifies the HUGR modules and packaged extensions in-place when
+        resolve_from is provided, replacing Custom operations with ExtOp operations and
+        opaque types with ExtType when their extensions are found in the registry.
+
+        Args:
+            resolve_from: Optional extension registry to resolve against.
+                If None, opaque types and Custom ops will not be resolved.
+
+        Returns:
+            The result of resolving the extensions, containing the used
+            extensions and a list of referenced but unresolved extensions.
+
+        Example:
+            >>> from hugr.build import Dfg
+            >>> Dfg(tys.Qubit).hugr.used_extensions().ids()
+            {'prelude'}
+        """
+        from hugr.ext import ExtensionResolutionResult
+
+        packaged_extensions = ext.ExtensionRegistry.from_extensions(self.extensions)
+
+        if resolve_from is None:
+            resolve_from = ext.ExtensionRegistry()
+        resolve_from.extend(packaged_extensions)
+
+        # Packaged extensions are always marked as "used".
+        result = ExtensionResolutionResult(
+            used_extensions=packaged_extensions,
+        )
+
+        for module in self.modules:
+            result.extend(module.used_extensions(resolve_from))
+
+        result._extend_with_transitive_ops(resolve_from)
+
+        return result
 
 
 @dataclass(frozen=True)

--- a/hugr-py/tests/test_used_extensions.py
+++ b/hugr-py/tests/test_used_extensions.py
@@ -1,6 +1,7 @@
 # ruff: noqa: I001
 
 import hugr
+from hugr.package import Package
 import hugr.ops as ops
 import hugr.tys as tys
 from hugr import ext, val
@@ -343,3 +344,60 @@ def test_hugr_with_opaque_type_resolve() -> None:
     test_ext_registry.add_extension(TEST_EXT)
     exts = h.hugr.used_extensions(resolve_from=test_ext_registry)
     assert TEST_EXT.name in exts.used_extensions.ids()
+
+
+def test_lower_funcs_resolve() -> None:
+    """Test that extensions in `OpDef.lower_func`s are resolved correctly."""
+    # A custom extension used by inside lower function.
+    inner_op_def = ext.OpDef(
+        name="InnerOp",
+        description="inner custom op",
+        signature=ext.OpDefSig(tys.FunctionType.endo([tys.Bool])),
+    )
+    inner_ext = ext.Extension(
+        version=ext.Version(0, 1, 0),
+        name="inner",
+        types={},
+    )
+    inner_ext.add_op_def(inner_op_def)
+
+    # Build a simple identity HUGR to use as a lowering implementation.
+    dfg = Dfg(tys.Bool)
+    [b] = dfg.inputs()
+    b = dfg.add_op(inner_ext.get_op("InnerOp").instantiate(args=[]), b).out(0)
+    dfg.set_outputs(b)
+    lower_hugr = dfg.hugr
+
+    # Wrap it in a FixedHugr lower function.
+    fixed_hugr = ext.FixedHugr(extensions=[inner_ext.name], hugr=lower_hugr)
+
+    # Build an extension whose op carries the lower_func.
+    outer_op_def = ext.OpDef(
+        name="OuterOp",
+        description="outer op with lowering",
+        signature=ext.OpDefSig(tys.FunctionType.endo([tys.Bool])),
+        lower_funcs=[fixed_hugr],
+    )
+    outer_ext = ext.Extension(
+        version=ext.Version(0, 1, 0),
+        name="outer",
+        types={},
+    )
+    outer_ext.add_op_def(outer_op_def)
+
+    # Include the extension in a package and check that the lower func is resolved.
+    package = Package(
+        modules=[],
+        extensions=[outer_ext],
+    )
+    used_exts = package.used_extensions()
+    assert outer_ext.name in used_exts.used_extensions
+    assert inner_ext.name in used_exts.used_extensions
+
+    bytes = package.to_bytes()
+    package = Package.from_bytes(bytes, extensions=used_exts.used_extensions)
+    assert len(package.extensions[0].operations["OuterOp"].lower_funcs) == 1
+
+    used_exts = package.used_extensions()
+    assert outer_ext.name in used_exts.used_extensions.ids()
+    assert inner_ext.name in used_exts.used_extensions.ids()


### PR DESCRIPTION
`hugr-py` was dropping lower_funcs in the operation definitions when loading an envelope.

This was a limitation of not having model envelope loaders, but that has been fixed in #2287.

I originally started looking at this thinking it was related to #2520, but it seems unrelated.