### PR TITLE
refactor: further cleanups to SiblingSubgraph + generalize over trait HugrConvexChecker

### DIFF
--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -77,7 +77,7 @@ impl<'a, H: HugrView, CC: CreateConvexChecker<CheckerRegion<'a, H>>> HugrConvexC
             .nodes_iter()
             .map(|index| self.node_map.from_portgraph(index))
             .collect_vec();
-        validate_subgraph_boundary(hugr, &nodes, inputs, outputs, function_calls)?;
+        validate_boundary(hugr, &nodes, inputs, outputs, function_calls)?;
 
         if subpg.is_convex_with_checker(self) {
             Ok(nodes)
@@ -187,7 +187,7 @@ impl<N: HugrNode> SiblingSubgraph<N> {
         let non_local = get_non_local_edges(&nodes, &dfg_graph);
         let function_calls = group_into_function_calls(non_local, &dfg_graph)?;
 
-        validate_subgraph_boundary(dfg_graph, &nodes, &inputs, &outputs, &function_calls)?;
+        validate_boundary(dfg_graph, &nodes, &inputs, &outputs, &function_calls)?;
 
         Ok(Self {
             nodes,
@@ -1200,7 +1200,7 @@ fn get_edge_type<H: HugrView, P: Into<Port> + Copy>(
 /// `outputs` are accurate wrt. `nodes`.
 ///
 /// Does NOT check convexity proper, i.e. whether the set of nodes form a convex induced graph.
-fn validate_subgraph_boundary<H: HugrView>(
+fn validate_boundary<H: HugrView>(
     hugr: &H,
     nodes: &[H::Node],
     inputs: &IncomingPorts<H::Node>,


### PR DESCRIPTION
* Add a trait capturing the validation + convexity checking operation at the Hugr (not portgraph) level.
* Implement this for any `struct ConvexChecker` wrapping a `CreateConvexChecker<CheckerRegion>` - this includes the `TopoConvexChecker` used previously.
* Generalize `try_new_with_checker` and `try_from_nodes_with_checker` to take an arbitrary `impl HugrConvexChecker`. (The old TopoCC implements, so this is non-breaking 😄 😁)
* `make_pg_subgraph` takes region and node_map, rather than recomputing them; avoid calling `region_portgraph` in (the majority of cases where) we already have them in a `struct ConvexChecker`
* Inline `pick_parent` into `try_new` (just to create a checker)
* Add `check_parent` i.e. that parents are all the same. (Thus fulfilling `try_new_with_checker`'s doc comment that it checks this.)
* Also check the ConvexChecker's region_parent is the same as the subgraph, seems this was missing before
* Remove the (internal) check in helper `validate_subgraph` that all nodes have the same parent; this is never called on the actual nodes of the subgraph, only nodes returned by `make_pg_subgraph` or children of a hugr dataflow region, where this is guaranteed. Then, rename to `validate_boundary`.