### PR TITLE
fix: Keep declared used_extensions in envelope description

### DIFF
--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -202,9 +202,9 @@ pub enum ExtensionBreakingError {
 /// and extension is registered in the given registry, check that the
 /// version of the extension in the metadata matches the registered version.
 /// Version compatibility is defined by [`compatible_versions`].
-fn check_breaking_extensions(
+fn check_breaking_extensions<'e>(
     registry: &ExtensionRegistry,
-    used_exts: impl IntoIterator<Item = description::ExtensionDesc>,
+    used_exts: impl IntoIterator<Item = &'e description::ExtensionDesc>,
 ) -> Result<(), ExtensionBreakingError> {
     for ext in used_exts {
         let Some(registered) = registry.get(ext.name.as_str()) else {
@@ -215,9 +215,9 @@ fn check_breaking_extensions(
 
             return Err(ExtensionBreakingError::ExtensionVersionMismatch(
                 ExtensionVersionMismatch {
-                    name: ext.name,
+                    name: ext.name.clone(),
                     registered: registered.version().clone(),
-                    used: ext.version,
+                    used: ext.version.clone(),
                 },
             ));
         }
@@ -383,7 +383,7 @@ pub(crate) mod test {
         let Some(used_exts) = desc.used_extensions_generator else {
             return Ok(());
         };
-        check_breaking_extensions(registry, used_exts)
+        check_breaking_extensions(registry, &used_exts)
     }
 
     #[rstest]

--- a/hugr-core/src/envelope/reader.rs
+++ b/hugr-core/src/envelope/reader.rs
@@ -137,8 +137,8 @@ impl<R: BufRead> EnvelopeReader<R> {
             let desc = desc.get_or_insert_default();
             desc.load_used_extensions_generator(module)
                 .map_err(ExtensionBreakingError::from)?;
-            if let Some(used_exts) = &mut desc.used_extensions_generator {
-                check_breaking_extensions(module.extensions(), used_exts.drain(..))?;
+            if let Some(used_exts) = &desc.used_extensions_generator {
+                check_breaking_extensions(module.extensions(), used_exts)?;
             }
 
             module


### PR DESCRIPTION
The validation check consumed the vector of used extensions declared by the hugr metadata, so `hugr describe --generator-claimed-extensions` always showed an empty table.

Not we get something like 
```
Generator claimed extensions:
+------------------------+---------+
| name                   | version |
+------------------------+---------+
| tket.quantum           | 0.2.1   |
+------------------------+---------+
| prelude                | 0.2.1   |
+------------------------+---------+
| arithmetic.float.types | 0.1.0   |
+------------------------+---------+
| tket.rotation          | 0.2.0   |
+------------------------+---------+
| tket.bool              | 0.2.0   |
+------------------------+---------+
| collections.borrow_arr | 0.2.0   |
+------------------------+---------+
| collections.array      | 0.1.1   |
+------------------------+---------+
```