### PR TITLE
feat!: Rename ModelText envelope format to SExpression

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -37,7 +37,7 @@ ot = "ot"
 inports = "inports" # not import
 inport = "inport"
 bimap = "bimap"     # bi-directional map
-edn = "edn"         # hugr model text file format
+edn = "edn"         # hugr S-expression file format
 
 tru = "tru"   # not clashing with keyword true
 fals = "fals" # not clashing with keyword false

--- a/hugr-cli/src/convert.rs
+++ b/hugr-cli/src/convert.rs
@@ -75,9 +75,9 @@ impl ConvertArgs {
                     "json" => EnvelopeFormat::PackageJson,
                     "model" => EnvelopeFormat::Model,
                     "model-exts" => EnvelopeFormat::ModelWithExtensions,
-                    "model-text" | "s-expression" => EnvelopeFormat::ModelText,
+                    "model-text" | "s-expression" => EnvelopeFormat::SExpression,
                     "model-text-exts" | "s-expression-exts" => {
-                        EnvelopeFormat::ModelTextWithExtensions
+                        EnvelopeFormat::SExpressionWithExtensions
                     }
                     _ => Err(CliError::InvalidFormat(fmt.clone()))?,
                 },

--- a/hugr-cli/tests/convert.rs
+++ b/hugr-cli/tests/convert.rs
@@ -180,7 +180,7 @@ fn test_convert_model_text_format(test_envelope_file: NamedTempFile, mut convert
     let config = desc.header.config();
 
     // Verify the format is correct
-    assert_eq!(config.format, EnvelopeFormat::ModelText);
+    assert_eq!(config.format, EnvelopeFormat::SExpression);
 }
 
 #[rstest]
@@ -311,5 +311,5 @@ fn test_convert_programmatic_model_text(test_package: Package) {
     let registry = ExtensionRegistry::default();
     let (desc, _) = read_envelope(reader, &registry).expect("Failed to read output envelope");
 
-    assert_eq!(desc.header.config().format, EnvelopeFormat::ModelText);
+    assert_eq!(desc.header.config().format, EnvelopeFormat::SExpression);
 }

--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -358,18 +358,18 @@ pub(crate) mod test {
     // Empty packages
     #[case::empty_model(Package::default(), EnvelopeFormat::Model)]
     #[case::empty_model_exts(Package::default(), EnvelopeFormat::ModelWithExtensions)]
-    #[case::empty_text(Package::default(), EnvelopeFormat::ModelText)]
-    #[case::empty_text_exts(Package::default(), EnvelopeFormat::ModelTextWithExtensions)]
+    #[case::empty_text(Package::default(), EnvelopeFormat::SExpression)]
+    #[case::empty_text_exts(Package::default(), EnvelopeFormat::SExpressionWithExtensions)]
     // Single hugrs
     #[case::simple_bin(simple_package(), EnvelopeFormat::Model)]
     #[case::simple_bin_exts(simple_package(), EnvelopeFormat::ModelWithExtensions)]
-    #[case::simple_text(simple_package(), EnvelopeFormat::ModelText)]
-    #[case::simple_text_exts(simple_package(), EnvelopeFormat::ModelTextWithExtensions)]
+    #[case::simple_text(simple_package(), EnvelopeFormat::SExpression)]
+    #[case::simple_text_exts(simple_package(), EnvelopeFormat::SExpressionWithExtensions)]
     // Multiple hugrs
     #[case::multi_bin(multi_module_package(), EnvelopeFormat::Model)]
     #[case::multi_bin_exts(multi_module_package(), EnvelopeFormat::ModelWithExtensions)]
-    #[case::multi_text(multi_module_package(), EnvelopeFormat::ModelText)]
-    #[case::multi_text_exts(multi_module_package(), EnvelopeFormat::ModelTextWithExtensions)]
+    #[case::multi_text(multi_module_package(), EnvelopeFormat::SExpression)]
+    #[case::multi_text_exts(multi_module_package(), EnvelopeFormat::SExpressionWithExtensions)]
     fn model_roundtrip(#[case] package: Package, #[case] format: EnvelopeFormat) {
         let mut buffer = Vec::new();
         let config = EnvelopeConfig { format, zstd: None };

--- a/hugr-core/src/envelope/header.rs
+++ b/hugr-core/src/envelope/header.rs
@@ -56,8 +56,7 @@ pub enum EnvelopeFormat {
     /// be avoided.
     //
     // TODO: Update comment once extension encoding is supported.
-    // TODO(deprecated): Change name to SExpression to avoid confusion with Model.
-    ModelText = 40, // '(' in ascii
+    SExpression = 40, // '(' in ascii
     /// Human-readable S-expression encoding using [`hugr_model::v0`].
     ///
     /// Uses a printable ascii value as the discriminant so the envelope can be
@@ -65,9 +64,7 @@ pub enum EnvelopeFormat {
     ///
     /// This is a temporary format required until the model adds support for
     /// extensions.
-    //
-    // TODO(deprecated): Change name to SExpressionWithExtensions to avoid confusion with Model.
-    ModelTextWithExtensions = 41, // ')' in ascii
+    SExpressionWithExtensions = 41, // ')' in ascii
     /// Json-encoded [`crate::package::Package`]
     ///
     /// Uses a printable ascii value as the discriminant so the envelope can be
@@ -86,8 +83,8 @@ impl EnvelopeFormat {
         match self {
             Self::Model
             | Self::ModelWithExtensions
-            | Self::ModelText
-            | Self::ModelTextWithExtensions => Some(0),
+            | Self::SExpression
+            | Self::SExpressionWithExtensions => Some(0),
             _ => None,
         }
     }
@@ -99,7 +96,7 @@ impl EnvelopeFormat {
     pub fn ascii_printable(self) -> bool {
         matches!(
             self,
-            Self::PackageJson | Self::ModelText | Self::ModelTextWithExtensions
+            Self::PackageJson | Self::SExpression | Self::SExpressionWithExtensions
         )
     }
 }
@@ -351,8 +348,8 @@ mod tests {
     #[rstest]
     #[case(EnvelopeFormat::Model)]
     #[case(EnvelopeFormat::ModelWithExtensions)]
-    #[case(EnvelopeFormat::ModelText)]
-    #[case(EnvelopeFormat::ModelTextWithExtensions)]
+    #[case(EnvelopeFormat::SExpression)]
+    #[case(EnvelopeFormat::SExpressionWithExtensions)]
     #[case(EnvelopeFormat::PackageJson)]
     fn header_round_trip(#[case] format: EnvelopeFormat) {
         // With zstd compression

--- a/hugr-core/src/envelope/reader.rs
+++ b/hugr-core/src/envelope/reader.rs
@@ -127,7 +127,7 @@ impl<R: BufRead> EnvelopeReader<R> {
         let mut package = match self.header().format {
             EnvelopeFormat::PackageJson => self.decode_json()?,
             EnvelopeFormat::Model | EnvelopeFormat::ModelWithExtensions => self.decode_model()?,
-            EnvelopeFormat::ModelText | EnvelopeFormat::ModelTextWithExtensions => {
+            EnvelopeFormat::SExpression | EnvelopeFormat::SExpressionWithExtensions => {
                 self.decode_model_ast()?
             }
         };
@@ -210,12 +210,12 @@ impl<R: BufRead> EnvelopeReader<R> {
             .map_err(Into::into)
     }
 
-    /// Read a HUGR model text payload from a reader.
-    fn decode_model_ast(&mut self) -> Result<Package, ModelTextReadError> {
+    /// Read a HUGR S-expression payload from a reader.
+    fn decode_model_ast(&mut self) -> Result<Package, SExpressionReadError> {
         let format = self.header().format;
         check_model_version(format)?;
 
-        let packaged_extensions = if format == EnvelopeFormat::ModelTextWithExtensions {
+        let packaged_extensions = if format == EnvelopeFormat::SExpressionWithExtensions {
             let deserializer = serde_json::Deserializer::from_reader(&mut self.reader);
             // Deserialize the first json object, leaving the rest of the reader unconsumed.
             let extra_extensions = deserializer
@@ -282,8 +282,8 @@ pub(crate) enum PayloadErrorInner {
     JsonRead(#[from] PackageEncodingError),
     /// Error decoding a binary model format package.
     ModelBinary(#[from] ModelBinaryReadError),
-    /// Error decoding a text model format package.
-    ModelText(#[from] ModelTextReadError),
+    /// Error decoding a S-expression model format package.
+    SExpression(#[from] SExpressionReadError),
     /// Error raised while checking for breaking extension version mismatch.
     ExtensionsBreaking(#[from] ExtensionBreakingError),
     /// Error resolving extensions while decoding the payload.
@@ -298,7 +298,7 @@ impl<T: Into<PayloadErrorInner>> From<T> for PayloadError {
 
 #[derive(Debug, Error)]
 #[error(transparent)]
-pub(crate) enum ModelTextReadError {
+pub(crate) enum SExpressionReadError {
     ParseString(#[from] hugr_model::v0::ast::ParseError),
     Import(#[from] ImportError),
     ExtensionLoad(#[from] crate::extension::ExtensionRegistryLoadError),
@@ -362,7 +362,7 @@ mod test {
     #[test]
     fn test_read_text_format() {
         let header = EnvelopeHeader {
-            format: EnvelopeFormat::ModelTextWithExtensions,
+            format: EnvelopeFormat::SExpressionWithExtensions,
             ..Default::default()
         };
         let mut cursor = Cursor::new(Vec::new());
@@ -373,7 +373,7 @@ mod test {
         let reader = EnvelopeReader::new(cursor, &registry).unwrap();
         let (description, result) = reader.read();
 
-        assert_matches!(result, Err(PayloadError(PayloadErrorInner::ModelText(_))));
+        assert_matches!(result, Err(PayloadError(PayloadErrorInner::SExpression(_))));
         assert_eq!(description.header, header);
     }
 
@@ -483,7 +483,7 @@ mod test {
             .unwrap();
 
         let header = EnvelopeHeader {
-            format: EnvelopeFormat::ModelTextWithExtensions,
+            format: EnvelopeFormat::SExpressionWithExtensions,
             ..Default::default()
         };
 
@@ -522,7 +522,7 @@ mod test {
     /// Test encoding/decoding a very large hugr payload (~64MB)
     #[rstest]
     #[case::model_with_extensions(EnvelopeFormat::ModelWithExtensions)]
-    #[case::model_text_with_extensions(EnvelopeFormat::ModelTextWithExtensions)]
+    #[case::model_text_with_extensions(EnvelopeFormat::SExpressionWithExtensions)]
     #[case::package_json(EnvelopeFormat::PackageJson)]
     #[ignore = "This test takes > 15s due to the large payload size."]
     fn big_hugr_payload(#[case] format: EnvelopeFormat, big_hugr: Hugr) {

--- a/hugr-core/src/envelope/writer.rs
+++ b/hugr-core/src/envelope/writer.rs
@@ -55,7 +55,7 @@ fn write_impl<'h>(
             check_model_version(config.format)?;
             encode_model_binary(writer, hugrs, extensions, config.format)?;
         }
-        EnvelopeFormat::ModelText | EnvelopeFormat::ModelTextWithExtensions => {
+        EnvelopeFormat::SExpression | EnvelopeFormat::SExpressionWithExtensions => {
             check_model_version(config.format)?;
             encode_model_text(writer, hugrs, extensions, config.format)?;
         }
@@ -93,13 +93,13 @@ fn encode_model_text<'h>(
     hugrs: impl IntoIterator<Item = &'h Hugr>,
     extensions: &ExtensionRegistry,
     format: EnvelopeFormat,
-) -> Result<(), ModelTextWriteError> {
+) -> Result<(), SExpressionWriteError> {
     use hugr_model::v0::bumpalo::Bump;
 
     use crate::export::export_package;
 
     // Prepend extensions for text model.
-    if format == EnvelopeFormat::ModelTextWithExtensions {
+    if format == EnvelopeFormat::SExpressionWithExtensions {
         serde_json::to_writer(&mut writer, &extensions.iter().collect_vec())?;
     }
 
@@ -135,7 +135,7 @@ pub(crate) enum WriteErrorInner {
     /// Error encoding a binary model format package.
     ModelBinary(#[from] ModelBinaryWriteError),
     /// Error encoding a text model format package.
-    ModelText(#[from] ModelTextWriteError),
+    SExpression(#[from] SExpressionWriteError),
     /// Error writing the envelope header.
     Header(#[from] HeaderError),
     /// The specified payload format is not supported.
@@ -165,7 +165,7 @@ impl<T: Into<WriteErrorInner>> From<T> for WriteError {
 
 #[derive(Debug, Error)]
 #[error(transparent)]
-pub(crate) enum ModelTextWriteError {
+pub(crate) enum SExpressionWriteError {
     JsonSerialize(#[from] serde_json::Error),
     StringWrite(#[from] std::io::Error),
 }

--- a/hugr-core/tests/model.rs
+++ b/hugr-core/tests/model.rs
@@ -106,7 +106,7 @@ fn simple_dfg_hugr() -> Hugr {
 }
 
 #[rstest]
-#[case(EnvelopeFormat::ModelTextWithExtensions)]
+#[case(EnvelopeFormat::SExpressionWithExtensions)]
 #[case(EnvelopeFormat::ModelWithExtensions)]
 fn import_package_with_extensions(#[case] format: EnvelopeFormat, simple_dfg_hugr: Hugr) {
     let ext = Extension::new_arc(


### PR DESCRIPTION
We renamed this already on the python side (hidden, as `EnvelopeFormat._S_EXPRESSION`).

BREAKING CHANGE: Renamed `ModelText` envelope format to `SExpression`