### PR TITLE
refactor!: Remove deprecated definitions

### DIFF
--- a/hugr-core/src/builder.rs
+++ b/hugr-core/src/builder.rs
@@ -177,14 +177,6 @@ pub enum BuildError {
         node: Node,
     },
 
-    /// Deprecated: [Self::HugrNodeLinkingError] is emitted instead
-    #[deprecated(
-        note = "No longer emitted; HugrNodeLinkingError used instead",
-        since = "0.25.0"
-    )]
-    #[error{"In inserting Hugr: {0}"}]
-    HugrInsertionError(NodeLinkingError<Node, Node>),
-
     /// From [Dataflow::add_link_hugr_by_node_with_wires]
     #[error("In inserting Hugr: {0}")]
     HugrNodeLinkingError(#[from] NodeLinkingError<Node, Node>),

--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -93,15 +93,6 @@ pub fn read_envelope(
     }
 }
 
-/// Deprecated alias for [`read_envelope`].
-#[deprecated(since = "0.25.0", note = "Use `read_envelope` instead.")]
-pub fn read_described_envelope(
-    reader: impl BufRead,
-    registry: &ExtensionRegistry,
-) -> Result<(PackageDesc, Package), ReadError> {
-    read_envelope(reader, registry)
-}
-
 /// Errors during reading a HUGR envelope.
 #[derive(Debug, Error)]
 #[non_exhaustive]


### PR DESCRIPTION
Last batch of miscellaneous deprecations.

BREAKING CHANGE: Removed no longer used `BuildError::HugrInsertionError`.
BREAKING CHANGE: Removed deprecated `hugr::envelope::read_described_envelope`. Use `read_envelope` instead.