### PR TITLE
ci: Don't create python releases as drafts

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -40,7 +40,7 @@ jobs:
   # Check if the tag matches the package name,
   # or if the workflow is running on a non-release event.
   check-tag:
-    name: Check tag
+    name: Check tag and temporarily mark the release as draft
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.check-tag.outputs.run }}
@@ -51,6 +51,17 @@ jobs:
           echo "run=$SHOULD_RUN" >> $GITHUB_OUTPUT
         env:
           SHOULD_RUN: ${{ github.ref_type != 'tag' || ( github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/hugr-py-v') ) }}
+
+      - name: Temporarily mark the release as draft
+        if: ${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/hugr-py-v') }}
+        run: |
+          gh release view ${{ github.ref_name }}
+          if [ $? -ne 0 ]; then
+            echo "No release found for tag ${{ github.ref_name }}"
+            exit 1
+          fi
+          # Make the GitHub release a draft until the package has been published to PyPI
+          gh release edit ${{ github.ref_name }} --draft=true
 
   linux:
     needs: check-tag

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,7 @@
             "component": "hugr-py",
             "package-name": "hugr",
             "include-component-in-tag": true,
-            "draft": true,
+            "draft": false,
             "prerelease": false,
             "draft-pull-request": true,
             "extra-files": [


### PR DESCRIPTION
This partially reverts https://github.com/Quantinuum/hugr/pull/2892.

The idea of that PR was to create the python releases as Draft while wheels are being built, only to mark them as ready once the wheels have been submitted.

> I had to change the trigger for the wheel-building workflow from release: published to push: tags, since apparently draft releases do not trigger workflows (https://github.com/orgs/community/discussions/7118) 🫠

Turns out, creating a draft release not only does not trigger `release` workflows but also it doesn't create tags 🫠 

So here instead we are creating a non-draft release, and marking it as draft when the wheels building workflow start.
This won't help when we want to start using github's [new immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases), but at least mimics the behaviour for now.

(Ideally we'd just create a tag **plus** the draft release, but we don't have control over `release-please`'s behaviour there).