### PR TITLE
feat(hugr-llvm): Emit rounding operation for `FloatOps::fround` extension ops

### DIFF
--- a/hugr-llvm/src/extension/float.rs
+++ b/hugr-llvm/src/extension/float.rs
@@ -226,6 +226,7 @@ mod test {
     #[case::fmul(FloatOps::fmul)]
     #[case::fdiv(FloatOps::fdiv)]
     #[case::fpow(FloatOps::fpow)]
+    #[case::fround(FloatOps::fround)]
     fn float_operations(mut llvm_ctx: TestContext, #[case] op: FloatOps) {
         let name: &str = op.into();
         let hugr = test_float_op(op);

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__float__test__fround@llvm21.snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__float__test__fround@llvm21.snap
@@ -1,0 +1,21 @@
+---
+source: hugr-llvm/src/extension/float.rs
+assertion_line: 234
+expression: mod_str
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define internal double @_hl.main.1(double %0) {
+alloca_block:
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  %1 = call double @llvm.round.f64(double %0)
+  ret double %1
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare double @llvm.round.f64(double) #0
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }

--- a/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__float__test__fround@pre-mem2reg@llvm21.snap
+++ b/hugr-llvm/src/extension/snapshots/hugr_llvm__extension__float__test__fround@pre-mem2reg@llvm21.snap
@@ -1,0 +1,30 @@
+---
+source: hugr-llvm/src/extension/float.rs
+assertion_line: 234
+expression: mod_str
+---
+; ModuleID = 'test_context'
+source_filename = "test_context"
+
+define internal double @_hl.main.1(double %0) {
+alloca_block:
+  %"0" = alloca double, align 8
+  %"2_0" = alloca double, align 8
+  %"4_0" = alloca double, align 8
+  br label %entry_block
+
+entry_block:                                      ; preds = %alloca_block
+  store double %0, ptr %"2_0", align 8
+  %"2_01" = load double, ptr %"2_0", align 8
+  %1 = call double @llvm.round.f64(double %"2_01")
+  store double %1, ptr %"4_0", align 8
+  %"4_02" = load double, ptr %"4_0", align 8
+  store double %"4_02", ptr %"0", align 8
+  %"03" = load double, ptr %"0", align 8
+  ret double %"03"
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare double @llvm.round.f64(double) #0
+
+attributes #0 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }


### PR DESCRIPTION
Adds `FloatOps::fround` LLVM lowering support. This is to add support for rounding operations in Selene, connected to https://github.com/Quantinuum/guppylang/issues/1561.

I am a bit unsure how the tests work, but simply adding another test case in line with the existing ones seems to work fine.