### PR TITLE
test: Fix type_row intos in doctests

### DIFF
--- a/hugr-core/src/builder/module.rs
+++ b/hugr-core/src/builder/module.rs
@@ -37,7 +37,7 @@ use smol_str::SmolStr;
 ///
 ///     // Create a module and define a function within it
 ///     let mut module_builder = ModuleBuilder::new();
-///     let mut f_build = module_builder.define_function("main", Signature::new_endo(bool_t()))?;
+///     let mut f_build = module_builder.define_function("main", Signature::new_endo([bool_t()]))?;
 ///     let [im] = f_build.input_wires_arr();
 ///
 ///     // We can build a DFG as a sub-component of the function body, and then link it in.

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -69,7 +69,7 @@
 //!
 //! // Create a conditional operation
 //! let conditional = Conditional {
-//!     sum_rows: vec![usize_t().into(), bool_t().into()],
+//!     sum_rows: vec![[usize_t()].into(), [bool_t()].into()],
 //!     other_inputs: vec![usize_t().into()].into(),
 //!     outputs: vec![bool_t()].into(),
 //! };


### PR DESCRIPTION
#2784 missed updating the typerow usage in some doctests (not run on the required `stable` ci check, since `nextest` doesn't support them).
