### PR TITLE
refactor(hugrv2)!: Rename Terms to clarify (runtime) Types from static parameter Kinds

### DIFF
--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -481,7 +481,7 @@ pub(crate) mod test {
     use crate::metadata::Metadata;
     use crate::ops::{FuncDecl, FuncDefn, OpParent, OpTag, OpTrait, Value, handle::NodeHandle};
     use crate::std_extensions::logic::test::and_op;
-    use crate::types::type_param::{TermTypeError, TypeParam};
+    use crate::types::type_param::{TermKindError, TypeParam};
     use crate::types::{EdgeKind, FuncValueType, Signature, Term, Type, TypeBound, TypeRowRV};
     use crate::utils::test_quantum_extension::h_gate;
     use crate::{Wire, builder::test::n_identity, type_row};
@@ -947,7 +947,7 @@ pub(crate) mod test {
         assert_eq!(
             ev,
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::InvalidValue(Box::new(rv.clone()))
+                TermKindError::InvalidValue(Box::new(rv.clone()))
             ))
         );
 
@@ -958,9 +958,9 @@ pub(crate) mod test {
         assert_eq!(
             ev,
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::TypeMismatch {
+                TermKindError::KindMismatch {
                     term: Box::new(rv),
-                    type_: Box::new(TypeBound::Linear.into())
+                    kind: Box::new(TypeBound::Linear.into())
                 }
             ))
         );

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -931,7 +931,7 @@ pub(crate) mod test {
         FunctionBuilder::new(
             "bad_eval",
             PolyFuncType::new(
-                [TypeParam::new_list_type(TypeBound::Copyable)],
+                [TypeParam::new_list_kind(TypeBound::Copyable)],
                 Signature::new(
                     [Type::new_function(FuncValueType::new(
                         [usize_t()],

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -962,11 +962,11 @@ impl<'a> Context<'a> {
                 let item_types = self.export_term(item_types, None);
                 self.make_term_apply(model::CORE_TUPLE_TYPE, &[item_types])
             }
-            Term::RuntimeExtension(ext) => self.export_custom_type(ext),
-            Term::RuntimeFunction(func) => {
+            Term::ExtensionType(ext) => self.export_custom_type(ext),
+            Term::FunctionType(func) => {
                 self.export_func_type(func, |this, trv| this.export_term(trv, None))
             }
-            Term::RuntimeSum(sum) => self.export_sum_type(sum),
+            Term::SumType(sum) => self.export_sum_type(sum),
 
             Term::BoundedNat(value) => self.make_term(model::Literal::Nat(*value).into()),
             Term::String(value) => self.make_term(model::Literal::Str(value.into()).into()),

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -941,7 +941,7 @@ impl<'a> Context<'a> {
         var: Option<(table::NodeId, table::VarIndex)>,
     ) -> table::TermId {
         match t {
-            Term::RuntimeKind(b) => {
+            Term::TypeKind(b) => {
                 if let (Some((node, index)), TypeBound::Copyable) = (var, b) {
                     let term = self.make_term(table::Term::Var(table::VarId(node, index)));
                     let non_linear = self.make_term_apply(model::CORE_NON_LINEAR, &[term]);

--- a/hugr-core/src/export.rs
+++ b/hugr-core/src/export.rs
@@ -941,7 +941,7 @@ impl<'a> Context<'a> {
         var: Option<(table::NodeId, table::VarIndex)>,
     ) -> table::TermId {
         match t {
-            Term::RuntimeType(b) => {
+            Term::RuntimeKind(b) => {
                 if let (Some((node, index)), TypeBound::Copyable) = (var, b) {
                     let term = self.make_term(table::Term::Var(table::VarId(node, index)));
                     let non_linear = self.make_term_apply(model::CORE_NON_LINEAR, &[term]);
@@ -950,15 +950,15 @@ impl<'a> Context<'a> {
 
                 self.make_term_apply(model::CORE_TYPE, &[])
             }
-            Term::BoundedNatType(_) => self.make_term_apply(model::CORE_NAT_TYPE, &[]),
-            Term::StringType => self.make_term_apply(model::CORE_STR_TYPE, &[]),
-            Term::BytesType => self.make_term_apply(model::CORE_BYTES_TYPE, &[]),
-            Term::FloatType => self.make_term_apply(model::CORE_FLOAT_TYPE, &[]),
-            Term::ListType(item_type) => {
+            Term::BoundedNatKind(_) => self.make_term_apply(model::CORE_NAT_TYPE, &[]),
+            Term::StringKind => self.make_term_apply(model::CORE_STR_TYPE, &[]),
+            Term::BytesKind => self.make_term_apply(model::CORE_BYTES_TYPE, &[]),
+            Term::FloatKind => self.make_term_apply(model::CORE_FLOAT_TYPE, &[]),
+            Term::ListKind(item_type) => {
                 let item_type = self.export_term(item_type, None);
                 self.make_term_apply(model::CORE_LIST_TYPE, &[item_type])
             }
-            Term::TupleType(item_types) => {
+            Term::TupleKind(item_types) => {
                 let item_types = self.export_term(item_types, None);
                 self.make_term_apply(model::CORE_TUPLE_TYPE, &[item_types])
             }
@@ -1005,8 +1005,8 @@ impl<'a> Context<'a> {
                 self.make_term(table::Term::Tuple(parts))
             }
             Term::Variable(v) => self.export_type_arg_var(v),
-            Term::StaticType => self.make_term_apply(model::CORE_STATIC, &[]),
-            Term::ConstType(ty) => {
+            Term::StaticKind => self.make_term_apply(model::CORE_STATIC, &[]),
+            Term::ConstKind(ty) => {
                 let ty = self.export_type(ty);
                 self.make_term_apply(model::CORE_CONST, &[ty])
             }

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -125,7 +125,7 @@ use thiserror::Error;
 use crate::hugr::IdentList;
 use crate::ops::custom::{ExtensionOp, OpaqueOp};
 use crate::ops::{OpName, OpNameRef};
-use crate::types::type_param::{TermTypeError, TypeArg, TypeParam};
+use crate::types::type_param::{TermKindError, TypeArg, TypeParam};
 use crate::types::{CustomType, TypeBound, TypeName};
 use crate::types::{Signature, TypeNameRef};
 
@@ -490,7 +490,7 @@ pub enum SignatureError {
     ExtensionMismatch(ExtensionId, ExtensionId),
     /// When the type arguments of the node did not match the params declared by the `OpDef`
     #[error("Type arguments of node did not match params declared by definition: {0}")]
-    TypeArgMismatch(#[from] TermTypeError),
+    TypeArgMismatch(#[from] TermKindError),
     /// Invalid type arguments
     #[error("Invalid type arguments for operation")]
     InvalidTypeArgs,

--- a/hugr-core/src/extension/declarative/types.rs
+++ b/hugr-core/src/extension/declarative/types.rs
@@ -129,6 +129,6 @@ impl TypeParamDeclaration {
         _extension: &Extension,
         _ctx: DeclarationContext<'_>,
     ) -> Result<TypeParam, ExtensionDeclarationError> {
-        Ok(TypeParam::StringType)
+        Ok(TypeParam::StringKind)
     }
 }

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -716,7 +716,7 @@ pub(super) mod test {
         const OP_NAME: OpName = OpName::new_inline("Reverse");
 
         let ext = Extension::try_new_test_arc(EXT_ID, |ext, extension_ref| {
-            const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Linear);
+            const TP: TypeParam = TypeParam::RuntimeKind(TypeBound::Linear);
             let list_of_var =
                 Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
             let type_scheme = PolyFuncTypeRV::new(vec![TP], Signature::new_endo([list_of_var]));
@@ -762,7 +762,7 @@ pub(super) mod test {
                 &self,
                 arg_values: &[TypeArg],
             ) -> Result<PolyFuncTypeRV, SignatureError> {
-                const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Linear);
+                const TP: TypeParam = TypeParam::RuntimeKind(TypeBound::Linear);
                 let [TypeArg::BoundedNat(n)] = arg_values else {
                     return Err(SignatureError::InvalidTypeArgs);
                 };

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -777,7 +777,7 @@ pub(super) mod test {
             }
 
             fn static_params(&self) -> &[TypeParam] {
-                const MAX_NAT: &[TypeParam] = &[TypeParam::max_nat_type()];
+                const MAX_NAT: &[TypeParam] = &[TypeParam::max_nat_kind()];
                 MAX_NAT
             }
         }
@@ -820,7 +820,7 @@ pub(super) mod test {
             );
 
             // First arg must be concrete, not a variable
-            let kind = TypeParam::bounded_nat_type(NonZeroU64::new(5).unwrap());
+            let kind = TypeParam::bounded_nat_kind(NonZeroU64::new(5).unwrap());
             let args = [TypeArg::new_var_use(0, kind.clone()), usize_t().into()];
             // We can't prevent this from getting into our compute_signature implementation:
             assert_eq!(

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -15,7 +15,7 @@ use crate::Hugr;
 use crate::envelope::serde_with::AsBinaryEnvelope;
 use crate::ops::{OpName, OpNameRef};
 use crate::package::Package;
-use crate::types::type_param::{TypeArg, TypeParam, check_term_types};
+use crate::types::type_param::{TypeArg, TypeParam, check_term_kinds};
 use crate::types::{FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature};
 mod serialize_signature_func;
 
@@ -254,7 +254,7 @@ impl SignatureFunc {
                 let static_params = func.static_params();
                 let (static_args, other_args) = args.split_at(min(static_params.len(), args.len()));
 
-                check_term_types(static_args, static_params)?;
+                check_term_kinds(static_args, static_params)?;
                 temp = func.compute_signature(static_args, def)?;
                 (&temp, other_args)
             }
@@ -406,7 +406,7 @@ impl OpDef {
                 let (static_args, other_args) =
                     args.split_at(min(custom.static_params().len(), args.len()));
                 static_args.iter().try_for_each(|ta| ta.validate(&[]))?;
-                check_term_types(static_args, custom.static_params())?;
+                check_term_kinds(static_args, custom.static_params())?;
                 temp = custom.compute_signature(static_args, self)?;
                 (&temp, other_args)
             }
@@ -416,7 +416,7 @@ impl OpDef {
             }
         };
         args.iter().try_for_each(|ta| ta.validate(var_decls))?;
-        check_term_types(args, pf.params())?;
+        check_term_kinds(args, pf.params())?;
         Ok(())
     }
 

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -613,7 +613,7 @@ pub(super) mod test {
     use crate::ops::OpName;
     use crate::package::Package;
     use crate::std_extensions::collections::list;
-    use crate::types::type_param::{TermTypeError, TypeParam};
+    use crate::types::type_param::{TermKindError, TypeParam};
     use crate::types::{PolyFuncTypeRV, Signature, Term, Type, TypeArg, TypeBound};
     use crate::{Extension, const_extension_ids};
 
@@ -866,8 +866,8 @@ pub(super) mod test {
             assert_eq!(
                 def.compute_signature(std::slice::from_ref(&arg)),
                 Err(SignatureError::TypeArgMismatch(
-                    TermTypeError::TypeMismatch {
-                        type_: Box::new(TypeBound::Linear.into()),
+                    TermKindError::KindMismatch {
+                        kind: Box::new(TypeBound::Linear.into()),
                         term: Box::new(arg),
                     }
                 ))

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -716,7 +716,7 @@ pub(super) mod test {
         const OP_NAME: OpName = OpName::new_inline("Reverse");
 
         let ext = Extension::try_new_test_arc(EXT_ID, |ext, extension_ref| {
-            const TP: TypeParam = TypeParam::RuntimeKind(TypeBound::Linear);
+            const TP: TypeParam = TypeParam::TypeKind(TypeBound::Linear);
             let list_of_var =
                 Type::new_extension(list_def.instantiate(vec![TypeArg::new_var_use(0, TP)])?);
             let type_scheme = PolyFuncTypeRV::new(vec![TP], Signature::new_endo([list_of_var]));
@@ -762,7 +762,7 @@ pub(super) mod test {
                 &self,
                 arg_values: &[TypeArg],
             ) -> Result<PolyFuncTypeRV, SignatureError> {
-                const TP: TypeParam = TypeParam::RuntimeKind(TypeBound::Linear);
+                const TP: TypeParam = TypeParam::TypeKind(TypeBound::Linear);
                 let [TypeArg::BoundedNat(n)] = arg_values else {
                     return Err(SignatureError::InvalidTypeArgs);
                 };

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -109,8 +109,8 @@ pub static PRELUDE: LazyLock<Arc<Extension>> = LazyLock::new(|| {
             .unwrap();
         let panic_exit_sig = PolyFuncTypeRV::new(
             [
-                TypeParam::new_list_type(TypeBound::Linear),
-                TypeParam::new_list_type(TypeBound::Linear),
+                TypeParam::new_list_kind(TypeBound::Linear),
+                TypeParam::new_list_kind(TypeBound::Linear),
             ],
             FuncValueType::new(
                 TypeRowRV::from([Type::new_extension(error_type.clone())])
@@ -624,7 +624,7 @@ impl MakeOpDef for TupleOpDef {
         let rv = TypeRowRV::new_var_use(0, TypeBound::Linear);
         let tuple_type = Type::new_tuple(rv.clone());
 
-        let param = TypeParam::new_list_type(TypeBound::Linear);
+        let param = TypeParam::new_list_kind(TypeBound::Linear);
         match self {
             TupleOpDef::MakeTuple => {
                 PolyFuncTypeRV::new([param], FuncValueType::new(rv, [tuple_type]))
@@ -893,7 +893,7 @@ impl MakeOpDef for BarrierDef {
 
     fn init_signature(&self, _extension_ref: &Weak<Extension>) -> SignatureFunc {
         PolyFuncTypeRV::new(
-            vec![TypeParam::new_list_type(TypeBound::Linear)],
+            vec![TypeParam::new_list_kind(TypeBound::Linear)],
             FuncValueType::new_endo(TypeRowRV::new_var_use(0, TypeBound::Linear)),
         )
         .into()

--- a/hugr-core/src/extension/prelude/generic.rs
+++ b/hugr-core/src/extension/prelude/generic.rs
@@ -74,7 +74,7 @@ impl MakeOpDef for LoadNatDef {
 
     fn init_signature(&self, _extension_ref: &Weak<Extension>) -> SignatureFunc {
         let usize_t: Type = usize_custom_t(_extension_ref).into();
-        let params = vec![TypeParam::max_nat_type()];
+        let params = vec![TypeParam::max_nat_kind()];
         PolyFuncTypeRV::new(params, FuncValueType::new(type_row![], vec![usize_t])).into()
     }
 

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -338,7 +338,7 @@ fn resolve_custom_const(#[case] custom_const: impl CustomConst) {
 #[rstest]
 fn resolve_call() {
     let dummy_fn_sig = PolyFuncType::new(
-        vec![TypeParam::RuntimeType(TypeBound::Linear)],
+        vec![TypeParam::RuntimeKind(TypeBound::Linear)],
         Signature::new(vec![], vec![bool_t()]),
     );
 

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -338,7 +338,7 @@ fn resolve_custom_const(#[case] custom_const: impl CustomConst) {
 #[rstest]
 fn resolve_call() {
     let dummy_fn_sig = PolyFuncType::new(
-        vec![TypeParam::RuntimeKind(TypeBound::Linear)],
+        vec![TypeParam::TypeKind(TypeBound::Linear)],
         Signature::new(vec![], vec![bool_t()]),
     );
 

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -238,7 +238,7 @@ pub(crate) fn collect_term_exts(
             }
         }
         Term::Variable(_)
-        | Term::RuntimeKind(_)
+        | Term::TypeKind(_)
         | Term::StaticKind
         | Term::BoundedNatKind(_)
         | Term::StringKind

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -186,7 +186,7 @@ pub(crate) fn collect_term_exts(
     missing_extensions: &mut ExtensionSet,
 ) {
     match term {
-        Term::RuntimeExtension(custom) => {
+        Term::ExtensionType(custom) => {
             for arg in custom.args() {
                 collect_term_exts(arg, used_extensions, missing_extensions);
             }
@@ -201,11 +201,11 @@ pub(crate) fn collect_term_exts(
                 }
             }
         }
-        Term::RuntimeFunction(f) => {
+        Term::FunctionType(f) => {
             collect_term_exts(&f.input, used_extensions, missing_extensions);
             collect_term_exts(&f.output, used_extensions, missing_extensions);
         }
-        Term::RuntimeSum(SumType::General { rows }) => {
+        Term::SumType(SumType::General { rows }) => {
             for row in rows {
                 collect_term_exts(row, used_extensions, missing_extensions);
             }
@@ -248,7 +248,7 @@ pub(crate) fn collect_term_exts(
         | Term::String(_)
         | Term::Bytes(_)
         | Term::Float(_)
-        | Term::RuntimeSum(SumType::Unit { .. }) => {}
+        | Term::SumType(SumType::Unit { .. }) => {}
     }
 }
 

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -210,7 +210,7 @@ pub(crate) fn collect_term_exts(
                 collect_term_exts(row, used_extensions, missing_extensions);
             }
         }
-        Term::ConstType(ty) => collect_term_exts(ty, used_extensions, missing_extensions),
+        Term::ConstKind(ty) => collect_term_exts(ty, used_extensions, missing_extensions),
         Term::List(elems) => {
             for elem in elems.iter() {
                 collect_term_exts(elem, used_extensions, missing_extensions);
@@ -221,10 +221,10 @@ pub(crate) fn collect_term_exts(
                 collect_term_exts(elem, used_extensions, missing_extensions);
             }
         }
-        Term::ListType(item_type) => {
+        Term::ListKind(item_type) => {
             collect_term_exts(item_type, used_extensions, missing_extensions)
         }
-        Term::TupleType(item_types) => {
+        Term::TupleKind(item_types) => {
             collect_term_exts(item_types, used_extensions, missing_extensions)
         }
         Term::ListConcat(lists) => {
@@ -238,12 +238,12 @@ pub(crate) fn collect_term_exts(
             }
         }
         Term::Variable(_)
-        | Term::RuntimeType(_)
-        | Term::StaticType
-        | Term::BoundedNatType(_)
-        | Term::StringType
-        | Term::BytesType
-        | Term::FloatType
+        | Term::RuntimeKind(_)
+        | Term::StaticKind
+        | Term::BoundedNatKind(_)
+        | Term::StringKind
+        | Term::BytesKind
+        | Term::FloatKind
         | Term::BoundedNat(_)
         | Term::String(_)
         | Term::Bytes(_)

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -248,7 +248,7 @@ pub(super) fn resolve_term_exts(
                 resolve_typerow_rv_exts(node, row, extensions, used_extensions)?;
             }
         }
-        Term::ConstType(ty) => resolve_type_exts(node, ty, extensions, used_extensions)?,
+        Term::ConstKind(ty) => resolve_type_exts(node, ty, extensions, used_extensions)?,
         Term::List(children)
         | Term::ListConcat(children)
         | Term::Tuple(children)
@@ -257,19 +257,19 @@ pub(super) fn resolve_term_exts(
                 resolve_term_exts(node, child, extensions, used_extensions)?;
             }
         }
-        Term::ListType(item_type) => {
+        Term::ListKind(item_type) => {
             resolve_term_exts(node, item_type.as_mut(), extensions, used_extensions)?;
         }
-        Term::TupleType(item_types) => {
+        Term::TupleKind(item_types) => {
             resolve_term_exts(node, item_types.as_mut(), extensions, used_extensions)?;
         }
         Term::Variable(_)
-        | Term::RuntimeType(_)
-        | Term::StaticType
-        | Term::BoundedNatType(_)
-        | Term::StringType
-        | Term::BytesType
-        | Term::FloatType
+        | Term::RuntimeKind(_)
+        | Term::StaticKind
+        | Term::BoundedNatKind(_)
+        | Term::StringKind
+        | Term::BytesKind
+        | Term::FloatKind
         | Term::BoundedNat(_)
         | Term::String(_)
         | Term::Bytes(_)

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -237,13 +237,13 @@ pub(super) fn resolve_term_exts(
     used_extensions: &mut WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
     match term {
-        Term::RuntimeExtension(custom) => {
+        Term::ExtensionType(custom) => {
             resolve_custom_type_exts(node, custom, extensions, used_extensions)?;
         }
-        Term::RuntimeFunction(f) => {
+        Term::FunctionType(f) => {
             resolve_func_type_exts(node, &mut *f, extensions, used_extensions)?;
         }
-        Term::RuntimeSum(SumType::General { rows }) => {
+        Term::SumType(SumType::General { rows }) => {
             for row in rows.iter_mut() {
                 resolve_typerow_rv_exts(node, row, extensions, used_extensions)?;
             }
@@ -274,7 +274,7 @@ pub(super) fn resolve_term_exts(
         | Term::String(_)
         | Term::Bytes(_)
         | Term::Float(_)
-        | Term::RuntimeSum(SumType::Unit { .. }) => {}
+        | Term::SumType(SumType::Unit { .. }) => {}
     }
     Ok(())
 }

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -264,7 +264,7 @@ pub(super) fn resolve_term_exts(
             resolve_term_exts(node, item_types.as_mut(), extensions, used_extensions)?;
         }
         Term::Variable(_)
-        | Term::RuntimeKind(_)
+        | Term::TypeKind(_)
         | Term::StaticKind
         | Term::BoundedNatKind(_)
         | Term::StringKind

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Weak};
 use strum::IntoEnumIterator;
 
 use crate::ops::{ExtensionOp, OpName, OpNameRef};
-use crate::types::type_param::TermTypeError;
+use crate::types::type_param::TermKindError;
 use crate::{Extension, ops::OpType, types::TypeArg};
 
 use super::{ExtensionBuildError, ExtensionId, OpDef, SignatureError, op_def::SignatureFunc};
@@ -27,8 +27,8 @@ pub enum OpLoadError {
     WrongExtension(ExtensionId, ExtensionId),
 }
 
-impl From<TermTypeError> for OpLoadError {
-    fn from(value: TermTypeError) -> Self {
+impl From<TermKindError> for OpLoadError {
+    fn from(value: TermKindError) -> Self {
         SignatureError::from(value).into()
     }
 }

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -249,7 +249,7 @@ mod test {
     fn test_instantiate_typedef() {
         let def = TypeDef {
             name: "MyType".into(),
-            params: vec![TypeParam::RuntimeType(TypeBound::Copyable)],
+            params: vec![TypeParam::RuntimeKind(TypeBound::Copyable)],
             extension: "MyRsrc".try_into().unwrap(),
             // Dummy extension. Will return `None` when trying to upgrade it into an `Arc`.
             extension_ref: Default::default(),

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -240,7 +240,7 @@ mod test {
     use crate::extension::SignatureError;
     use crate::extension::prelude::{qb_t, usize_t};
     use crate::std_extensions::arithmetic::float_types::float64_type;
-    use crate::types::type_param::{TermTypeError, TypeParam};
+    use crate::types::type_param::{TermKindError, TypeParam};
     use crate::types::{Signature, Type, TypeBound};
 
     use super::{TypeDef, TypeDefBound};
@@ -270,22 +270,22 @@ mod test {
         assert_eq!(
             def.instantiate([qb_t().into()]),
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::TypeMismatch {
+                TermKindError::KindMismatch {
                     term: Box::new(qb_t().into()),
-                    type_: Box::new(TypeBound::Copyable.into())
+                    kind: Box::new(TypeBound::Copyable.into())
                 }
             ))
         );
         // Too few arguments:
         assert_eq!(
             def.instantiate([]).unwrap_err(),
-            SignatureError::TypeArgMismatch(TermTypeError::WrongNumberArgs(0, 1))
+            SignatureError::TypeArgMismatch(TermKindError::WrongNumberArgs(0, 1))
         );
         // Too many arguments:
         assert_eq!(
             def.instantiate([float64_type().into(), float64_type().into(),])
                 .unwrap_err(),
-            SignatureError::TypeArgMismatch(TermTypeError::WrongNumberArgs(2, 1))
+            SignatureError::TypeArgMismatch(TermKindError::WrongNumberArgs(2, 1))
         );
     }
 }

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -249,7 +249,7 @@ mod test {
     fn test_instantiate_typedef() {
         let def = TypeDef {
             name: "MyType".into(),
-            params: vec![TypeParam::RuntimeKind(TypeBound::Copyable)],
+            params: vec![TypeParam::TypeKind(TypeBound::Copyable)],
             extension: "MyRsrc".try_into().unwrap(),
             // Dummy extension. Will return `None` when trying to upgrade it into an `Arc`.
             extension_ref: Default::default(),

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -6,7 +6,7 @@ use super::{Extension, ExtensionId, SignatureError};
 
 use crate::types::{CustomType, TypeName, least_upper_bound};
 
-use crate::types::type_param::{TypeArg, check_term_types};
+use crate::types::type_param::{TypeArg, check_term_kinds};
 
 use crate::types::type_param::TypeParam;
 
@@ -79,7 +79,7 @@ pub struct TypeDef {
 impl TypeDef {
     /// Check provided type arguments are valid against parameters.
     pub fn check_args(&self, args: &[TypeArg]) -> Result<(), SignatureError> {
-        Ok(check_term_types(args, &self.params)?)
+        Ok(check_term_kinds(args, &self.params)?)
     }
 
     /// Check [`CustomType`] is a valid instantiation of this definition.
@@ -102,7 +102,7 @@ impl TypeDef {
             ));
         }
 
-        check_term_types(custom.type_args(), &self.params)?;
+        check_term_kinds(custom.type_args(), &self.params)?;
 
         let calc_bound = self.bound(custom.args());
         if calc_bound == custom.bound() {
@@ -123,7 +123,7 @@ impl TypeDef {
     /// valid instances of the type parameters.
     pub fn instantiate(&self, args: impl Into<Vec<TypeArg>>) -> Result<CustomType, SignatureError> {
         let args = args.into();
-        check_term_types(&args, &self.params)?;
+        check_term_kinds(&args, &self.params)?;
         let bound = self.bound(&args);
         Ok(CustomType::new(
             self.name().clone(),

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -595,7 +595,7 @@ fn polyfunctype2() -> PolyFuncTypeRV {
 #[rstest]
 #[case(Signature::new_endo(type_row![]).into())]
 #[case(polyfunctype1())]
-#[case(PolyFuncType::new([TypeParam::StringType], Signature::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
+#[case(PolyFuncType::new([TypeParam::StringKind], Signature::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
 #[case(PolyFuncType::new([TypeBound::Copyable.into()], Signature::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
 #[case(PolyFuncType::new([TypeParam::new_list_type(TypeBound::Linear)], Signature::new_endo(type_row![])))]
 #[case(PolyFuncType::new([TypeParam::new_tuple_type([TypeBound::Linear.into(), TypeParam::bounded_nat_type(2.try_into().unwrap())])], Signature::new_endo(type_row![])))]
@@ -608,7 +608,7 @@ fn roundtrip_polyfunctype_fixedlen(#[case] poly_func_type: PolyFuncType) {
 
 #[rstest]
 #[case(FuncValueType::new_endo(type_row![]).into())]
-#[case(PolyFuncTypeRV::new([TypeParam::StringType], FuncValueType::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
+#[case(PolyFuncTypeRV::new([TypeParam::StringKind], FuncValueType::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
 #[case(PolyFuncTypeRV::new([TypeBound::Copyable.into()], FuncValueType::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
 #[case(PolyFuncTypeRV::new([TypeParam::new_list_type(TypeBound::Linear)], FuncValueType::new_endo(type_row![])))]
 #[case(PolyFuncTypeRV::new([TypeParam::new_tuple_type([TypeBound::Linear.into(), TypeParam::bounded_nat_type(2.try_into().unwrap())])], FuncValueType::new_endo(type_row![])))]

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -573,13 +573,13 @@ fn roundtrip_value(#[case] value: Value) {
 
 fn polyfunctype1() -> PolyFuncType {
     let function_type = Signature::new_endo(type_row![]);
-    PolyFuncType::new([TypeParam::max_nat_type()], function_type)
+    PolyFuncType::new([TypeParam::max_nat_kind()], function_type)
 }
 
 fn polyfunctype2() -> PolyFuncTypeRV {
     let tv0 = TypeRowRV::new_var_use(0, TypeBound::Linear);
     let tv1 = TypeRowRV::new_var_use(1, TypeBound::Copyable);
-    let params = [TypeBound::Linear, TypeBound::Copyable].map(TypeParam::new_list_type);
+    let params = [TypeBound::Linear, TypeBound::Copyable].map(TypeParam::new_list_kind);
     let inputs = TypeRowRV::from([Type::new_function(FuncValueType::new(
         tv0.clone(),
         tv1.clone(),
@@ -597,10 +597,10 @@ fn polyfunctype2() -> PolyFuncTypeRV {
 #[case(polyfunctype1())]
 #[case(PolyFuncType::new([TypeParam::StringKind], Signature::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
 #[case(PolyFuncType::new([TypeBound::Copyable.into()], Signature::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
-#[case(PolyFuncType::new([TypeParam::new_list_type(TypeBound::Linear)], Signature::new_endo(type_row![])))]
-#[case(PolyFuncType::new([TypeParam::new_tuple_type([TypeBound::Linear.into(), TypeParam::bounded_nat_type(2.try_into().unwrap())])], Signature::new_endo(type_row![])))]
+#[case(PolyFuncType::new([TypeParam::new_list_kind(TypeBound::Linear)], Signature::new_endo(type_row![])))]
+#[case(PolyFuncType::new([TypeParam::new_tuple_kind([TypeBound::Linear.into(), TypeParam::bounded_nat_kind(2.try_into().unwrap())])], Signature::new_endo(type_row![])))]
 #[case(PolyFuncType::new(
-    [TypeParam::new_list_type(TypeBound::Linear)],
+    [TypeParam::new_list_kind(TypeBound::Linear)],
     Signature::new_endo([Type::new_tuple(TypeRowRV::new_var_use(0, TypeBound::Linear))])))]
 fn roundtrip_polyfunctype_fixedlen(#[case] poly_func_type: PolyFuncType) {
     check_testing_roundtrip(poly_func_type);
@@ -610,10 +610,10 @@ fn roundtrip_polyfunctype_fixedlen(#[case] poly_func_type: PolyFuncType) {
 #[case(FuncValueType::new_endo(type_row![]).into())]
 #[case(PolyFuncTypeRV::new([TypeParam::StringKind], FuncValueType::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
 #[case(PolyFuncTypeRV::new([TypeBound::Copyable.into()], FuncValueType::new_endo([Type::new_var_use(0, TypeBound::Copyable)])))]
-#[case(PolyFuncTypeRV::new([TypeParam::new_list_type(TypeBound::Linear)], FuncValueType::new_endo(type_row![])))]
-#[case(PolyFuncTypeRV::new([TypeParam::new_tuple_type([TypeBound::Linear.into(), TypeParam::bounded_nat_type(2.try_into().unwrap())])], FuncValueType::new_endo(type_row![])))]
+#[case(PolyFuncTypeRV::new([TypeParam::new_list_kind(TypeBound::Linear)], FuncValueType::new_endo(type_row![])))]
+#[case(PolyFuncTypeRV::new([TypeParam::new_tuple_kind([TypeBound::Linear.into(), TypeParam::bounded_nat_kind(2.try_into().unwrap())])], FuncValueType::new_endo(type_row![])))]
 #[case(PolyFuncTypeRV::new(
-    [TypeParam::new_list_type(TypeBound::Linear)],
+    [TypeParam::new_list_kind(TypeBound::Linear)],
     FuncValueType::new_endo(TypeRowRV::new_var_use(0, TypeBound::Linear))))]
 #[case(polyfunctype2())]
 fn roundtrip_polyfunctype_varlen(#[case] poly_func_type: PolyFuncTypeRV) {

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -493,7 +493,7 @@ fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 pub(crate) fn extension_with_eval_parallel() -> Arc<Extension> {
-    let rowp = TypeParam::new_list_type(TypeBound::Linear);
+    let rowp = TypeParam::new_list_kind(TypeBound::Linear);
     Extension::new_test_arc(EXT_ID, |ext, extension_ref| {
         let inputs = TypeRowRV::new_var_use(0, TypeBound::Linear);
         let outputs = TypeRowRV::new_var_use(1, TypeBound::Linear);
@@ -561,7 +561,7 @@ fn row_variables() -> Result<(), Box<dyn std::error::Error>> {
     let mut fb = FunctionBuilder::new(
         "id",
         PolyFuncType::new(
-            [TypeParam::new_list_type(TypeBound::Linear)],
+            [TypeParam::new_list_kind(TypeBound::Linear)],
             Signature::new([inner_ft.clone()], [ft_usz]),
         ),
     )?;

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -22,7 +22,7 @@ use crate::ops::handle::NodeHandle;
 use crate::ops::{self, FuncDecl, FuncDefn, OpType, Value};
 use crate::std_extensions::logic::LogicOp;
 use crate::std_extensions::logic::test::{and_op, or_op};
-use crate::types::type_param::{TermTypeError, TypeArg};
+use crate::types::type_param::{TermKindError, TypeArg};
 use crate::types::{
     CustomType, FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, Term, Type, TypeBound,
     TypeRow, TypeRowRV,
@@ -343,8 +343,8 @@ fn invalid_types() {
     );
     assert_eq!(
         validate_to_sig_error(element_outside_bound),
-        SignatureError::TypeArgMismatch(TermTypeError::TypeMismatch {
-            type_: Box::new(TypeBound::Copyable.into()),
+        SignatureError::TypeArgMismatch(TermKindError::KindMismatch {
+            kind: Box::new(TypeBound::Copyable.into()),
             term: Box::new(valid.into())
         })
     );
@@ -389,7 +389,7 @@ fn invalid_types() {
     );
     assert_eq!(
         validate_to_sig_error(too_many_type_args),
-        SignatureError::TypeArgMismatch(TermTypeError::WrongNumberArgs(2, 1))
+        SignatureError::TypeArgMismatch(TermKindError::WrongNumberArgs(2, 1))
     );
 }
 

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -460,7 +460,7 @@ fn no_nested_funcdefns() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
     use crate::std_extensions::collections::list;
-    const BOUND: TypeParam = TypeParam::RuntimeKind(TypeBound::Copyable);
+    const BOUND: TypeParam = TypeParam::TypeKind(TypeBound::Copyable);
     let list_of_var = Type::new_extension(
         list::EXTENSION
             .get_type(&list::LIST_TYPENAME)

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -460,7 +460,7 @@ fn no_nested_funcdefns() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn no_polymorphic_consts() -> Result<(), Box<dyn std::error::Error>> {
     use crate::std_extensions::collections::list;
-    const BOUND: TypeParam = TypeParam::RuntimeType(TypeBound::Copyable);
+    const BOUND: TypeParam = TypeParam::RuntimeKind(TypeBound::Copyable);
     let list_of_var = Type::new_extension(
         list::EXTENSION
             .get_type(&list::LIST_TYPENAME)

--- a/hugr-core/src/hugr/views/sibling_subgraph/tests.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph/tests.rs
@@ -192,14 +192,14 @@ fn test_signature() -> Result<(), InvalidSubgraph> {
 fn test_polymorphic_signature() -> Result<(), InvalidSubgraph> {
     let mut mod_builder = ModuleBuilder::new();
     let arr_type =
-        array_type_parametric(TypeArg::new_var_use(0, TypeParam::max_nat_type()), bool_t())
+        array_type_parametric(TypeArg::new_var_use(0, TypeParam::max_nat_kind()), bool_t())
             .unwrap();
     let func_id = {
         let mut h = mod_builder
             .define_function(
                 "test",
                 PolyFuncType::new(
-                    vec![TypeParam::max_nat_type()],
+                    vec![TypeParam::max_nat_kind()],
                     Signature::new_endo(vec![arr_type.clone()]),
                 ),
             )
@@ -220,7 +220,7 @@ fn test_polymorphic_signature() -> Result<(), InvalidSubgraph> {
     assert_eq!(
         sub.poly_func_type(&func),
         PolyFuncType::new(
-            vec![TypeParam::max_nat_type()],
+            vec![TypeParam::max_nat_kind()],
             Signature::new_endo(vec![arr_type]),
         ),
     );
@@ -231,14 +231,14 @@ fn test_polymorphic_signature() -> Result<(), InvalidSubgraph> {
 fn test_polymorphic_signature_nested() -> Result<(), InvalidSubgraph> {
     let mut mod_builder = ModuleBuilder::new();
     let arr_type =
-        array_type_parametric(TypeArg::new_var_use(0, TypeParam::max_nat_type()), bool_t())
+        array_type_parametric(TypeArg::new_var_use(0, TypeParam::max_nat_kind()), bool_t())
             .unwrap();
     let dfg_node = {
         let mut h = mod_builder
             .define_function(
                 "test",
                 PolyFuncType::new(
-                    vec![TypeParam::max_nat_type()],
+                    vec![TypeParam::max_nat_kind()],
                     Signature::new_endo(vec![arr_type.clone()]),
                 ),
             )
@@ -267,7 +267,7 @@ fn test_polymorphic_signature_nested() -> Result<(), InvalidSubgraph> {
     assert_eq!(
         sub.poly_func_type(&hugr),
         PolyFuncType::new(
-            vec![TypeParam::max_nat_type()],
+            vec![TypeParam::max_nat_kind()],
             Signature::new_endo(vec![arr_type]),
         ),
     );

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1457,7 +1457,7 @@ impl<'a> Context<'a> {
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_NAT_TYPE)? {
-                return Ok(Term::max_nat_type());
+                return Ok(Term::max_nat_kind());
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_BYTES_TYPE)? {
@@ -1493,7 +1493,7 @@ impl<'a> Context<'a> {
                 let item_type = self
                     .import_term(item_type)
                     .map_err(|err| error_context!(err, "item type of list type"))?;
-                return Ok(TypeParam::new_list_type(item_type));
+                return Ok(TypeParam::new_list_kind(item_type));
             }
 
             if let Some([item_types]) = self.match_symbol(term_id, model::CORE_TUPLE_TYPE)? {
@@ -1502,7 +1502,7 @@ impl<'a> Context<'a> {
                 let item_types = self
                     .import_term(item_types)
                     .map_err(|err| error_context!(err, "item types of tuple type"))?;
-                return Ok(TypeParam::new_tuple_type(item_types));
+                return Ok(TypeParam::new_tuple_kind(item_types));
             }
 
             if let Some([_, _]) = self.match_symbol(term_id, model::CORE_FN)? {

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1469,7 +1469,7 @@ impl<'a> Context<'a> {
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_TYPE)? {
-                return Ok(TypeParam::RuntimeKind(bound));
+                return Ok(TypeParam::TypeKind(bound));
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_CONSTRAINT)? {

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1453,7 +1453,7 @@ impl<'a> Context<'a> {
     ) -> Result<Term, ImportErrorInner> {
         (|| {
             if let Some([]) = self.match_symbol(term_id, model::CORE_STR_TYPE)? {
-                return Ok(Term::StringType);
+                return Ok(Term::StringKind);
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_NAT_TYPE)? {
@@ -1461,15 +1461,15 @@ impl<'a> Context<'a> {
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_BYTES_TYPE)? {
-                return Ok(Term::BytesType);
+                return Ok(Term::BytesKind);
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_FLOAT_TYPE)? {
-                return Ok(Term::FloatType);
+                return Ok(Term::FloatKind);
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_TYPE)? {
-                return Ok(TypeParam::RuntimeType(bound));
+                return Ok(TypeParam::RuntimeKind(bound));
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_CONSTRAINT)? {
@@ -1477,7 +1477,7 @@ impl<'a> Context<'a> {
             }
 
             if let Some([]) = self.match_symbol(term_id, model::CORE_STATIC)? {
-                return Ok(Term::StaticType);
+                return Ok(Term::StaticKind);
             }
 
             if let Some([ty]) = self.match_symbol(term_id, model::CORE_CONST)? {

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -1926,7 +1926,7 @@ impl<'a> Context<'a> {
                 .map(|(value, ty)| self.import_value(*value, *ty))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            let Term::RuntimeSum(ty) = self.import_term(type_id)? else {
+            let Term::SumType(ty) = self.import_term(type_id)? else {
                 unreachable!()
             };
 

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::envelope::description::{ExtensionDesc, GeneratorDesc, ModuleDesc};
 use crate::metadata::{self, Metadata, RawMetadataValue};
-use crate::types::type_param::{SeqPart, TermTypeError, TypeParam};
+use crate::types::type_param::{SeqPart, TermKindError, TypeParam};
 use crate::types::{
     CustomType, FuncTypeBase, PolyFuncType, Signature, Term, Type, TypeArg, TypeBound, TypeName,
     TypeRow, TypeRowLike, TypeRowRV,
@@ -112,8 +112,8 @@ enum ImportErrorInner {
     ExtensionResolution(#[from] ExtensionResolutionError),
 }
 
-impl From<TermTypeError> for ImportErrorInner {
-    fn from(err: TermTypeError) -> Self {
+impl From<TermKindError> for ImportErrorInner {
+    fn from(err: TermKindError) -> Self {
         SignatureError::from(err).into()
     }
 }

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -11,7 +11,7 @@ use crate::{
     ops::constant::CustomConst,
     types::{
         ConstTypeError, CustomType, Type, TypeBound,
-        type_param::{TermTypeError, TypeArg, TypeParam},
+        type_param::{TermKindError, TypeArg, TypeParam},
     },
 };
 /// The extension identifier.
@@ -75,12 +75,12 @@ pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::bounded_nat_kind({
 
 /// Get the log width  of the specified type argument or error if the argument
 /// is invalid.
-pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TermTypeError> {
+pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TermKindError> {
     match arg {
         TypeArg::BoundedNat(n) if is_valid_log_width(*n as u8) => Ok(*n as u8),
-        _ => Err(TermTypeError::TypeMismatch {
+        _ => Err(TermKindError::KindMismatch {
             term: Box::new(arg.clone()),
-            type_: Box::new(LOG_WIDTH_TYPE_PARAM),
+            kind: Box::new(LOG_WIDTH_TYPE_PARAM),
         }),
     }
 }
@@ -240,7 +240,7 @@ mod test {
         let type_arg_128 = TypeArg::BoundedNat(7);
         assert_matches!(
             get_log_width(&type_arg_128),
-            Err(TermTypeError::TypeMismatch { .. })
+            Err(TermKindError::KindMismatch { .. })
         );
     }
 

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -68,7 +68,7 @@ pub const LOG_WIDTH_BOUND: u8 = LOG_WIDTH_MAX + 1;
 
 /// Type parameter for the log width of the integer.
 #[allow(clippy::assertions_on_constants)]
-pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::bounded_nat_type({
+pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::bounded_nat_kind({
     assert!(LOG_WIDTH_BOUND > 0);
     NonZeroU64::MIN.saturating_add(LOG_WIDTH_BOUND as u64 - 1)
 });

--- a/hugr-core/src/std_extensions/collections/array.rs
+++ b/hugr-core/src/std_extensions/collections/array.rs
@@ -95,7 +95,7 @@ pub static EXTENSION: LazyLock<Arc<Extension>> = LazyLock::new(|| {
         extension
             .add_type(
                 ARRAY_TYPENAME,
-                vec![TypeParam::max_nat_type(), TypeBound::Linear.into()],
+                vec![TypeParam::max_nat_kind(), TypeBound::Linear.into()],
                 "Fixed-length array".into(),
                 // Default array is linear, even if the elements are copyable
                 TypeDefBound::any(),

--- a/hugr-core/src/std_extensions/collections/array/array_clone.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_clone.rs
@@ -51,8 +51,8 @@ impl<AK: ArrayKind> FromStr for GenericArrayCloneDef<AK> {
 impl<AK: ArrayKind> GenericArrayCloneDef<AK> {
     /// To avoid recursion when defining the extension, take the type definition as an argument.
     fn signature_from_def(&self, array_def: &TypeDef) -> SignatureFunc {
-        let params = vec![TypeParam::max_nat_type(), TypeBound::Copyable.into()];
-        let size = TypeArg::new_var_use(0, TypeParam::max_nat_type());
+        let params = vec![TypeParam::max_nat_kind(), TypeBound::Copyable.into()];
+        let size = TypeArg::new_var_use(0, TypeParam::max_nat_kind());
         let element_ty = Type::new_var_use(1, TypeBound::Copyable);
         let array_ty = AK::instantiate_ty(array_def, size, element_ty)
             .expect("Array type instantiation failed");

--- a/hugr-core/src/std_extensions/collections/array/array_conversion.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_conversion.rs
@@ -76,8 +76,8 @@ impl<AK: ArrayKind, const DIR: Direction, OtherAK: ArrayKind>
 {
     /// To avoid recursion when defining the extension, take the type definition as an argument.
     fn signature_from_def(&self, array_def: &TypeDef) -> SignatureFunc {
-        let params = vec![TypeParam::max_nat_type(), TypeBound::Linear.into()];
-        let size = TypeArg::new_var_use(0, TypeParam::max_nat_type());
+        let params = vec![TypeParam::max_nat_kind(), TypeBound::Linear.into()];
+        let size = TypeArg::new_var_use(0, TypeParam::max_nat_kind());
         let element_ty = Type::new_var_use(1, TypeBound::Linear);
 
         let this_ty = AK::instantiate_ty(array_def, size.clone(), element_ty.clone())

--- a/hugr-core/src/std_extensions/collections/array/array_discard.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_discard.rs
@@ -51,8 +51,8 @@ impl<AK: ArrayKind> FromStr for GenericArrayDiscardDef<AK> {
 impl<AK: ArrayKind> GenericArrayDiscardDef<AK> {
     /// To avoid recursion when defining the extension, take the type definition as an argument.
     fn signature_from_def(&self, array_def: &TypeDef) -> SignatureFunc {
-        let params = vec![TypeParam::max_nat_type(), TypeBound::Copyable.into()];
-        let size = TypeArg::new_var_use(0, TypeParam::max_nat_type());
+        let params = vec![TypeParam::max_nat_kind(), TypeBound::Copyable.into()];
+        let size = TypeArg::new_var_use(0, TypeParam::max_nat_kind());
         let element_ty = Type::new_var_use(1, TypeBound::Copyable);
         let array_ty = AK::instantiate_ty(array_def, size, element_ty)
             .expect("Array type instantiation failed");

--- a/hugr-core/src/std_extensions/collections/array/array_op.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_op.rs
@@ -65,7 +65,7 @@ pub enum GenericArrayOpDef<AK: ArrayKind> {
 }
 
 /// Static parameters for array operations. Includes array size. Type is part of the type scheme.
-const STATIC_SIZE_PARAM: &[TypeParam; 1] = &[TypeParam::max_nat_type()];
+const STATIC_SIZE_PARAM: &[TypeParam; 1] = &[TypeParam::max_nat_kind()];
 
 impl<AK: ArrayKind> SignatureFromArgs for GenericArrayOpDef<AK> {
     fn compute_signature(&self, arg_values: &[TypeArg]) -> Result<PolyFuncTypeRV, SignatureError> {
@@ -139,11 +139,11 @@ impl<AK: ArrayKind> GenericArrayOpDef<AK> {
             // signature computed dynamically, so can rely on type definition in extension.
             (*self).into()
         } else {
-            let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_type());
+            let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_kind());
             let elem_ty_var = Type::new_var_use(1, TypeBound::Linear);
             let array_ty = AK::instantiate_ty(array_def, size_var.clone(), elem_ty_var.clone())
                 .expect("Array type instantiation failed");
-            let standard_params = vec![TypeParam::max_nat_type(), TypeBound::Linear.into()];
+            let standard_params = vec![TypeParam::max_nat_kind(), TypeBound::Linear.into()];
 
             // We can assume that the prelude has ben loaded at this point,
             // since it doesn't depend on the array extension.
@@ -151,7 +151,7 @@ impl<AK: ArrayKind> GenericArrayOpDef<AK> {
 
             match self {
                 get => {
-                    let params = vec![TypeParam::max_nat_type(), TypeBound::Copyable.into()];
+                    let params = vec![TypeParam::max_nat_kind(), TypeBound::Copyable.into()];
                     let copy_elem_ty = Type::new_var_use(1, TypeBound::Copyable);
                     let copy_array_ty =
                         AK::instantiate_ty(array_def, size_var, copy_elem_ty.clone())

--- a/hugr-core/src/std_extensions/collections/array/array_repeat.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_repeat.rs
@@ -52,8 +52,8 @@ impl<AK: ArrayKind> FromStr for GenericArrayRepeatDef<AK> {
 impl<AK: ArrayKind> GenericArrayRepeatDef<AK> {
     /// To avoid recursion when defining the extension, take the type definition as an argument.
     fn signature_from_def(&self, array_def: &TypeDef) -> SignatureFunc {
-        let params = vec![TypeParam::max_nat_type(), TypeBound::Linear.into()];
-        let n = TypeArg::new_var_use(0, TypeParam::max_nat_type());
+        let params = vec![TypeParam::max_nat_kind(), TypeBound::Linear.into()];
+        let n = TypeArg::new_var_use(0, TypeParam::max_nat_kind());
         let t = Type::new_var_use(1, TypeBound::Linear);
         let func = Type::new_function(Signature::new(vec![], vec![t.clone()]));
         let array_ty =

--- a/hugr-core/src/std_extensions/collections/array/array_scan.rs
+++ b/hugr-core/src/std_extensions/collections/array/array_scan.rs
@@ -54,12 +54,12 @@ impl<AK: ArrayKind> GenericArrayScanDef<AK> {
     fn signature_from_def(&self, array_def: &TypeDef) -> SignatureFunc {
         // array<N, T1>, (T1, *A -> T2, *A), *A, -> array<N, T2>, *A
         let params = vec![
-            TypeParam::max_nat_type(),
+            TypeParam::max_nat_kind(),
             TypeBound::Linear.into(),
             TypeBound::Linear.into(),
-            TypeParam::new_list_type(TypeBound::Linear),
+            TypeParam::new_list_kind(TypeBound::Linear),
         ];
-        let n = TypeArg::new_var_use(0, TypeParam::max_nat_type());
+        let n = TypeArg::new_var_use(0, TypeParam::max_nat_kind());
         let t1 = Type::new_var_use(1, TypeBound::Linear);
         let t2 = Type::new_var_use(2, TypeBound::Linear);
         let with_rest = |tys: Vec<Type>| {

--- a/hugr-core/src/std_extensions/collections/borrow_array.rs
+++ b/hugr-core/src/std_extensions/collections/borrow_array.rs
@@ -139,14 +139,14 @@ impl BArrayUnsafeOpDef {
     }
 
     fn signature_from_def(&self, def: &TypeDef, _: &sync::Weak<Extension>) -> SignatureFunc {
-        let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_type());
+        let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_kind());
         let elem_ty_var = Type::new_var_use(1, TypeBound::Linear);
         let array_ty: Type = def
             .instantiate(vec![size_var, elem_ty_var.clone().into()])
             .unwrap()
             .into();
 
-        let params = vec![TypeParam::max_nat_type(), TypeBound::Linear.into()];
+        let params = vec![TypeParam::max_nat_kind(), TypeBound::Linear.into()];
 
         let usize_t: Type = usize_t();
 
@@ -305,7 +305,7 @@ pub static EXTENSION: LazyLock<Arc<Extension>> = LazyLock::new(|| {
         extension
             .add_type(
                 BORROW_ARRAY_TYPENAME,
-                vec![TypeParam::max_nat_type(), TypeBound::Linear.into()],
+                vec![TypeParam::max_nat_kind(), TypeBound::Linear.into()],
                 "Fixed-length borrow array".into(),
                 // Borrow array is linear, even if the elements are copyable.
                 TypeDefBound::any(),

--- a/hugr-core/src/std_extensions/collections/list.rs
+++ b/hugr-core/src/std_extensions/collections/list.rs
@@ -167,7 +167,7 @@ pub enum ListOp {
 
 impl ListOp {
     /// Type parameter used in the list types.
-    const TP: TypeParam = TypeParam::RuntimeType(TypeBound::Linear);
+    const TP: TypeParam = TypeParam::RuntimeKind(TypeBound::Linear);
 
     /// Instantiate a list operation with an `element_type`.
     #[must_use]

--- a/hugr-core/src/std_extensions/collections/list.rs
+++ b/hugr-core/src/std_extensions/collections/list.rs
@@ -167,7 +167,7 @@ pub enum ListOp {
 
 impl ListOp {
     /// Type parameter used in the list types.
-    const TP: TypeParam = TypeParam::RuntimeKind(TypeBound::Linear);
+    const TP: TypeParam = TypeParam::TypeKind(TypeBound::Linear);
 
     /// Instantiate a list operation with an `element_type`.
     #[must_use]

--- a/hugr-core/src/std_extensions/collections/static_array.rs
+++ b/hugr-core/src/std_extensions/collections/static_array.rs
@@ -38,7 +38,7 @@ use crate::{
     types::{
         ConstTypeError, CustomCheckFailure, CustomType, PolyFuncType, Signature, Type, TypeArg,
         TypeBound, TypeName,
-        type_param::{TermTypeError, TypeParam},
+        type_param::{TermKindError, TypeParam},
     },
 };
 
@@ -311,8 +311,8 @@ impl HasConcrete for StaticArrayOpDef {
         match type_args {
             [arg] => {
                 if !arg.copyable() {
-                    Err(SignatureError::from(TermTypeError::TypeMismatch {
-                        type_: Box::new(Copyable.into()),
+                    Err(SignatureError::from(TermKindError::KindMismatch {
+                        kind: Box::new(Copyable.into()),
                         term: Box::new(arg.clone()),
                     }))?
                 }
@@ -324,7 +324,7 @@ impl HasConcrete for StaticArrayOpDef {
                 })
             }
             _ => Err(
-                SignatureError::TypeArgMismatch(TermTypeError::WrongNumberArgs(type_args.len(), 1))
+                SignatureError::TypeArgMismatch(TermKindError::WrongNumberArgs(type_args.len(), 1))
                     .into(),
             ),
         }

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -88,7 +88,7 @@ impl MakeOpDef for PtrOpDef {
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("ptr");
 /// Name of pointer type.
 pub const PTR_TYPE_ID: TypeName = TypeName::new_inline("ptr");
-const TYPE_PARAMS: [TypeParam; 1] = [TypeParam::RuntimeType(TypeBound::Copyable)];
+const TYPE_PARAMS: [TypeParam; 1] = [TypeParam::RuntimeKind(TypeBound::Copyable)];
 /// Extension version.
 pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 

--- a/hugr-core/src/std_extensions/ptr.rs
+++ b/hugr-core/src/std_extensions/ptr.rs
@@ -88,7 +88,7 @@ impl MakeOpDef for PtrOpDef {
 pub const EXTENSION_ID: ExtensionId = ExtensionId::new_unchecked("ptr");
 /// Name of pointer type.
 pub const PTR_TYPE_ID: TypeName = TypeName::new_inline("ptr");
-const TYPE_PARAMS: [TypeParam; 1] = [TypeParam::RuntimeKind(TypeBound::Copyable)];
+const TYPE_PARAMS: [TypeParam; 1] = [TypeParam::TypeKind(TypeBound::Copyable)];
 /// Extension version.
 pub const VERSION: semver::Version = semver::Version::new(0, 1, 0);
 

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -12,7 +12,7 @@ use crate::extension::resolution::{
     ExtensionCollectionError, WeakExtensionRegistry, collect_term_exts,
 };
 pub use crate::ops::constant::{ConstTypeError, CustomCheckFailure};
-use crate::types::type_param::{TermTypeError, check_term_kind};
+use crate::types::type_param::{TermKindError, check_term_kind};
 use crate::utils::display_list_with_separator;
 pub use check::SumTypeError;
 pub use custom::CustomType;
@@ -503,14 +503,14 @@ impl Deref for Type {
 }
 
 impl TryFrom<Term> for Type {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
-    fn try_from(t: Term) -> Result<Self, TermTypeError> {
+    fn try_from(t: Term) -> Result<Self, TermKindError> {
         match t.least_upper_bound() {
             Some(b) => Ok(Self(t, b)),
-            None => Err(TermTypeError::TypeMismatch {
+            None => Err(TermKindError::KindMismatch {
                 term: Box::new(t),
-                type_: Box::new(TypeBound::Linear.into()),
+                kind: Box::new(TypeBound::Linear.into()),
             }),
         }
     }
@@ -608,7 +608,7 @@ pub(crate) mod test {
     use crate::extension::prelude::{option_type, qb_t, usize_t};
     use crate::std_extensions::collections::array::{array_type, array_type_parametric};
     use crate::std_extensions::collections::list::list_type;
-    use crate::types::type_param::TermTypeError;
+    use crate::types::type_param::TermKindError;
     use crate::{Extension, hugr::IdentList, type_row};
 
     #[test]
@@ -783,8 +783,8 @@ pub(crate) mod test {
         let mut t = Type::new_extension(c_of_cpy.clone());
         assert_eq!(
             t.transform(&cpy_to_qb),
-            Err(SignatureError::from(TermTypeError::TypeMismatch {
-                type_: Box::new(TypeBound::Copyable.into()),
+            Err(SignatureError::from(TermKindError::KindMismatch {
+                kind: Box::new(TypeBound::Copyable.into()),
                 term: Box::new(qb_t().into())
             }))
         );
@@ -795,8 +795,8 @@ pub(crate) mod test {
         );
         assert_eq!(
             t.transform(&cpy_to_qb),
-            Err(SignatureError::from(TermTypeError::TypeMismatch {
-                type_: Box::new(TypeBound::Copyable.into()),
+            Err(SignatureError::from(TermKindError::KindMismatch {
+                kind: Box::new(TypeBound::Copyable.into()),
                 term: Box::new(mk_opt(qb_t()).into())
             }))
         );

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -275,7 +275,7 @@ impl SumType {
     }
 
     /// If the sum matches the convention of `Option[row]`, return the row
-    /// (an instance of [Term::ListType]([Term::RuntimeType]).
+    /// (an instance of [Term::ListKind]([Term::RuntimeKind]).
     #[must_use]
     pub fn as_option(&self) -> Option<&TypeRowRV> {
         match self {
@@ -420,7 +420,7 @@ impl Type {
 
     /// New use (occurrence) of the type variable with specified index.
     /// `bound` must be exactly that with which the variable was declared
-    /// (i.e. as a [`Term::RuntimeType`]`(bound)`), which may be narrower
+    /// (i.e. as a [`Term::RuntimeKind`]`(bound)`), which may be narrower
     /// than required for the use.
     #[must_use]
     pub fn new_var_use(idx: usize, bound: TypeBound) -> Self {

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -275,7 +275,7 @@ impl SumType {
     }
 
     /// If the sum matches the convention of `Option[row]`, return the row
-    /// (an instance of [Term::ListKind]([Term::RuntimeKind]).
+    /// (an instance of [Term::ListKind]([Term::TypeKind]).
     #[must_use]
     pub fn as_option(&self) -> Option<&TypeRowRV> {
         match self {
@@ -420,7 +420,7 @@ impl Type {
 
     /// New use (occurrence) of the type variable with specified index.
     /// `bound` must be exactly that with which the variable was declared
-    /// (i.e. as a [`Term::RuntimeKind`]`(bound)`), which may be narrower
+    /// (i.e. as a [`Term::TypeKind`]`(bound)`), which may be narrower
     /// than required for the use.
     #[must_use]
     pub fn new_var_use(idx: usize, bound: TypeBound) -> Self {

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -301,7 +301,7 @@ impl SumType {
             SumType::General { rows } => {
                 if rows
                     .iter()
-                    .all(|t| check_term_kind(t, &Term::new_list_type(TypeBound::Copyable)).is_ok())
+                    .all(|t| check_term_kind(t, &Term::new_list_kind(TypeBound::Copyable)).is_ok())
                 {
                     TypeBound::Copyable
                 } else {
@@ -734,7 +734,7 @@ pub(crate) mod test {
             |t| array_type(10, t),
             |t| {
                 array_type_parametric(
-                    TypeArg::new_var_use(0, TypeParam::bounded_nat_type(3.try_into().unwrap())),
+                    TypeArg::new_var_use(0, TypeParam::bounded_nat_kind(3.try_into().unwrap())),
                     t,
                 )
                 .unwrap()
@@ -758,7 +758,7 @@ pub(crate) mod test {
                 .unwrap();
             e.add_type(
                 COLN,
-                vec![TypeParam::new_list_type(TypeBound::Copyable)],
+                vec![TypeParam::new_list_kind(TypeBound::Copyable)],
                 String::new(),
                 TypeDefBound::copyable(),
                 w,

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -367,14 +367,14 @@ impl Type {
     pub const EMPTY_TYPEROW: TypeRow = TypeRow::new();
     /// Unit type (empty tuple).
     pub const UNIT: Self = Self(
-        Term::RuntimeSum(SumType::Unit { size: 1 }),
+        Term::SumType(SumType::Unit { size: 1 }),
         TypeBound::Copyable,
     );
 
     /// Initialize a new function type.
     pub fn new_function(fun_ty: impl Into<FuncValueType>) -> Self {
         Self(
-            Term::RuntimeFunction(Box::new(fun_ty.into())),
+            Term::FunctionType(Box::new(fun_ty.into())),
             TypeBound::Copyable,
         )
     }
@@ -397,7 +397,7 @@ impl Type {
     {
         let st = SumType::new(variants);
         let b = st.bound();
-        Self(Term::RuntimeSum(st), b)
+        Self(Term::SumType(st), b)
     }
 
     /// Initialize a new custom type.
@@ -405,17 +405,14 @@ impl Type {
     #[must_use]
     pub const fn new_extension(opaque: CustomType) -> Self {
         let bound = opaque.bound();
-        Self(Term::RuntimeExtension(opaque), bound)
+        Self(Term::ExtensionType(opaque), bound)
     }
 
     /// New `UnitSum` with empty Tuple variants
     #[must_use]
     pub const fn new_unit_sum(size: u8) -> Self {
         // should be the only way to avoid going through SumType::new
-        Self(
-            Term::RuntimeSum(SumType::new_unary(size)),
-            TypeBound::Copyable,
-        )
+        Self(Term::SumType(SumType::new_unary(size)), TypeBound::Copyable)
     }
 
     /// New use (occurrence) of the type variable with specified index.

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -12,7 +12,7 @@ use crate::extension::resolution::{
     ExtensionCollectionError, WeakExtensionRegistry, collect_term_exts,
 };
 pub use crate::ops::constant::{ConstTypeError, CustomCheckFailure};
-use crate::types::type_param::{TermTypeError, check_term_type};
+use crate::types::type_param::{TermTypeError, check_term_kind};
 use crate::utils::display_list_with_separator;
 pub use check::SumTypeError;
 pub use custom::CustomType;
@@ -301,7 +301,7 @@ impl SumType {
             SumType::General { rows } => {
                 if rows
                     .iter()
-                    .all(|t| check_term_type(t, &Term::new_list_type(TypeBound::Copyable)).is_ok())
+                    .all(|t| check_term_kind(t, &Term::new_list_type(TypeBound::Copyable)).is_ok())
                 {
                     TypeBound::Copyable
                 } else {
@@ -448,10 +448,10 @@ impl Type {
         // ALAN even this should be only a debug-assert really:
         // we have no unchecked access from outside crate::types
         // so it must be a bug in our caching logic if this is wrong:
-        check_term_type(&self.0, &self.1.into())?;
+        check_term_kind(&self.0, &self.1.into())?;
         debug_assert!(
             self.1 == TypeBound::Copyable
-                || check_term_type(&self.0, &TypeBound::Copyable.into()).is_err()
+                || check_term_kind(&self.0, &TypeBound::Copyable.into()).is_err()
         );
         Ok(())
     }
@@ -545,7 +545,7 @@ impl<'a> Substitution<'a> {
             .0
             .get(idx)
             .expect("Undeclared type variable - call validate() ?");
-        debug_assert_eq!(check_term_type(arg, decl), Ok(()));
+        debug_assert_eq!(check_term_kind(arg, decl), Ok(()));
         arg.clone()
     }
 }

--- a/hugr-core/src/types/check.rs
+++ b/hugr-core/src/types/check.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use super::{Type, TypeRow};
 use crate::{
     ops::Value,
-    types::{Term, type_param::TermTypeError},
+    types::{Term, type_param::TermKindError},
 };
 
 /// Errors that arise from typechecking constants
@@ -72,7 +72,7 @@ impl super::SumType {
                 num_variants: self.num_variants(),
             })?;
         let variant: TypeRow = variant.clone().try_into().map_err(|e| {
-            let TermTypeError::TypeMismatch { term, .. } = e else {
+            let TermKindError::KindMismatch { term, .. } = e else {
                 panic!("Unexpected error {e}")
             };
             let Term::Variable(tv) = &*term else {

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -162,7 +162,7 @@ pub(crate) mod test {
     use crate::std_extensions::collections::array::{self, array_type_parametric};
     use crate::std_extensions::collections::list;
     use crate::types::signature::FuncTypeBase;
-    use crate::types::type_param::{TermTypeError, TypeArg, TypeParam};
+    use crate::types::type_param::{TermKindError, TypeArg, TypeParam};
     use crate::types::{
         CustomType, FuncValueType, PolyFuncTypeBase, Signature, Term, Type, TypeBound, TypeName,
         TypeRowLike, TypeRowRV,
@@ -250,16 +250,16 @@ pub(crate) mod test {
         assert_eq!(
             wrong_args,
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::TypeMismatch {
-                    type_: Box::new(type_params[0].clone()),
+                TermKindError::KindMismatch {
+                    kind: Box::new(type_params[0].clone()),
                     term: Box::new(usize_t().into()),
                 }
             ))
         );
 
         // (Try to) make a schema with the args in the wrong order
-        let arg_err = SignatureError::TypeArgMismatch(TermTypeError::TypeMismatch {
-            type_: Box::new(type_params[0].clone()),
+        let arg_err = SignatureError::TypeArgMismatch(TermKindError::KindMismatch {
+            kind: Box::new(type_params[0].clone()),
             term: Box::new(ty_var.clone()),
         });
         assert_eq!(
@@ -355,8 +355,8 @@ pub(crate) mod test {
             assert_eq!(
                 make_scheme(decl.clone()).err(),
                 Some(SignatureError::TypeArgMismatch(
-                    TermTypeError::TypeMismatch {
-                        type_: Box::new(bound.clone()),
+                    TermKindError::KindMismatch {
+                        kind: Box::new(bound.clone()),
                         term: Box::new(TypeArg::new_var_use(0, decl.clone()))
                     }
                 ))

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -392,7 +392,7 @@ pub(crate) mod test {
         Ok(())
     }
 
-    const TP_ANY: TypeParam = TypeParam::RuntimeKind(TypeBound::Linear);
+    const TP_ANY: TypeParam = TypeParam::TypeKind(TypeBound::Linear);
     #[test]
     fn row_variables_bad_schema() {
         // Mismatched TypeBound (Copyable vs Any)

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -232,9 +232,9 @@ pub(crate) mod test {
 
     #[test]
     fn test_mismatched_args() -> Result<(), SignatureError> {
-        let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_type());
+        let size_var = TypeArg::new_var_use(0, TypeParam::max_nat_kind());
         let ty_var = TypeArg::new_var_use(1, TypeBound::Linear);
-        let type_params = [TypeParam::max_nat_type(), TypeBound::Linear.into()];
+        let type_params = [TypeParam::max_nat_kind(), TypeBound::Linear.into()];
 
         // Valid schema...
         let good_array = array_type_parametric(size_var.clone(), ty_var.clone())?;
@@ -288,9 +288,9 @@ pub(crate) mod test {
         let list_def = list::EXTENSION.get_type(&list::LIST_TYPENAME).unwrap();
         let body_type = Signature::new_endo([Type::new_extension(list_def.instantiate([tv])?)]);
         for decl in [
-            Term::new_list_type(Term::max_nat_type()),
+            Term::new_list_kind(Term::max_nat_kind()),
             Term::StringKind,
-            Term::new_tuple_type([TypeBound::Linear.into(), Term::max_nat_type()]),
+            Term::new_tuple_kind([TypeBound::Linear.into(), Term::max_nat_kind()]),
         ] {
             let invalid_ts = PolyFuncTypeBase::new_validated([decl.clone()], body_type.clone());
             assert_eq!(
@@ -374,20 +374,20 @@ pub(crate) mod test {
         )?;
 
         decl_accepts_rejects_var(
-            Term::new_list_type(TypeBound::Copyable),
-            &[Term::new_list_type(TypeBound::Copyable)],
-            &[Term::new_list_type(TypeBound::Linear)],
+            Term::new_list_kind(TypeBound::Copyable),
+            &[Term::new_list_kind(TypeBound::Copyable)],
+            &[Term::new_list_kind(TypeBound::Linear)],
         )?;
 
         decl_accepts_rejects_var(
-            TypeParam::max_nat_type(),
-            &[TypeParam::bounded_nat_type(NonZeroU64::new(5).unwrap())],
+            TypeParam::max_nat_kind(),
+            &[TypeParam::bounded_nat_kind(NonZeroU64::new(5).unwrap())],
             &[],
         )?;
         decl_accepts_rejects_var(
-            TypeParam::bounded_nat_type(NonZeroU64::new(10).unwrap()),
-            &[TypeParam::bounded_nat_type(NonZeroU64::new(5).unwrap())],
-            &[TypeParam::max_nat_type()],
+            TypeParam::bounded_nat_kind(NonZeroU64::new(10).unwrap()),
+            &[TypeParam::bounded_nat_kind(NonZeroU64::new(5).unwrap())],
+            &[TypeParam::max_nat_kind()],
         )?;
         Ok(())
     }
@@ -396,7 +396,7 @@ pub(crate) mod test {
     #[test]
     fn row_variables_bad_schema() {
         // Mismatched TypeBound (Copyable vs Any)
-        let decl = Term::new_list_type(TP_ANY);
+        let decl = Term::new_list_kind(TP_ANY);
         let e = PolyFuncTypeBase::new_validated(
             [decl.clone()],
             FuncValueType::new([usize_t()], TypeRowRV::new_var_use(0, TypeBound::Copyable)),
@@ -404,7 +404,7 @@ pub(crate) mod test {
         .unwrap_err();
         assert_matches!(e, SignatureError::TypeVarDoesNotMatchDeclaration { actual, cached } => {
             assert_eq!(*actual, decl);
-            assert_eq!(*cached, TypeParam::new_list_type(TypeBound::Copyable));
+            assert_eq!(*cached, TypeParam::new_list_kind(TypeBound::Copyable));
         });
         // Declared as row variable, used as type variable
         let e = PolyFuncTypeBase::new_validated(
@@ -422,7 +422,7 @@ pub(crate) mod test {
     fn row_variables() {
         let rty = TypeRowRV::new_var_use(0, TypeBound::Linear);
         let pf = PolyFuncTypeBase::new_validated(
-            [TypeParam::new_list_type(TP_ANY)],
+            [TypeParam::new_list_kind(TP_ANY)],
             FuncValueType::new(
                 TypeRowRV::from([usize_t()]).concat(rty.clone()),
                 [Type::new_tuple(rty)],
@@ -454,7 +454,7 @@ pub(crate) mod test {
             TypeBound::Copyable,
         )));
         let pf = PolyFuncTypeBase::new_validated(
-            [Term::new_list_type(TypeBound::Copyable)],
+            [Term::new_list_kind(TypeBound::Copyable)],
             Signature::new(vec![usize_t(), inner_fty.clone()], vec![inner_fty]),
         )
         .unwrap();

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -11,7 +11,7 @@ use crate::{
 
 use super::Substitution;
 use super::signature::FuncTypeBase;
-use super::type_param::{TypeArg, TypeParam, check_term_types};
+use super::type_param::{TypeArg, TypeParam, check_term_kinds};
 
 /// A polymorphic type scheme, i.e. of a [`FuncDecl`], [`FuncDefn`] or [`OpDef`].
 /// (Nodes/operations in the Hugr are not polymorphic.)
@@ -130,7 +130,7 @@ impl<T: TypeRowLike> PolyFuncTypeBase<T> {
     pub fn instantiate(&self, args: &[TypeArg]) -> Result<FuncTypeBase<T>, SignatureError> {
         // Check that args are applicable, and that we have a value for each binder,
         // i.e. each possible free variable within the body.
-        check_term_types(args, &self.params)?;
+        check_term_kinds(args, &self.params)?;
         Ok(self.body.substitute(&Substitution(args)))
     }
 

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -289,7 +289,7 @@ pub(crate) mod test {
         let body_type = Signature::new_endo([Type::new_extension(list_def.instantiate([tv])?)]);
         for decl in [
             Term::new_list_type(Term::max_nat_type()),
-            Term::StringType,
+            Term::StringKind,
             Term::new_tuple_type([TypeBound::Linear.into(), Term::max_nat_type()]),
         ] {
             let invalid_ts = PolyFuncTypeBase::new_validated([decl.clone()], body_type.clone());
@@ -392,7 +392,7 @@ pub(crate) mod test {
         Ok(())
     }
 
-    const TP_ANY: TypeParam = TypeParam::RuntimeType(TypeBound::Linear);
+    const TP_ANY: TypeParam = TypeParam::RuntimeKind(TypeBound::Linear);
     #[test]
     fn row_variables_bad_schema() {
         // Mismatched TypeBound (Copyable vs Any)

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -10,7 +10,7 @@ use super::custom::CustomType;
 use crate::extension::prelude::{qb_t, usize_t};
 use crate::ops::AliasDecl;
 use crate::types::TypeRowRV;
-use crate::types::type_param::{SeqPart, TermTypeError, TermVar, UpperBound};
+use crate::types::type_param::{SeqPart, TermKindError, TermVar, UpperBound};
 
 #[derive(Serialize, serde::Deserialize, Clone, Debug)]
 #[serde(tag = "t")]
@@ -51,7 +51,7 @@ impl From<Type> for SerSimpleType {
 
 // Row Variables can also be serialized as "simple types"
 impl TryFrom<Term> for SerSimpleType {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
         if let Term::Variable(tv) = &value
@@ -83,7 +83,7 @@ impl From<SerSimpleType> for Term {
 }
 
 impl TryFrom<SerSimpleType> for Type {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: SerSimpleType) -> Result<Self, Self::Error> {
         Term::from(value).try_into()

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -34,8 +34,8 @@ impl From<Type> for SerSimpleType {
             return SerSimpleType::I;
         }
         match value.into() {
-            Term::RuntimeExtension(o) => SerSimpleType::Opaque(o),
-            Term::RuntimeFunction(sig) => SerSimpleType::G(sig),
+            Term::ExtensionType(o) => SerSimpleType::Opaque(o),
+            Term::FunctionType(sig) => SerSimpleType::G(sig),
             Term::Variable(tv) => {
                 let i = tv.index();
                 let Term::TypeKind(b) = &*tv.cached_decl else {
@@ -43,7 +43,7 @@ impl From<Type> for SerSimpleType {
                 };
                 SerSimpleType::V { i, b: *b }
             }
-            Term::RuntimeSum(st) => SerSimpleType::Sum(st),
+            Term::SumType(st) => SerSimpleType::Sum(st),
             v => panic!("{} was not a valid Type", v),
         }
     }
@@ -161,7 +161,7 @@ impl From<Term> for TermSer {
             Term::FloatKind => TermSer::TypeParam(TypeParamSer::Float),
             Term::ListKind(param) => TermSer::TypeParam(TypeParamSer::List { param }),
             Term::ConstKind(ty) => TermSer::TypeParam(TypeParamSer::ConstType { ty: *ty }),
-            Term::RuntimeFunction(_) | Term::RuntimeExtension(_) | Term::RuntimeSum(_) => {
+            Term::FunctionType(_) | Term::ExtensionType(_) | Term::SumType(_) => {
                 TermSer::TypeArg(TypeArgSer::Type {
                     ty: value.try_into().unwrap(),
                 })

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -38,7 +38,7 @@ impl From<Type> for SerSimpleType {
             Term::RuntimeFunction(sig) => SerSimpleType::G(sig),
             Term::Variable(tv) => {
                 let i = tv.index();
-                let Term::RuntimeKind(b) = &*tv.cached_decl else {
+                let Term::TypeKind(b) = &*tv.cached_decl else {
                     panic!("Variable with bound {} is not a valid Type", tv.cached_decl);
                 };
                 SerSimpleType::V { i, b: *b }
@@ -56,7 +56,7 @@ impl TryFrom<Term> for SerSimpleType {
     fn try_from(value: Term) -> Result<Self, Self::Error> {
         if let Term::Variable(tv) = &value
             && let Term::ListKind(t) = &*tv.cached_decl
-            && let Term::RuntimeKind(b) = &**t
+            && let Term::TypeKind(b) = &**t
         {
             return Ok(SerSimpleType::R {
                 i: tv.index(),
@@ -153,7 +153,7 @@ pub(super) enum TermSer {
 impl From<Term> for TermSer {
     fn from(value: Term) -> Self {
         match value {
-            Term::RuntimeKind(b) => TermSer::TypeParam(TypeParamSer::Type { b }),
+            Term::TypeKind(b) => TermSer::TypeParam(TypeParamSer::Type { b }),
             Term::StaticKind => TermSer::TypeParam(TypeParamSer::StaticType),
             Term::BoundedNatKind(bound) => TermSer::TypeParam(TypeParamSer::BoundedNat { bound }),
             Term::StringKind => TermSer::TypeParam(TypeParamSer::String),
@@ -175,7 +175,7 @@ impl From<Term> for TermSer {
             Term::Float(value) => TermSer::TypeArg(TypeArgSer::Float { value }),
             Term::List(elems) => TermSer::TypeArg(TypeArgSer::List { elems }),
             Term::Tuple(elems) => TermSer::TypeArg(TypeArgSer::Tuple { elems }),
-            Term::Variable(ref v) if matches!(&*v.cached_decl, Term::RuntimeKind(_)) => {
+            Term::Variable(ref v) if matches!(&*v.cached_decl, Term::TypeKind(_)) => {
                 TermSer::TypeArg(TypeArgSer::Type {
                     ty: value.try_into().unwrap(),
                 })
@@ -192,7 +192,7 @@ impl From<TermSer> for Term {
     fn from(value: TermSer) -> Self {
         match value {
             TermSer::TypeParam(param) => match param {
-                TypeParamSer::Type { b } => Term::RuntimeKind(b),
+                TypeParamSer::Type { b } => Term::TypeKind(b),
                 TypeParamSer::StaticType => Term::StaticKind,
                 TypeParamSer::BoundedNat { bound } => Term::BoundedNatKind(bound),
                 TypeParamSer::String => Term::StringKind,

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -38,7 +38,7 @@ impl From<Type> for SerSimpleType {
             Term::RuntimeFunction(sig) => SerSimpleType::G(sig),
             Term::Variable(tv) => {
                 let i = tv.index();
-                let Term::RuntimeType(b) = &*tv.cached_decl else {
+                let Term::RuntimeKind(b) = &*tv.cached_decl else {
                     panic!("Variable with bound {} is not a valid Type", tv.cached_decl);
                 };
                 SerSimpleType::V { i, b: *b }
@@ -55,8 +55,8 @@ impl TryFrom<Term> for SerSimpleType {
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
         if let Term::Variable(tv) = &value
-            && let Term::ListType(t) = &*tv.cached_decl
-            && let Term::RuntimeType(b) = &**t
+            && let Term::ListKind(t) = &*tv.cached_decl
+            && let Term::RuntimeKind(b) = &**t
         {
             return Ok(SerSimpleType::R {
                 i: tv.index(),
@@ -153,20 +153,20 @@ pub(super) enum TermSer {
 impl From<Term> for TermSer {
     fn from(value: Term) -> Self {
         match value {
-            Term::RuntimeType(b) => TermSer::TypeParam(TypeParamSer::Type { b }),
-            Term::StaticType => TermSer::TypeParam(TypeParamSer::StaticType),
-            Term::BoundedNatType(bound) => TermSer::TypeParam(TypeParamSer::BoundedNat { bound }),
-            Term::StringType => TermSer::TypeParam(TypeParamSer::String),
-            Term::BytesType => TermSer::TypeParam(TypeParamSer::Bytes),
-            Term::FloatType => TermSer::TypeParam(TypeParamSer::Float),
-            Term::ListType(param) => TermSer::TypeParam(TypeParamSer::List { param }),
-            Term::ConstType(ty) => TermSer::TypeParam(TypeParamSer::ConstType { ty: *ty }),
+            Term::RuntimeKind(b) => TermSer::TypeParam(TypeParamSer::Type { b }),
+            Term::StaticKind => TermSer::TypeParam(TypeParamSer::StaticType),
+            Term::BoundedNatKind(bound) => TermSer::TypeParam(TypeParamSer::BoundedNat { bound }),
+            Term::StringKind => TermSer::TypeParam(TypeParamSer::String),
+            Term::BytesKind => TermSer::TypeParam(TypeParamSer::Bytes),
+            Term::FloatKind => TermSer::TypeParam(TypeParamSer::Float),
+            Term::ListKind(param) => TermSer::TypeParam(TypeParamSer::List { param }),
+            Term::ConstKind(ty) => TermSer::TypeParam(TypeParamSer::ConstType { ty: *ty }),
             Term::RuntimeFunction(_) | Term::RuntimeExtension(_) | Term::RuntimeSum(_) => {
                 TermSer::TypeArg(TypeArgSer::Type {
                     ty: value.try_into().unwrap(),
                 })
             }
-            Term::TupleType(params) => TermSer::TypeParam(TypeParamSer::Tuple {
+            Term::TupleKind(params) => TermSer::TypeParam(TypeParamSer::Tuple {
                 params: (*params).into(),
             }),
             Term::BoundedNat(n) => TermSer::TypeArg(TypeArgSer::BoundedNat { n }),
@@ -175,7 +175,7 @@ impl From<Term> for TermSer {
             Term::Float(value) => TermSer::TypeArg(TypeArgSer::Float { value }),
             Term::List(elems) => TermSer::TypeArg(TypeArgSer::List { elems }),
             Term::Tuple(elems) => TermSer::TypeArg(TypeArgSer::Tuple { elems }),
-            Term::Variable(ref v) if matches!(&*v.cached_decl, Term::RuntimeType(_)) => {
+            Term::Variable(ref v) if matches!(&*v.cached_decl, Term::RuntimeKind(_)) => {
                 TermSer::TypeArg(TypeArgSer::Type {
                     ty: value.try_into().unwrap(),
                 })
@@ -192,15 +192,15 @@ impl From<TermSer> for Term {
     fn from(value: TermSer) -> Self {
         match value {
             TermSer::TypeParam(param) => match param {
-                TypeParamSer::Type { b } => Term::RuntimeType(b),
-                TypeParamSer::StaticType => Term::StaticType,
-                TypeParamSer::BoundedNat { bound } => Term::BoundedNatType(bound),
-                TypeParamSer::String => Term::StringType,
-                TypeParamSer::Bytes => Term::BytesType,
-                TypeParamSer::Float => Term::FloatType,
-                TypeParamSer::List { param } => Term::ListType(param),
-                TypeParamSer::Tuple { params } => Term::TupleType(Box::new(params.into())),
-                TypeParamSer::ConstType { ty } => Term::ConstType(Box::new(ty)),
+                TypeParamSer::Type { b } => Term::RuntimeKind(b),
+                TypeParamSer::StaticType => Term::StaticKind,
+                TypeParamSer::BoundedNat { bound } => Term::BoundedNatKind(bound),
+                TypeParamSer::String => Term::StringKind,
+                TypeParamSer::Bytes => Term::BytesKind,
+                TypeParamSer::Float => Term::FloatKind,
+                TypeParamSer::List { param } => Term::ListKind(param),
+                TypeParamSer::Tuple { params } => Term::TupleKind(Box::new(params.into())),
+                TypeParamSer::ConstType { ty } => Term::ConstKind(Box::new(ty)),
             },
             TermSer::TypeArg(arg) => match arg {
                 TypeArgSer::Type { ty } => Term::from(ty),

--- a/hugr-core/src/types/signature.rs
+++ b/hugr-core/src/types/signature.rs
@@ -357,7 +357,7 @@ mod test {
 
     #[test]
     fn test_transform() {
-        let Term::RuntimeExtension(usz_t) = usize_t().into() else {
+        let Term::ExtensionType(usz_t) = usize_t().into() else {
             panic!()
         };
         let tr = FnTransformer(|ct: &CustomType| (ct == &usz_t).then_some(bool_t()));

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -53,7 +53,7 @@ impl UpperBound {
 /// A [`Term`] that is a static argument to an operation or constructor.
 pub type TypeArg = Term;
 
-/// A [`Term`] that is the static type of an operation or constructor parameter.
+/// A [`Term`] that is the static kind of an operation or constructor parameter.
 pub type TypeParam = Term;
 
 /// The main entity in the static language (aka "type system") of Hugr.
@@ -68,8 +68,8 @@ pub type TypeParam = Term;
 /// with a [Term::Float] argument. [`check_term_kind`] checks that an argument
 /// is valid (of the correct kind) for the parameter.
 // TODO it might be good to have a separate function that tells, for a given Term,
-// whether there is *any* valid argument; we could then rule out using as parameters
-// any Term for which there are no valid arguments.
+// whether it is a kind (for which there is *any* valid argument); we could then
+// rule out using as parameters any Term which is not a kind.
 #[derive(
     Clone, Debug, PartialEq, Eq, Hash, derive_more::Display, serde::Deserialize, serde::Serialize,
 )]
@@ -79,31 +79,31 @@ pub type TypeParam = Term;
     into = "crate::types::serialize::TermSer"
 )]
 pub enum Term {
-    /// The type of runtime types.
+    /// The kind of runtime types.
     #[display("Type{}", match _0 {
         TypeBound::Linear => String::new(),
         _ => format!("[{_0}]")
     })]
     TypeKind(TypeBound),
-    /// The type of static data.
+    /// The kind of static data.
     StaticKind,
-    /// The type of static natural numbers up to a given bound.
+    /// The kind of static natural numbers up to a given bound.
     #[display("{}", match _0.value() {
         Some(v) => format!("BoundedNat[{v}]"),
         None => "Nat".to_string()
     })]
     BoundedNatKind(UpperBound),
-    /// The type of static strings. See [`Term::String`].
+    /// The kind of static strings. See [`Term::String`].
     StringKind,
-    /// The type of static byte strings. See [`Term::Bytes`].
+    /// The kind of static byte strings. See [`Term::Bytes`].
     BytesKind,
-    /// The type of static floating point numbers. See [`Term::Float`].
+    /// The kind of static floating point numbers. See [`Term::Float`].
     FloatKind,
-    /// The type of static lists of indeterminate size containing terms of the
-    /// specified static type.
+    /// The kind of static lists of indeterminate size, each of whose elements
+    /// is a `Term` of the specified kind
     #[display("ListType[{_0}]")]
     ListKind(Box<Term>),
-    /// The type of static tuples.
+    /// The kind of static tuples.
     #[display("TupleType[{_0}]")]
     TupleKind(Box<Term>),
     /// The type of runtime values defined by an extension type.
@@ -138,19 +138,19 @@ pub enum Term {
     /// A list of static terms. Instance of [`Term::ListKind`].
     #[display("[{}]", _0.iter().map(|t|t.to_string()).join(", "))]
     List(Vec<Term>),
-    /// Instance of [`TypeParam::List`] defined by a sequence of concatenated lists of the same type.
+    /// Instance of [`TypeParam::ListKind`] defined by a sequence of concatenated lists of the same type.
     #[display("[{}]", {
         use itertools::Itertools as _;
         _0.iter().map(|t| format!("... {t}")).join(",")
     })]
     ListConcat(Vec<TypeArg>),
-    /// Instance of [`TypeParam::Tuple`] defined by a sequence of elements of varying type.
+    /// Instance of [`TypeParam::TupleKind`] defined by a sequence of elements of varying kind.
     #[display("({})", {
         use itertools::Itertools as _;
         _0.iter().map(std::string::ToString::to_string).join(",")
     })]
     Tuple(Vec<Term>),
-    /// Instance of [`TypeParam::Tuple`] defined by a sequence of concatenated tuples.
+    /// Instance of [`TypeParam::TupleKind`] defined by a sequence of concatenated tuples.
     #[display("({})", {
         use itertools::Itertools as _;
         _0.iter().map(|tuple| format!("... {tuple}")).join(",")
@@ -162,7 +162,7 @@ pub enum Term {
     #[display("{_0}")]
     Variable(TermVar),
 
-    /// The type of constants for a runtime type.
+    /// The kind of constants for a runtime type.
     ///
     /// A constant is a compile time description of how to produce a runtime value.
     /// The runtime value is constructed when the constant is loaded.
@@ -179,13 +179,13 @@ impl Term {
 
     /// Creates a [`Term::BoundedNatKind`] with the maximum bound (`u64::MAX` + 1).
     #[must_use]
-    pub const fn max_nat_type() -> Self {
+    pub const fn max_nat_kind() -> Self {
         Self::BoundedNatKind(UpperBound(None))
     }
 
     /// Creates a [`Term::BoundedNatKind`] with the stated upper bound (non-exclusive).
     #[must_use]
-    pub const fn bounded_nat_type(upper_bound: NonZeroU64) -> Self {
+    pub const fn bounded_nat_kind(upper_bound: NonZeroU64) -> Self {
         Self::BoundedNatKind(UpperBound(Some(upper_bound)))
     }
 
@@ -195,12 +195,12 @@ impl Term {
     }
 
     /// Creates a new [`Term::ListKind`] given the type of its elements.
-    pub fn new_list_type(elem: impl Into<Term>) -> Self {
+    pub fn new_list_kind(elem: impl Into<Term>) -> Self {
         Self::ListKind(Box::new(elem.into()))
     }
 
     /// Creates a new [`Term::TupleKind`] given the type of its elements.
-    pub fn new_tuple_type(item_types: impl Into<Term>) -> Self {
+    pub fn new_tuple_kind(item_types: impl Into<Term>) -> Self {
         Self::TupleKind(Box::new(item_types.into()))
     }
 
@@ -344,7 +344,7 @@ impl Term {
     /// kind is a [Term::ListKind] of [Term::TypeKind].
     #[must_use]
     pub fn new_row_var_use(idx: usize, b: TypeBound) -> Self {
-        Self::new_var_use(idx, Term::new_list_type(b))
+        Self::new_var_use(idx, Term::new_list_kind(b))
     }
 
     /// Creates a new string literal.
@@ -493,8 +493,8 @@ impl Term {
             Term::StringKind => self.clone(),
             Term::BytesKind => self.clone(),
             Term::FloatKind => self.clone(),
-            Term::ListKind(item_type) => Term::new_list_type(item_type.substitute(t)),
-            Term::TupleKind(item_types) => Term::new_tuple_type(item_types.substitute(t)),
+            Term::ListKind(item_type) => Term::new_list_kind(item_type.substitute(t)),
+            Term::TupleKind(item_types) => Term::new_tuple_kind(item_types.substitute(t)),
             Term::StaticKind => self.clone(),
             Term::ConstKind(ty) => Term::new_const(ty.substitute(t)),
         }
@@ -565,7 +565,7 @@ impl Term {
     /// # let a = Term::new_string("a");
     /// # let b = Term::new_string("b");
     /// # let c = Term::new_string("c");
-    /// let var = Term::new_var_use(0, Term::new_list_type(Term::StringKind));
+    /// let var = Term::new_var_use(0, Term::new_list_kind(Term::StringKind));
     /// let term = Term::concat_lists([
     ///     Term::new_list([a.clone(), b.clone()]),
     ///     var.clone(),
@@ -943,7 +943,7 @@ mod test {
         let b = Term::new_string("b");
         let c = Term::new_string("c");
         let d = Term::new_string("d");
-        let var = Term::new_var_use(0, Term::new_list_type(Term::StringKind));
+        let var = Term::new_var_use(0, Term::new_list_kind(Term::StringKind));
         let parts = [
             SeqPart::Splice(Term::new_list([a.clone(), b.clone()])),
             SeqPart::Splice(Term::concat_lists([Term::new_list([c.clone()])])),
@@ -989,7 +989,7 @@ mod test {
         }
         // Simple cases: Term::XXXTypes are Term::TypeKind's
         check(usize_t(), &TypeBound::Copyable.into()).unwrap();
-        let lst_of_cpy = TypeParam::new_list_type(TypeBound::Copyable);
+        let lst_of_cpy = TypeParam::new_list_kind(TypeBound::Copyable);
         check(usize_t(), &lst_of_cpy).unwrap_err();
         // ...but singleton sequences thereof are lists
         check_seq(&[usize_t()], &TypeBound::Linear.into()).unwrap_err();
@@ -1009,7 +1009,7 @@ mod test {
                 Term::new_list([usize_t()]),
                 rowvar(0, TypeBound::Copyable),
             ]),
-            &TypeParam::new_list_type(TypeBound::Linear),
+            &TypeParam::new_list_kind(TypeBound::Linear),
         )
         .unwrap();
         // but a *list* of the rowvar is a list of list of types, which is wrong
@@ -1033,9 +1033,9 @@ mod test {
         .unwrap_err();
 
         // Similar for nats (but no equivalent of fancy row vars)
-        check(5, &TypeParam::max_nat_type()).unwrap();
-        check_seq(&[5], &TypeParam::max_nat_type()).unwrap_err();
-        let list_of_nat = TypeParam::new_list_type(TypeParam::max_nat_type());
+        check(5, &TypeParam::max_nat_kind()).unwrap();
+        check_seq(&[5], &TypeParam::max_nat_kind()).unwrap_err();
+        let list_of_nat = TypeParam::new_list_kind(TypeParam::max_nat_kind());
         check(5, &list_of_nat).unwrap_err();
         check_seq(&[5], &list_of_nat).unwrap();
         check(TypeArg::new_var_use(0, list_of_nat.clone()), &list_of_nat).unwrap();
@@ -1048,7 +1048,7 @@ mod test {
 
         // `Term::TupleKind` requires a `Term::Tuple` of the same number of elems
         let usize_and_ty =
-            TypeParam::new_tuple_type([TypeParam::max_nat_type(), Term::from(TypeBound::Copyable)]);
+            TypeParam::new_tuple_kind([TypeParam::max_nat_kind(), Term::from(TypeBound::Copyable)]);
         check(
             TypeArg::Tuple(vec![5.into(), usize_t().into()]),
             &usize_and_ty,
@@ -1061,7 +1061,7 @@ mod test {
         .unwrap_err(); // Wrong way around
 
         let two_types =
-            Term::new_tuple_type(Term::new_list([TypeBound::Linear, TypeBound::Linear]));
+            Term::new_tuple_kind(Term::new_list([TypeBound::Linear, TypeBound::Linear]));
         check(TypeArg::new_var_use(0, two_types.clone()), &two_types).unwrap();
         // not a Row Var which could have any number of elems
         check(TypeArg::new_var_use(0, lst_of_cpy), &two_types).unwrap_err();
@@ -1069,13 +1069,13 @@ mod test {
 
     #[test]
     fn type_arg_subst_row() {
-        let row_param = Term::new_list_type(TypeBound::Copyable);
+        let row_param = Term::new_list_kind(TypeBound::Copyable);
         let row_arg: Term = Term::new_list([bool_t(), Type::UNIT]);
         check_term_kind(&row_arg, &row_param).unwrap();
 
         // Now say a row variable referring to *that* row was used
         // to instantiate an outer "row parameter" (list of type).
-        let outer_param = Term::new_list_type(TypeBound::Linear);
+        let outer_param = Term::new_list_kind(TypeBound::Linear);
         let outer_arg = Term::concat_lists([
             Term::new_row_var_use(0, TypeBound::Copyable),
             Term::new_list([usize_t()]),
@@ -1094,8 +1094,8 @@ mod test {
 
     #[test]
     fn subst_list_list() {
-        let outer_param = Term::new_list_type(Term::new_list_type(TypeBound::Linear));
-        let row_var_decl = Term::new_list_type(TypeBound::Copyable);
+        let outer_param = Term::new_list_kind(Term::new_list_kind(TypeBound::Linear));
+        let row_var_decl = Term::new_list_kind(TypeBound::Copyable);
         let row_var_use = Term::new_var_use(0, row_var_decl.clone());
         let good_arg = Term::new_list([
             // The row variables here refer to `row_var_decl` above
@@ -1116,7 +1116,7 @@ mod test {
             Err(TermTypeError::TypeMismatch {
                 term: Box::new(usize_t().into()),
                 // The error reports the type expected for each element of the list:
-                type_: Box::new(TypeParam::new_list_type(TypeBound::Linear))
+                type_: Box::new(TypeParam::new_list_kind(TypeBound::Linear))
             })
         );
 
@@ -1238,10 +1238,10 @@ mod test {
                         any_with::<TermVar>(depth).prop_map(Self::Variable).boxed(),
                     )
                     .or(any_with::<Self>(depth)
-                        .prop_map(Self::new_list_type)
+                        .prop_map(Self::new_list_kind)
                         .boxed())
                     .or(any_with::<Self>(depth)
-                        .prop_map(Self::new_tuple_type)
+                        .prop_map(Self::new_tuple_kind)
                         .boxed())
                     .or(vec(any_with::<Self>(depth), 0..3)
                         .prop_map(Self::new_list)

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -65,7 +65,7 @@ pub type TypeParam = Term;
 ///
 /// Terms are used for both parameter declarations and arguments fitting those
 /// parameters, e.g. a [Term::FloatKind] parameter would be instantiated (statically)
-/// with a [Term::Float] argument. [`check_term_type`] checks that an argument
+/// with a [Term::Float] argument. [`check_term_kind`] checks that an argument
 /// is valid (of the correct kind) for the parameter.
 // TODO it might be good to have a separate function that tells, for a given Term,
 // whether there is *any* valid argument; we could then rule out using as parameters
@@ -425,7 +425,7 @@ impl Term {
     /// Checks variables are as declared and [CustomType] arguments fit their parameters.
     /// Does not check that e.g. list elements all have same type (except inside a
     /// [CustomType] where we know the element type from the corresponding list parameter)
-    /// - this is left to [check_term_type].
+    /// - this is left to [check_term_kind].
     pub(crate) fn validate(&self, var_decls: &[TypeParam]) -> Result<(), SignatureError> {
         match self {
             Term::SumType(SumType::General { rows }) => {
@@ -700,7 +700,7 @@ impl TermVar {
     /// Check that the cached declaration of this variable matches the actual one (provided).
     ///
     /// The cache just mirrors the declaration; the typevar can be used anywhere expecting
-    /// a kind containing the decl - see [check_term_type] / [Term::is_supertype].
+    /// a kind containing the decl - see [check_term_kind] / [Term::is_supertype].
     fn check_decl(&self, decls: &[TypeParam]) -> Result<(), SignatureError> {
         let idx = self.idx;
         let cached_decl: &TypeParam = &self.cached_decl;
@@ -724,7 +724,7 @@ impl TermVar {
 }
 
 /// Checks that a [`Term`] is valid for a given type.
-pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
+pub fn check_term_kind(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
     match (term, type_) {
         (Term::Variable(TermVar { cached_decl, .. }), _) if type_.is_supertype(cached_decl) => {
             Ok(())
@@ -734,10 +734,10 @@ pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
         (Term::ExtensionType(cty), Term::TypeKind(bound)) if bound.contains(cty.bound()) => Ok(()),
         (Term::List(elems), Term::ListKind(item_type)) => elems
             .iter()
-            .try_for_each(|elem| check_term_type(elem, item_type)),
+            .try_for_each(|elem| check_term_kind(elem, item_type)),
         (Term::ListConcat(lists), Term::ListKind(_)) => lists
             .iter()
-            .try_for_each(|list| check_term_type(list, type_)),
+            .try_for_each(|list| check_term_kind(list, type_)),
         (TypeArg::Tuple(_) | TypeArg::TupleConcat(_), TypeParam::TupleKind(item_types)) => {
             let term_parts: Vec<_> = term.clone().into_tuple_parts().collect();
             let type_parts: Vec<_> = item_types.clone().into_list_parts().collect();
@@ -745,7 +745,7 @@ pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
             for (term, type_) in term_parts.iter().zip(&type_parts) {
                 match (term, type_) {
                     (SeqPart::Item(term), SeqPart::Item(type_)) => {
-                        check_term_type(term, type_)?;
+                        check_term_kind(term, type_)?;
                     }
                     (_, SeqPart::Splice(_)) | (SeqPart::Splice(_), _) => {
                         // TODO: Checking tuples with splicing requires more
@@ -791,12 +791,12 @@ pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
 }
 
 /// Check a list of [`Term`]s is valid for a list of types.
-pub fn check_term_types(terms: &[Term], types: &[Term]) -> Result<(), TermTypeError> {
+pub fn check_term_kinds(terms: &[Term], types: &[Term]) -> Result<(), TermTypeError> {
     if terms.len() != types.len() {
         return Err(TermTypeError::WrongNumberArgs(terms.len(), types.len()));
     }
     for (term, type_) in terms.iter().zip(types.iter()) {
-        check_term_type(term, type_)?;
+        check_term_kind(term, type_)?;
     }
     Ok(())
 }
@@ -911,7 +911,7 @@ impl FusedIterator for TuplePartIter {}
 
 #[cfg(test)]
 mod test {
-    use super::{Substitution, TypeArg, TypeParam, check_term_type};
+    use super::{Substitution, TypeArg, TypeParam, check_term_kind};
     use crate::extension::prelude::{bool_t, usize_t};
     use crate::types::type_param::SeqPart;
     use crate::types::{Term, Type, TypeBound, TypeRow, type_param::TermTypeError};
@@ -977,13 +977,13 @@ mod test {
     fn type_arg_fits_param() {
         let rowvar = Term::new_row_var_use;
         fn check(arg: impl Into<TypeArg>, param: &TypeParam) -> Result<(), TermTypeError> {
-            check_term_type(&arg.into(), param)
+            check_term_kind(&arg.into(), param)
         }
         fn check_seq<T: Clone + Into<TypeArg>>(
             args: &[T],
             param: &TypeParam,
         ) -> Result<(), TermTypeError> {
-            check_term_type(&Term::new_list(args.to_vec()), param)
+            check_term_kind(&Term::new_list(args.to_vec()), param)
         }
         // Simple cases: Term::XXXTypes are Term::TypeKind's
         check(usize_t(), &TypeBound::Copyable.into()).unwrap();
@@ -1069,7 +1069,7 @@ mod test {
     fn type_arg_subst_row() {
         let row_param = Term::new_list_type(TypeBound::Copyable);
         let row_arg: Term = Term::new_list([bool_t(), Type::UNIT]);
-        check_term_type(&row_arg, &row_param).unwrap();
+        check_term_kind(&row_arg, &row_param).unwrap();
 
         // Now say a row variable referring to *that* row was used
         // to instantiate an outer "row parameter" (list of type).
@@ -1078,7 +1078,7 @@ mod test {
             Term::new_row_var_use(0, TypeBound::Copyable),
             Term::new_list([usize_t()]),
         ]);
-        check_term_type(&outer_arg, &outer_param).unwrap();
+        check_term_kind(&outer_arg, &outer_param).unwrap();
 
         let outer_arg2 = outer_arg.substitute(&Substitution(&[row_arg]));
         assert_eq!(
@@ -1087,7 +1087,7 @@ mod test {
         );
 
         // Of course this is still valid (as substitution is guaranteed to preserve validity)
-        check_term_type(&outer_arg2, &outer_param).unwrap();
+        check_term_kind(&outer_arg2, &outer_param).unwrap();
     }
 
     #[test]
@@ -1101,7 +1101,7 @@ mod test {
             row_var_use.clone(),
             Term::concat_lists([row_var_use, Term::new_list([usize_t()])]),
         ]);
-        check_term_type(&good_arg, &outer_param).unwrap();
+        check_term_kind(&good_arg, &outer_param).unwrap();
 
         // Outer list cannot include single types:
         let Term::List(mut elems) = good_arg.clone() else {
@@ -1110,7 +1110,7 @@ mod test {
         let t: Term = usize_t().into();
         elems.push(t);
         assert_eq!(
-            check_term_type(&Term::new_list(elems), &outer_param),
+            check_term_kind(&Term::new_list(elems), &outer_param),
             Err(TermTypeError::TypeMismatch {
                 term: Box::new(usize_t().into()),
                 // The error reports the type expected for each element of the list:
@@ -1120,9 +1120,9 @@ mod test {
 
         // Now substitute a list of two types for that row-variable
         let row_var_arg = Term::new_list([usize_t(), bool_t()]);
-        check_term_type(&row_var_arg, &row_var_decl).unwrap();
+        check_term_kind(&row_var_arg, &row_var_decl).unwrap();
         let subst_arg = good_arg.substitute(&Substitution(std::slice::from_ref(&row_var_arg)));
-        check_term_type(&subst_arg, &outer_param).unwrap(); // invariance of substitution
+        check_term_kind(&subst_arg, &outer_param).unwrap(); // invariance of substitution
         assert_eq!(
             subst_arg,
             Term::new_list([

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -84,7 +84,7 @@ pub enum Term {
         TypeBound::Linear => String::new(),
         _ => format!("[{_0}]")
     })]
-    RuntimeKind(TypeBound),
+    TypeKind(TypeBound),
     /// The type of static data.
     StaticKind,
     /// The type of static natural numbers up to a given bound.
@@ -107,20 +107,20 @@ pub enum Term {
     #[display("TupleType[{_0}]")]
     TupleKind(Box<Term>),
     /// The type of runtime values defined by an extension type.
-    /// Instance of [Self::RuntimeKind] for some bound.
+    /// Instance of [Self::TypeKind] for some bound.
     //
     // TODO optimise with `Box<CustomType>`?
     // or some static version of this?
     #[display("{_0}")]
     RuntimeExtension(CustomType),
     /// The type of runtime values that are function pointers.
-    /// Instance of [Self::RuntimeKind]`(`[TypeBound::Copyable]`)`.
+    /// Instance of [Self::TypeKind]`(`[TypeBound::Copyable]`)`.
     /// Function values may be passed around without knowing their arity
     /// (i.e. with row vars) as long as they are not called.
     #[display("{_0}")]
     RuntimeFunction(Box<FuncValueType>),
     /// The type of runtime values that are sums of products (ADTs)
-    /// Instance of [Self::RuntimeKind]`(bound)` for `bound` calculated from each variant's elements.
+    /// Instance of [Self::TypeKind]`(bound)` for `bound` calculated from each variant's elements.
     #[display("{_0}")]
     RuntimeSum(SumType),
     /// A 64bit unsigned integer literal. Instance of [`Term::BoundedNatKind`].
@@ -217,7 +217,7 @@ impl Term {
     /// is not a static type) is considered a subtype of itself.
     fn is_supertype(&self, other: &Term) -> bool {
         match (self, other) {
-            (Term::RuntimeKind(b1), Term::RuntimeKind(b2)) => b1.contains(*b2),
+            (Term::TypeKind(b1), Term::TypeKind(b2)) => b1.contains(*b2),
             (Term::BoundedNatKind(b1), Term::BoundedNatKind(b2)) => b1.contains(b2),
             (Term::StringKind, Term::StringKind) => true,
             (Term::StaticKind, Term::StaticKind) => true,
@@ -277,7 +277,7 @@ impl Term {
 
 impl From<TypeBound> for Term {
     fn from(bound: TypeBound) -> Self {
-        Self::RuntimeKind(bound)
+        Self::TypeKind(bound)
     }
 }
 
@@ -341,7 +341,7 @@ impl Term {
     }
 
     /// Makes a `Term` representing a use (occurrence) of a variable whose
-    /// kind is a [Term::ListKind] of [Term::RuntimeKind].
+    /// kind is a [Term::ListKind] of [Term::TypeKind].
     #[must_use]
     pub fn new_row_var_use(idx: usize, b: TypeBound) -> Self {
         Self::new_var_use(idx, Term::new_list_type(b))
@@ -391,7 +391,7 @@ impl Term {
             Self::RuntimeSum(st) => Some(st.bound()),
             Self::RuntimeFunction(_) => Some(TypeBound::Copyable),
             Self::Variable(v) => match &*v.cached_decl {
-                TypeParam::RuntimeKind(b) => Some(*b),
+                TypeParam::TypeKind(b) => Some(*b),
                 _ => None,
             },
             _ => None,
@@ -399,14 +399,14 @@ impl Term {
     }
 
     /// Report if this is a copyable runtime type, i.e. an instance
-    /// of [Self::RuntimeKind]`(`[TypeBound::Copyable]`)`
+    /// of [Self::TypeKind]`(`[TypeBound::Copyable]`)`
     // where the least upper bound of the type is contained by the copyable bound.
     pub(crate) fn copyable(&self) -> bool {
         self.least_upper_bound()
             .is_some_and(|b| TypeBound::Copyable.contains(b))
     }
 
-    /// Report if this is a runtime type, i.e. an instance of [Self::RuntimeKind] for some bound.
+    /// Report if this is a runtime type, i.e. an instance of [Self::TypeKind] for some bound.
     ///
     /// If so, [Type::try_from(Type)] will succeed and can be followed by [Type::least_upper_bound] to get the bound.
     pub fn is_runtime_type(&self) -> bool {
@@ -441,7 +441,7 @@ impl Term {
             TypeArg::ListConcat(lists) => lists.iter().try_for_each(|a| a.validate(var_decls)),
             TypeArg::TupleConcat(tuples) => tuples.iter().try_for_each(|a| a.validate(var_decls)),
             Term::Variable(tv) => tv.check_decl(var_decls),
-            Term::RuntimeKind { .. } => Ok(()),
+            Term::TypeKind { .. } => Ok(()),
             Term::BoundedNatKind { .. } => Ok(()),
             Term::StringKind => Ok(()),
             Term::BytesKind => Ok(()),
@@ -488,7 +488,7 @@ impl Term {
                 )
             }
             TypeArg::Variable(TermVar { idx, cached_decl }) => t.apply_var(*idx, cached_decl),
-            Term::RuntimeKind(_) => self.clone(),
+            Term::TypeKind(_) => self.clone(),
             Term::BoundedNatKind(_) => self.clone(),
             Term::StringKind => self.clone(),
             Term::BytesKind => self.clone(),
@@ -663,7 +663,7 @@ impl Transformable for Term {
             | Term::Variable(_)
             | Term::Float(_)
             | Term::Bytes(_) => Ok(false),
-            Term::RuntimeKind { .. } => Ok(false),
+            Term::TypeKind { .. } => Ok(false),
             Term::BoundedNatKind { .. } => Ok(false),
             Term::StringKind => Ok(false),
             Term::BytesKind => Ok(false),
@@ -690,7 +690,7 @@ impl TermVar {
     #[must_use]
     pub fn bound_if_row_var(&self) -> Option<TypeBound> {
         if let Term::ListKind(item_type) = &*self.cached_decl
-            && let Term::RuntimeKind(b) = **item_type
+            && let Term::TypeKind(b) = **item_type
         {
             return Some(b);
         }
@@ -729,9 +729,9 @@ pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
         (Term::Variable(TermVar { cached_decl, .. }), _) if type_.is_supertype(cached_decl) => {
             Ok(())
         }
-        (Term::RuntimeSum(st), Term::RuntimeKind(bound)) if bound.contains(st.bound()) => Ok(()),
-        (Term::RuntimeFunction(_), Term::RuntimeKind(_)) => Ok(()), // Function pointers are always Copyable so fit any bound
-        (Term::RuntimeExtension(cty), Term::RuntimeKind(bound)) if bound.contains(cty.bound()) => {
+        (Term::RuntimeSum(st), Term::TypeKind(bound)) if bound.contains(st.bound()) => Ok(()),
+        (Term::RuntimeFunction(_), Term::TypeKind(_)) => Ok(()), // Function pointers are always Copyable so fit any bound
+        (Term::RuntimeExtension(cty), Term::TypeKind(bound)) if bound.contains(cty.bound()) => {
             Ok(())
         }
         (Term::List(elems), Term::ListKind(item_type)) => elems
@@ -782,7 +782,7 @@ pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
         (Term::FloatKind, Term::StaticKind) => Ok(()),
         (Term::ListKind { .. }, Term::StaticKind) => Ok(()),
         (Term::TupleKind(_), Term::StaticKind) => Ok(()),
-        (Term::RuntimeKind(_), Term::StaticKind) => Ok(()),
+        (Term::TypeKind(_), Term::StaticKind) => Ok(()),
         (Term::ConstKind(_), Term::StaticKind) => Ok(()),
 
         _ => Err(TermTypeError::TypeMismatch {
@@ -987,7 +987,7 @@ mod test {
         ) -> Result<(), TermTypeError> {
             check_term_type(&Term::new_list(args.to_vec()), param)
         }
-        // Simple cases: Term::RuntimeXXXs are Term::RuntimeKind's
+        // Simple cases: Term::RuntimeXXXs are Term::TypeKind's
         check(usize_t(), &TypeBound::Copyable.into()).unwrap();
         let lst_of_cpy = TypeParam::new_list_type(TypeBound::Copyable);
         check(usize_t(), &lst_of_cpy).unwrap_err();
@@ -1234,7 +1234,7 @@ mod test {
                 strat
                     .or(
                         // TODO this means we have two ways to create variables of type
-                        // `RuntimeKind`, so we probably get more of them than we should`
+                        // `TypeKind`, so we probably get more of them than we should`
                         any_with::<TermVar>(depth).prop_map(Self::Variable).boxed(),
                     )
                     .or(any_with::<Self>(depth)

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -820,9 +820,7 @@ pub enum TermKindError {
     WrongNumberArgs(usize, usize),
 
     /// Wrong number of terms in tuple (actual vs expected).
-    #[error(
-        "Wrong number of terms in tuple: {0} vs expected {1} declared by parameter"
-    )]
+    #[error("Wrong number of terms in tuple: {0} vs expected {1} declared by parameter")]
     WrongNumberTuple(usize, usize),
     /// Invalid value
     #[error("Invalid value of term argument")]

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -723,10 +723,12 @@ impl TermVar {
     }
 }
 
-/// Checks that a [`Term`] is valid for a given type.
-pub fn check_term_kind(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
-    match (term, type_) {
-        (Term::Variable(TermVar { cached_decl, .. }), _) if type_.is_supertype(cached_decl) => {
+/// Checks that a [`Term`] (value) is a valid instance of another [`Term`] (kind)
+///
+/// I.e. the former is acceptable as an argument to a parameter of the latter.
+pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
+    match (value, kind) {
+        (Term::Variable(TermVar { cached_decl, .. }), _) if kind.is_supertype(cached_decl) => {
             Ok(())
         }
         (Term::SumType(st), Term::TypeKind(bound)) if bound.contains(st.bound()) => Ok(()),
@@ -737,9 +739,9 @@ pub fn check_term_kind(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
             .try_for_each(|elem| check_term_kind(elem, item_type)),
         (Term::ListConcat(lists), Term::ListKind(_)) => lists
             .iter()
-            .try_for_each(|list| check_term_kind(list, type_)),
+            .try_for_each(|list| check_term_kind(list, kind)),
         (TypeArg::Tuple(_) | TypeArg::TupleConcat(_), TypeParam::TupleKind(item_types)) => {
-            let term_parts: Vec<_> = term.clone().into_tuple_parts().collect();
+            let term_parts: Vec<_> = value.clone().into_tuple_parts().collect();
             let type_parts: Vec<_> = item_types.clone().into_list_parts().collect();
 
             for (term, type_) in term_parts.iter().zip(&type_parts) {
@@ -784,8 +786,8 @@ pub fn check_term_kind(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
         (Term::ConstKind(_), Term::StaticKind) => Ok(()),
 
         _ => Err(TermTypeError::TypeMismatch {
-            term: Box::new(term.clone()),
-            type_: Box::new(type_.clone()),
+            term: Box::new(value.clone()),
+            type_: Box::new(kind.clone()),
         }),
     }
 }

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -112,17 +112,17 @@ pub enum Term {
     // TODO optimise with `Box<CustomType>`?
     // or some static version of this?
     #[display("{_0}")]
-    RuntimeExtension(CustomType),
+    ExtensionType(CustomType),
     /// The type of runtime values that are function pointers.
     /// Instance of [Self::TypeKind]`(`[TypeBound::Copyable]`)`.
     /// Function values may be passed around without knowing their arity
     /// (i.e. with row vars) as long as they are not called.
     #[display("{_0}")]
-    RuntimeFunction(Box<FuncValueType>),
+    FunctionType(Box<FuncValueType>),
     /// The type of runtime values that are sums of products (ADTs)
     /// Instance of [Self::TypeKind]`(bound)` for `bound` calculated from each variant's elements.
     #[display("{_0}")]
-    RuntimeSum(SumType),
+    SumType(SumType),
     /// A 64bit unsigned integer literal. Instance of [`Term::BoundedNatKind`].
     #[display("{_0}")]
     BoundedNat(u64),
@@ -233,9 +233,9 @@ impl Term {
             }
             // The following are not types (they have no instances), so these are just to
             // maintain reflexivity of the relation:
-            (Term::RuntimeSum(t1), Term::RuntimeSum(t2)) => t1 == t2,
-            (Term::RuntimeFunction(f1), Term::RuntimeFunction(f2)) => f1 == f2,
-            (Term::RuntimeExtension(c1), Term::RuntimeExtension(c2)) => c1 == c2,
+            (Term::SumType(t1), Term::SumType(t2)) => t1 == t2,
+            (Term::FunctionType(f1), Term::FunctionType(f2)) => f1 == f2,
+            (Term::ExtensionType(c1), Term::ExtensionType(c2)) => c1 == c2,
             (Term::BoundedNat(n1), Term::BoundedNat(n2)) => n1 == n2,
             (Term::String(s1), Term::String(s2)) => s1 == s2,
             (Term::Bytes(v1), Term::Bytes(v2)) => v1 == v2,
@@ -258,18 +258,18 @@ impl Term {
         }
     }
 
-    /// Returns the inner [`CustomType`] if this `Term` is a [Self::RuntimeExtension]
+    /// Returns the inner [`CustomType`] if this `Term` is a [Self::ExtensionType]
     pub fn as_extension(&self) -> Option<&CustomType> {
         match self {
-            Term::RuntimeExtension(ct) => Some(ct),
+            Term::ExtensionType(ct) => Some(ct),
             _ => None,
         }
     }
 
-    /// Returns the inner [`SumType`] if this `Term` is a [Self::RuntimeSum].
+    /// Returns the inner [`SumType`] if this `Term` is a [Self::SumType].
     pub fn as_sum(&self) -> Option<&SumType> {
         match self {
-            Term::RuntimeSum(s) => Some(s),
+            Term::SumType(s) => Some(s),
             _ => None,
         }
     }
@@ -387,9 +387,9 @@ impl Term {
 
     pub(crate) fn least_upper_bound(&self) -> Option<TypeBound> {
         match self {
-            Self::RuntimeExtension(ct) => Some(ct.bound()),
-            Self::RuntimeSum(st) => Some(st.bound()),
-            Self::RuntimeFunction(_) => Some(TypeBound::Copyable),
+            Self::ExtensionType(ct) => Some(ct.bound()),
+            Self::SumType(st) => Some(st.bound()),
+            Self::FunctionType(_) => Some(TypeBound::Copyable),
             Self::Variable(v) => match &*v.cached_decl {
                 TypeParam::TypeKind(b) => Some(*b),
                 _ => None,
@@ -428,13 +428,13 @@ impl Term {
     /// - this is left to [check_term_type].
     pub(crate) fn validate(&self, var_decls: &[TypeParam]) -> Result<(), SignatureError> {
         match self {
-            Term::RuntimeSum(SumType::General { rows }) => {
+            Term::SumType(SumType::General { rows }) => {
                 rows.iter().try_for_each(|row| row.validate(var_decls))?;
                 Ok(())
             }
-            Term::RuntimeSum(SumType::Unit { .. }) => Ok(()), // No leaves there
-            Term::RuntimeExtension(custy) => custy.validate(var_decls),
-            Term::RuntimeFunction(ft) => ft.validate(var_decls),
+            Term::SumType(SumType::Unit { .. }) => Ok(()), // No leaves there
+            Term::ExtensionType(custy) => custy.validate(var_decls),
+            Term::FunctionType(ft) => ft.validate(var_decls),
             Term::List(elems) => elems.iter().try_for_each(|a| a.validate(var_decls)),
             Term::Tuple(elems) => elems.iter().try_for_each(|a| a.validate(var_decls)),
             Term::BoundedNat(_) | Term::String { .. } | Term::Float(_) | Term::Bytes(_) => Ok(()),
@@ -455,14 +455,14 @@ impl Term {
 
     pub(crate) fn substitute(&self, t: &Substitution) -> Self {
         match self {
-            TypeArg::RuntimeSum(SumType::Unit { .. }) => self.clone(),
-            TypeArg::RuntimeSum(SumType::General { rows }) => {
+            TypeArg::SumType(SumType::Unit { .. }) => self.clone(),
+            TypeArg::SumType(SumType::General { rows }) => {
                 // A substitution of a row variable for an empty list,
                 // could make the general case into a unary SumType.
-                Term::RuntimeSum(SumType::new(rows.iter().map(|r| r.substitute(t))))
+                Term::SumType(SumType::new(rows.iter().map(|r| r.substitute(t))))
             }
-            TypeArg::RuntimeExtension(cty) => Term::RuntimeExtension(cty.substitute(t)),
-            TypeArg::RuntimeFunction(bf) => Term::RuntimeFunction(Box::new(bf.substitute(t))),
+            TypeArg::ExtensionType(cty) => Term::ExtensionType(cty.substitute(t)),
+            TypeArg::FunctionType(bf) => Term::FunctionType(Box::new(bf.substitute(t))),
 
             TypeArg::BoundedNat(_) | TypeArg::String(_) | TypeArg::Bytes(_) | TypeArg::Float(_) => {
                 self.clone()
@@ -640,7 +640,7 @@ impl Term {
 impl Transformable for Term {
     fn transform<T: TypeTransformer>(&mut self, tr: &T) -> Result<bool, T::Err> {
         match self {
-            Term::RuntimeExtension(custom_type) => {
+            Term::ExtensionType(custom_type) => {
                 if let Some(nt) = tr.apply_custom(custom_type)? {
                     *self = nt.0;
                     Ok(true)
@@ -654,8 +654,8 @@ impl Transformable for Term {
                     Ok(args_changed)
                 }
             }
-            Term::RuntimeFunction(fty) => fty.transform(tr),
-            Term::RuntimeSum(sum_type) => sum_type.transform(tr),
+            Term::FunctionType(fty) => fty.transform(tr),
+            Term::SumType(sum_type) => sum_type.transform(tr),
             Term::List(elems) => elems.transform(tr),
             Term::Tuple(elems) => elems.transform(tr),
             Term::BoundedNat(_)
@@ -729,11 +729,9 @@ pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
         (Term::Variable(TermVar { cached_decl, .. }), _) if type_.is_supertype(cached_decl) => {
             Ok(())
         }
-        (Term::RuntimeSum(st), Term::TypeKind(bound)) if bound.contains(st.bound()) => Ok(()),
-        (Term::RuntimeFunction(_), Term::TypeKind(_)) => Ok(()), // Function pointers are always Copyable so fit any bound
-        (Term::RuntimeExtension(cty), Term::TypeKind(bound)) if bound.contains(cty.bound()) => {
-            Ok(())
-        }
+        (Term::SumType(st), Term::TypeKind(bound)) if bound.contains(st.bound()) => Ok(()),
+        (Term::FunctionType(_), Term::TypeKind(_)) => Ok(()), // Function pointers are always Copyable so fit any bound
+        (Term::ExtensionType(cty), Term::TypeKind(bound)) if bound.contains(cty.bound()) => Ok(()),
         (Term::List(elems), Term::ListKind(item_type)) => elems
             .iter()
             .try_for_each(|elem| check_term_type(elem, item_type)),
@@ -987,7 +985,7 @@ mod test {
         ) -> Result<(), TermTypeError> {
             check_term_type(&Term::new_list(args.to_vec()), param)
         }
-        // Simple cases: Term::RuntimeXXXs are Term::TypeKind's
+        // Simple cases: Term::XXXTypes are Term::TypeKind's
         check(usize_t(), &TypeBound::Copyable.into()).unwrap();
         let lst_of_cpy = TypeParam::new_list_type(TypeBound::Copyable);
         check(usize_t(), &lst_of_cpy).unwrap_err();

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -64,7 +64,7 @@ pub type TypeParam = Term;
 /// are not types but they are static parameters of array types and ops.)
 ///
 /// Terms are used for both parameter declarations and arguments fitting those
-/// parameters, e.g. a [Term::FloatType] parameter would be instantiated (statically)
+/// parameters, e.g. a [Term::FloatKind] parameter would be instantiated (statically)
 /// with a [Term::Float] argument. [`check_term_type`] checks that an argument
 /// is valid (of the correct kind) for the parameter.
 // TODO it might be good to have a separate function that tells, for a given Term,
@@ -84,58 +84,58 @@ pub enum Term {
         TypeBound::Linear => String::new(),
         _ => format!("[{_0}]")
     })]
-    RuntimeType(TypeBound),
+    RuntimeKind(TypeBound),
     /// The type of static data.
-    StaticType,
+    StaticKind,
     /// The type of static natural numbers up to a given bound.
     #[display("{}", match _0.value() {
         Some(v) => format!("BoundedNat[{v}]"),
         None => "Nat".to_string()
     })]
-    BoundedNatType(UpperBound),
+    BoundedNatKind(UpperBound),
     /// The type of static strings. See [`Term::String`].
-    StringType,
+    StringKind,
     /// The type of static byte strings. See [`Term::Bytes`].
-    BytesType,
+    BytesKind,
     /// The type of static floating point numbers. See [`Term::Float`].
-    FloatType,
+    FloatKind,
     /// The type of static lists of indeterminate size containing terms of the
     /// specified static type.
     #[display("ListType[{_0}]")]
-    ListType(Box<Term>),
+    ListKind(Box<Term>),
     /// The type of static tuples.
     #[display("TupleType[{_0}]")]
-    TupleType(Box<Term>),
+    TupleKind(Box<Term>),
     /// The type of runtime values defined by an extension type.
-    /// Instance of [Self::RuntimeType] for some bound.
+    /// Instance of [Self::RuntimeKind] for some bound.
     //
     // TODO optimise with `Box<CustomType>`?
     // or some static version of this?
     #[display("{_0}")]
     RuntimeExtension(CustomType),
     /// The type of runtime values that are function pointers.
-    /// Instance of [Self::RuntimeType]`(`[TypeBound::Copyable]`)`.
+    /// Instance of [Self::RuntimeKind]`(`[TypeBound::Copyable]`)`.
     /// Function values may be passed around without knowing their arity
     /// (i.e. with row vars) as long as they are not called.
     #[display("{_0}")]
     RuntimeFunction(Box<FuncValueType>),
     /// The type of runtime values that are sums of products (ADTs)
-    /// Instance of [Self::RuntimeType]`(bound)` for `bound` calculated from each variant's elements.
+    /// Instance of [Self::RuntimeKind]`(bound)` for `bound` calculated from each variant's elements.
     #[display("{_0}")]
     RuntimeSum(SumType),
-    /// A 64bit unsigned integer literal. Instance of [`Term::BoundedNatType`].
+    /// A 64bit unsigned integer literal. Instance of [`Term::BoundedNatKind`].
     #[display("{_0}")]
     BoundedNat(u64),
-    /// UTF-8 encoded string literal. Instance of [`Term::StringType`].
+    /// UTF-8 encoded string literal. Instance of [`Term::StringKind`].
     #[display("\"{_0}\"")]
     String(String),
-    /// Byte string literal. Instance of [`Term::BytesType`].
+    /// Byte string literal. Instance of [`Term::BytesKind`].
     #[display("bytes")]
     Bytes(Arc<[u8]>),
-    /// A 64-bit floating point number. Instance of [`Term::FloatType`].
+    /// A 64-bit floating point number. Instance of [`Term::FloatKind`].
     #[display("{}", _0.into_inner())]
     Float(OrderedFloat<f64>),
-    /// A list of static terms. Instance of [`Term::ListType`].
+    /// A list of static terms. Instance of [`Term::ListKind`].
     #[display("[{}]", _0.iter().map(|t|t.to_string()).join(", "))]
     List(Vec<Term>),
     /// Instance of [`TypeParam::List`] defined by a sequence of concatenated lists of the same type.
@@ -170,23 +170,23 @@ pub enum Term {
     /// Constants are distinct from the runtime values that they describe. In
     /// particular, as part of the term language, constants can be freely copied
     /// or destroyed even when they describe a non-linear runtime value.
-    ConstType(Box<Type>),
+    ConstKind(Box<Type>),
 }
 
 impl Term {
     /// An empty list of Terms.
     pub const EMPTY_LIST: Self = Self::List(vec![]);
 
-    /// Creates a [`Term::BoundedNatType`] with the maximum bound (`u64::MAX` + 1).
+    /// Creates a [`Term::BoundedNatKind`] with the maximum bound (`u64::MAX` + 1).
     #[must_use]
     pub const fn max_nat_type() -> Self {
-        Self::BoundedNatType(UpperBound(None))
+        Self::BoundedNatKind(UpperBound(None))
     }
 
-    /// Creates a [`Term::BoundedNatType`] with the stated upper bound (non-exclusive).
+    /// Creates a [`Term::BoundedNatKind`] with the stated upper bound (non-exclusive).
     #[must_use]
     pub const fn bounded_nat_type(upper_bound: NonZeroU64) -> Self {
-        Self::BoundedNatType(UpperBound(Some(upper_bound)))
+        Self::BoundedNatKind(UpperBound(Some(upper_bound)))
     }
 
     /// Creates a new [`Term::List`] given a sequence of its items.
@@ -194,19 +194,19 @@ impl Term {
         Self::List(items.into_iter().map_into().collect())
     }
 
-    /// Creates a new [`Term::ListType`] given the type of its elements.
+    /// Creates a new [`Term::ListKind`] given the type of its elements.
     pub fn new_list_type(elem: impl Into<Term>) -> Self {
-        Self::ListType(Box::new(elem.into()))
+        Self::ListKind(Box::new(elem.into()))
     }
 
-    /// Creates a new [`Term::TupleType`] given the type of its elements.
+    /// Creates a new [`Term::TupleKind`] given the type of its elements.
     pub fn new_tuple_type(item_types: impl Into<Term>) -> Self {
-        Self::TupleType(Box::new(item_types.into()))
+        Self::TupleKind(Box::new(item_types.into()))
     }
 
-    /// Creates a new [`Term::ConstType`] from a runtime type.
+    /// Creates a new [`Term::ConstKind`] from a runtime type.
     pub fn new_const(ty: impl Into<Type>) -> Self {
-        Self::ConstType(Box::new(ty.into()))
+        Self::ConstKind(Box::new(ty.into()))
     }
 
     /// Checks if this term is a supertype of another.
@@ -217,16 +217,16 @@ impl Term {
     /// is not a static type) is considered a subtype of itself.
     fn is_supertype(&self, other: &Term) -> bool {
         match (self, other) {
-            (Term::RuntimeType(b1), Term::RuntimeType(b2)) => b1.contains(*b2),
-            (Term::BoundedNatType(b1), Term::BoundedNatType(b2)) => b1.contains(b2),
-            (Term::StringType, Term::StringType) => true,
-            (Term::StaticType, Term::StaticType) => true,
-            (Term::ListType(e1), Term::ListType(e2)) => e1.is_supertype(e2),
+            (Term::RuntimeKind(b1), Term::RuntimeKind(b2)) => b1.contains(*b2),
+            (Term::BoundedNatKind(b1), Term::BoundedNatKind(b2)) => b1.contains(b2),
+            (Term::StringKind, Term::StringKind) => true,
+            (Term::StaticKind, Term::StaticKind) => true,
+            (Term::ListKind(e1), Term::ListKind(e2)) => e1.is_supertype(e2),
             // The term inside a TupleType is a list of types, so this is ok as long as
             // supertype holds element-wise
-            (Term::TupleType(es1), Term::TupleType(es2)) => es1.is_supertype(es2),
-            (Term::BytesType, Term::BytesType) => true,
-            (Term::FloatType, Term::FloatType) => true,
+            (Term::TupleKind(es1), Term::TupleKind(es2)) => es1.is_supertype(es2),
+            (Term::BytesKind, Term::BytesKind) => true,
+            (Term::FloatKind, Term::FloatKind) => true,
             // Needed for TupleType, does not make a great deal of sense otherwise:
             (Term::List(es1), Term::List(es2)) => {
                 es1.len() == es2.len() && es1.iter().zip(es2).all(|(e1, e2)| e1.is_supertype(e2))
@@ -277,13 +277,13 @@ impl Term {
 
 impl From<TypeBound> for Term {
     fn from(bound: TypeBound) -> Self {
-        Self::RuntimeType(bound)
+        Self::RuntimeKind(bound)
     }
 }
 
 impl From<UpperBound> for Term {
     fn from(bound: UpperBound) -> Self {
-        Self::BoundedNatType(bound)
+        Self::BoundedNatKind(bound)
     }
 }
 
@@ -341,7 +341,7 @@ impl Term {
     }
 
     /// Makes a `Term` representing a use (occurrence) of a variable whose
-    /// kind is a [Term::ListType] of [Term::RuntimeType].
+    /// kind is a [Term::ListKind] of [Term::RuntimeKind].
     #[must_use]
     pub fn new_row_var_use(idx: usize, b: TypeBound) -> Self {
         Self::new_var_use(idx, Term::new_list_type(b))
@@ -391,7 +391,7 @@ impl Term {
             Self::RuntimeSum(st) => Some(st.bound()),
             Self::RuntimeFunction(_) => Some(TypeBound::Copyable),
             Self::Variable(v) => match &*v.cached_decl {
-                TypeParam::RuntimeType(b) => Some(*b),
+                TypeParam::RuntimeKind(b) => Some(*b),
                 _ => None,
             },
             _ => None,
@@ -399,14 +399,14 @@ impl Term {
     }
 
     /// Report if this is a copyable runtime type, i.e. an instance
-    /// of [Self::RuntimeType]`(`[TypeBound::Copyable]`)`
+    /// of [Self::RuntimeKind]`(`[TypeBound::Copyable]`)`
     // where the least upper bound of the type is contained by the copyable bound.
     pub(crate) fn copyable(&self) -> bool {
         self.least_upper_bound()
             .is_some_and(|b| TypeBound::Copyable.contains(b))
     }
 
-    /// Report if this is a runtime type, i.e. an instance of [Self::RuntimeType] for some bound.
+    /// Report if this is a runtime type, i.e. an instance of [Self::RuntimeKind] for some bound.
     ///
     /// If so, [Type::try_from(Type)] will succeed and can be followed by [Type::least_upper_bound] to get the bound.
     pub fn is_runtime_type(&self) -> bool {
@@ -441,15 +441,15 @@ impl Term {
             TypeArg::ListConcat(lists) => lists.iter().try_for_each(|a| a.validate(var_decls)),
             TypeArg::TupleConcat(tuples) => tuples.iter().try_for_each(|a| a.validate(var_decls)),
             Term::Variable(tv) => tv.check_decl(var_decls),
-            Term::RuntimeType { .. } => Ok(()),
-            Term::BoundedNatType { .. } => Ok(()),
-            Term::StringType => Ok(()),
-            Term::BytesType => Ok(()),
-            Term::FloatType => Ok(()),
-            Term::ListType(item_type) => item_type.validate(var_decls),
-            Term::TupleType(item_types) => item_types.validate(var_decls),
-            Term::StaticType => Ok(()),
-            Term::ConstType(ty) => ty.validate(var_decls),
+            Term::RuntimeKind { .. } => Ok(()),
+            Term::BoundedNatKind { .. } => Ok(()),
+            Term::StringKind => Ok(()),
+            Term::BytesKind => Ok(()),
+            Term::FloatKind => Ok(()),
+            Term::ListKind(item_type) => item_type.validate(var_decls),
+            Term::TupleKind(item_types) => item_types.validate(var_decls),
+            Term::StaticKind => Ok(()),
+            Term::ConstKind(ty) => ty.validate(var_decls),
         }
     }
 
@@ -488,15 +488,15 @@ impl Term {
                 )
             }
             TypeArg::Variable(TermVar { idx, cached_decl }) => t.apply_var(*idx, cached_decl),
-            Term::RuntimeType(_) => self.clone(),
-            Term::BoundedNatType(_) => self.clone(),
-            Term::StringType => self.clone(),
-            Term::BytesType => self.clone(),
-            Term::FloatType => self.clone(),
-            Term::ListType(item_type) => Term::new_list_type(item_type.substitute(t)),
-            Term::TupleType(item_types) => Term::new_tuple_type(item_types.substitute(t)),
-            Term::StaticType => self.clone(),
-            Term::ConstType(ty) => Term::new_const(ty.substitute(t)),
+            Term::RuntimeKind(_) => self.clone(),
+            Term::BoundedNatKind(_) => self.clone(),
+            Term::StringKind => self.clone(),
+            Term::BytesKind => self.clone(),
+            Term::FloatKind => self.clone(),
+            Term::ListKind(item_type) => Term::new_list_type(item_type.substitute(t)),
+            Term::TupleKind(item_types) => Term::new_tuple_type(item_types.substitute(t)),
+            Term::StaticKind => self.clone(),
+            Term::ConstKind(ty) => Term::new_const(ty.substitute(t)),
         }
     }
 
@@ -565,7 +565,7 @@ impl Term {
     /// # let a = Term::new_string("a");
     /// # let b = Term::new_string("b");
     /// # let c = Term::new_string("c");
-    /// let var = Term::new_var_use(0, Term::new_list_type(Term::StringType));
+    /// let var = Term::new_var_use(0, Term::new_list_type(Term::StringKind));
     /// let term = Term::concat_lists([
     ///     Term::new_list([a.clone(), b.clone()]),
     ///     var.clone(),
@@ -663,17 +663,17 @@ impl Transformable for Term {
             | Term::Variable(_)
             | Term::Float(_)
             | Term::Bytes(_) => Ok(false),
-            Term::RuntimeType { .. } => Ok(false),
-            Term::BoundedNatType { .. } => Ok(false),
-            Term::StringType => Ok(false),
-            Term::BytesType => Ok(false),
-            Term::FloatType => Ok(false),
-            Term::ListType(item_type) => item_type.transform(tr),
-            Term::TupleType(item_types) => item_types.transform(tr),
-            Term::StaticType => Ok(false),
+            Term::RuntimeKind { .. } => Ok(false),
+            Term::BoundedNatKind { .. } => Ok(false),
+            Term::StringKind => Ok(false),
+            Term::BytesKind => Ok(false),
+            Term::FloatKind => Ok(false),
+            Term::ListKind(item_type) => item_type.transform(tr),
+            Term::TupleKind(item_types) => item_types.transform(tr),
+            Term::StaticKind => Ok(false),
             TypeArg::ListConcat(lists) => lists.transform(tr),
             TypeArg::TupleConcat(tuples) => tuples.transform(tr),
-            Term::ConstType(ty) => ty.transform(tr),
+            Term::ConstKind(ty) => ty.transform(tr),
         }
     }
 }
@@ -689,8 +689,8 @@ impl TermVar {
     /// the [`TypeBound`] of the individual types it might stand for.
     #[must_use]
     pub fn bound_if_row_var(&self) -> Option<TypeBound> {
-        if let Term::ListType(item_type) = &*self.cached_decl
-            && let Term::RuntimeType(b) = **item_type
+        if let Term::ListKind(item_type) = &*self.cached_decl
+            && let Term::RuntimeKind(b) = **item_type
         {
             return Some(b);
         }
@@ -729,18 +729,18 @@ pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
         (Term::Variable(TermVar { cached_decl, .. }), _) if type_.is_supertype(cached_decl) => {
             Ok(())
         }
-        (Term::RuntimeSum(st), Term::RuntimeType(bound)) if bound.contains(st.bound()) => Ok(()),
-        (Term::RuntimeFunction(_), Term::RuntimeType(_)) => Ok(()), // Function pointers are always Copyable so fit any bound
-        (Term::RuntimeExtension(cty), Term::RuntimeType(bound)) if bound.contains(cty.bound()) => {
+        (Term::RuntimeSum(st), Term::RuntimeKind(bound)) if bound.contains(st.bound()) => Ok(()),
+        (Term::RuntimeFunction(_), Term::RuntimeKind(_)) => Ok(()), // Function pointers are always Copyable so fit any bound
+        (Term::RuntimeExtension(cty), Term::RuntimeKind(bound)) if bound.contains(cty.bound()) => {
             Ok(())
         }
-        (Term::List(elems), Term::ListType(item_type)) => elems
+        (Term::List(elems), Term::ListKind(item_type)) => elems
             .iter()
             .try_for_each(|elem| check_term_type(elem, item_type)),
-        (Term::ListConcat(lists), Term::ListType(_)) => lists
+        (Term::ListConcat(lists), Term::ListKind(_)) => lists
             .iter()
             .try_for_each(|list| check_term_type(list, type_)),
-        (TypeArg::Tuple(_) | TypeArg::TupleConcat(_), TypeParam::TupleType(item_types)) => {
+        (TypeArg::Tuple(_) | TypeArg::TupleConcat(_), TypeParam::TupleKind(item_types)) => {
             let term_parts: Vec<_> = term.clone().into_tuple_parts().collect();
             let type_parts: Vec<_> = item_types.clone().into_list_parts().collect();
 
@@ -769,21 +769,21 @@ pub fn check_term_type(term: &Term, type_: &Term) -> Result<(), TermTypeError> {
 
             Ok(())
         }
-        (Term::BoundedNat(val), Term::BoundedNatType(bound)) if bound.valid_value(*val) => Ok(()),
-        (Term::String { .. }, Term::StringType) => Ok(()),
-        (Term::Bytes(_), Term::BytesType) => Ok(()),
-        (Term::Float(_), Term::FloatType) => Ok(()),
+        (Term::BoundedNat(val), Term::BoundedNatKind(bound)) if bound.valid_value(*val) => Ok(()),
+        (Term::String { .. }, Term::StringKind) => Ok(()),
+        (Term::Bytes(_), Term::BytesKind) => Ok(()),
+        (Term::Float(_), Term::FloatKind) => Ok(()),
 
         // Static types
-        (Term::StaticType, Term::StaticType) => Ok(()),
-        (Term::StringType, Term::StaticType) => Ok(()),
-        (Term::BytesType, Term::StaticType) => Ok(()),
-        (Term::BoundedNatType { .. }, Term::StaticType) => Ok(()),
-        (Term::FloatType, Term::StaticType) => Ok(()),
-        (Term::ListType { .. }, Term::StaticType) => Ok(()),
-        (Term::TupleType(_), Term::StaticType) => Ok(()),
-        (Term::RuntimeType(_), Term::StaticType) => Ok(()),
-        (Term::ConstType(_), Term::StaticType) => Ok(()),
+        (Term::StaticKind, Term::StaticKind) => Ok(()),
+        (Term::StringKind, Term::StaticKind) => Ok(()),
+        (Term::BytesKind, Term::StaticKind) => Ok(()),
+        (Term::BoundedNatKind { .. }, Term::StaticKind) => Ok(()),
+        (Term::FloatKind, Term::StaticKind) => Ok(()),
+        (Term::ListKind { .. }, Term::StaticKind) => Ok(()),
+        (Term::TupleKind(_), Term::StaticKind) => Ok(()),
+        (Term::RuntimeKind(_), Term::StaticKind) => Ok(()),
+        (Term::ConstKind(_), Term::StaticKind) => Ok(()),
 
         _ => Err(TermTypeError::TypeMismatch {
             term: Box::new(term.clone()),
@@ -943,7 +943,7 @@ mod test {
         let b = Term::new_string("b");
         let c = Term::new_string("c");
         let d = Term::new_string("d");
-        let var = Term::new_var_use(0, Term::new_list_type(Term::StringType));
+        let var = Term::new_var_use(0, Term::new_list_type(Term::StringKind));
         let parts = [
             SeqPart::Splice(Term::new_list([a.clone(), b.clone()])),
             SeqPart::Splice(Term::concat_lists([Term::new_list([c.clone()])])),
@@ -962,7 +962,7 @@ mod test {
         let b = Term::new_string("b");
         let c = Term::new_string("c");
         let d = Term::new_string("d");
-        let var = Term::new_var_use(0, Term::new_tuple([Term::StringType]));
+        let var = Term::new_var_use(0, Term::new_tuple([Term::StringKind]));
         let parts = [
             SeqPart::Splice(Term::new_tuple([a.clone(), b.clone()])),
             SeqPart::Splice(Term::new_tuple_concat([Term::new_tuple([c.clone()])])),
@@ -987,7 +987,7 @@ mod test {
         ) -> Result<(), TermTypeError> {
             check_term_type(&Term::new_list(args.to_vec()), param)
         }
-        // Simple cases: Term::RuntimeXXXs are Term::RuntimeType's
+        // Simple cases: Term::RuntimeXXXs are Term::RuntimeKind's
         check(usize_t(), &TypeBound::Copyable.into()).unwrap();
         let lst_of_cpy = TypeParam::new_list_type(TypeBound::Copyable);
         check(usize_t(), &lst_of_cpy).unwrap_err();
@@ -1046,7 +1046,7 @@ mod test {
         )
         .unwrap_err();
 
-        // `Term::TupleType` requires a `Term::Tuple` of the same number of elems
+        // `Term::TupleKind` requires a `Term::Tuple` of the same number of elems
         let usize_and_ty =
             TypeParam::new_tuple_type([TypeParam::max_nat_type(), Term::from(TypeBound::Copyable)]);
         check(
@@ -1210,10 +1210,10 @@ mod test {
             type Strategy = BoxedStrategy<Self>;
             fn arbitrary_with(depth: Self::Parameters) -> Self::Strategy {
                 let strat = Union::new([
-                    Just(Self::StringType).boxed(),
-                    Just(Self::BytesType).boxed(),
-                    Just(Self::FloatType).boxed(),
-                    Just(Self::StringType).boxed(),
+                    Just(Self::StringKind).boxed(),
+                    Just(Self::BytesKind).boxed(),
+                    Just(Self::FloatKind).boxed(),
+                    Just(Self::StringKind).boxed(),
                     any::<TypeBound>().prop_map(Self::from).boxed(),
                     any::<UpperBound>().prop_map(Self::from).boxed(),
                     any::<u64>().prop_map(Self::from).boxed(),
@@ -1234,7 +1234,7 @@ mod test {
                 strat
                     .or(
                         // TODO this means we have two ways to create variables of type
-                        // `RuntimeType`, so we probably get more of them than we should`
+                        // `RuntimeKind`, so we probably get more of them than we should`
                         any_with::<TermVar>(depth).prop_map(Self::Variable).boxed(),
                     )
                     .or(any_with::<Self>(depth)

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -726,7 +726,7 @@ impl TermVar {
 /// Checks that a [`Term`] (value) is a valid instance of another [`Term`] (kind)
 ///
 /// I.e. the former is acceptable as an argument to a parameter of the latter.
-pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
+pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermKindError> {
     match (value, kind) {
         (Term::Variable(TermVar { cached_decl, .. }), _) if kind.is_supertype(cached_decl) => {
             Ok(())
@@ -761,7 +761,7 @@ pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
             }
 
             if term_parts.len() != type_parts.len() {
-                return Err(TermTypeError::WrongNumberTuple(
+                return Err(TermKindError::WrongNumberTuple(
                     term_parts.len(),
                     type_parts.len(),
                 ));
@@ -785,17 +785,17 @@ pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
         (Term::TypeKind(_), Term::StaticKind) => Ok(()),
         (Term::ConstKind(_), Term::StaticKind) => Ok(()),
 
-        _ => Err(TermTypeError::TypeMismatch {
+        _ => Err(TermKindError::KindMismatch {
             term: Box::new(value.clone()),
-            type_: Box::new(kind.clone()),
+            kind: Box::new(kind.clone()),
         }),
     }
 }
 
 /// Check a list of [`Term`]s is valid for a list of types.
-pub fn check_term_kinds(terms: &[Term], types: &[Term]) -> Result<(), TermTypeError> {
+pub fn check_term_kinds(terms: &[Term], types: &[Term]) -> Result<(), TermKindError> {
     if terms.len() != types.len() {
-        return Err(TermTypeError::WrongNumberArgs(terms.len(), types.len()));
+        return Err(TermKindError::WrongNumberArgs(terms.len(), types.len()));
     }
     for (term, type_) in terms.iter().zip(types.iter()) {
         check_term_kind(term, type_)?;
@@ -803,32 +803,29 @@ pub fn check_term_kinds(terms: &[Term], types: &[Term]) -> Result<(), TermTypeEr
     Ok(())
 }
 
-/// Errors that can occur when checking that a [`Term`] has an expected type.
+/// Errors that can occur when checking that a [`Term`] has an expected kind.
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
 #[non_exhaustive]
-pub enum TermTypeError {
+pub enum TermKindError {
     #[allow(missing_docs)]
-    /// For now, general case of a term not fitting a type.
+    /// For now, general case of a term not fitting a kind.
     /// We'll have more cases when we allow general Containers.
     // TODO It may become possible to combine this with ConstTypeError.
-    #[error("Term {term} does not fit declared type {type_}")]
-    TypeMismatch { term: Box<Term>, type_: Box<Term> },
-    /// Wrong number of type arguments (actual vs expected).
-    // For now this only happens at the top level (TypeArgs of op/type vs TypeParams of Op/TypeDef).
-    // However in the future it may be applicable to e.g. contents of Tuples too.
-    #[error("Wrong number of type arguments: {0} vs expected {1} declared type parameters")]
+    #[error("Term {term} does not fit declared kind {kind}")]
+    KindMismatch { term: Box<Term>, kind: Box<Term> },
+    /// Wrong number of term arguments (actual vs expected).
+    // For now this is just args of op/type vs params declared by Op/TypeDef,
+    // however in the future it may be applicable to e.g. contents of Tuples too.
+    #[error("Wrong number of term arguments: {0} vs expected {1} declared parameters")]
     WrongNumberArgs(usize, usize),
 
-    /// Wrong number of type arguments in tuple (actual vs expected).
+    /// Wrong number of terms in tuple (actual vs expected).
     #[error(
-        "Wrong number of type arguments to tuple parameter: {0} vs expected {1} declared type parameters"
+        "Wrong number of terms in tuple: {0} vs expected {1} declared by parameter"
     )]
     WrongNumberTuple(usize, usize),
-    /// Opaque value type check error.
-    #[error("Opaque type argument does not fit declared parameter type: {0}")]
-    OpaqueTypeMismatch(#[from] crate::types::CustomCheckFailure),
     /// Invalid value
-    #[error("Invalid value of type argument")]
+    #[error("Invalid value of term argument")]
     InvalidValue(Box<TypeArg>),
 }
 
@@ -916,7 +913,7 @@ mod test {
     use super::{Substitution, TypeArg, TypeParam, check_term_kind};
     use crate::extension::prelude::{bool_t, usize_t};
     use crate::types::type_param::SeqPart;
-    use crate::types::{Term, Type, TypeBound, TypeRow, type_param::TermTypeError};
+    use crate::types::{Term, Type, TypeBound, TypeRow, type_param::TermKindError};
 
     #[test]
     fn new_list_from_parts_items() {
@@ -978,13 +975,13 @@ mod test {
     #[test]
     fn type_arg_fits_param() {
         let rowvar = Term::new_row_var_use;
-        fn check(arg: impl Into<TypeArg>, param: &TypeParam) -> Result<(), TermTypeError> {
+        fn check(arg: impl Into<TypeArg>, param: &TypeParam) -> Result<(), TermKindError> {
             check_term_kind(&arg.into(), param)
         }
         fn check_seq<T: Clone + Into<TypeArg>>(
             args: &[T],
             param: &TypeParam,
-        ) -> Result<(), TermTypeError> {
+        ) -> Result<(), TermKindError> {
             check_term_kind(&Term::new_list(args.to_vec()), param)
         }
         // Simple cases: Term::XXXTypes are Term::TypeKind's
@@ -1113,10 +1110,10 @@ mod test {
         elems.push(t);
         assert_eq!(
             check_term_kind(&Term::new_list(elems), &outer_param),
-            Err(TermTypeError::TypeMismatch {
+            Err(TermKindError::KindMismatch {
                 term: Box::new(usize_t().into()),
                 // The error reports the type expected for each element of the list:
-                type_: Box::new(TypeParam::new_list_kind(TypeBound::Linear))
+                kind: Box::new(TypeParam::new_list_kind(TypeBound::Linear))
             })
         );
 

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -456,23 +456,23 @@ impl Term {
     /// Checks whether the term is parametric, i.e. it (recursively) contains variables.
     pub(crate) fn is_parametrized(&self) -> bool {
         match self {
-            Term::RuntimeSum(SumType::General { rows }) => {
+            Term::SumType(SumType::General { rows }) => {
                 rows.iter().any(|row| row.is_parametrized())
             }
-            Term::RuntimeSum(SumType::Unit { .. }) => false, // No leaves there
-            Term::RuntimeExtension(custy) => custy.args().iter().any(Term::is_parametrized),
-            Term::RuntimeFunction(ft) => ft.input.is_parametrized() || ft.output.is_parametrized(),
+            Term::SumType(SumType::Unit { .. }) => false, // No leaves there
+            Term::ExtensionType(custy) => custy.args().iter().any(Term::is_parametrized),
+            Term::FunctionType(ft) => ft.input.is_parametrized() || ft.output.is_parametrized(),
             Term::List(elems) => elems.iter().any(Term::is_parametrized),
             Term::Tuple(elems) => elems.iter().any(Term::is_parametrized),
             TypeArg::ListConcat(lists) => lists.iter().any(Term::is_parametrized),
             TypeArg::TupleConcat(tuples) => tuples.iter().any(Term::is_parametrized),
             Term::BoundedNat(_) | Term::String(_) | Term::Float(_) | Term::Bytes(_) => false,
-            Term::BoundedNatType(_) | Term::StringType | Term::BytesType | Term::FloatType => false,
-            Term::RuntimeType(_) => false,
-            Term::StaticType => false,
-            Term::ListType(item_type) => item_type.is_parametrized(),
-            Term::TupleType(item_types) => item_types.is_parametrized(),
-            Term::ConstType(ty) => ty.is_parametrized(),
+            Term::BoundedNatKind(_) | Term::StringKind | Term::BytesKind | Term::FloatKind => false,
+            Term::TypeKind(_) => false,
+            Term::StaticKind => false,
+            Term::ListKind(item_type) => item_type.is_parametrized(),
+            Term::TupleKind(item_types) => item_types.is_parametrized(),
+            Term::ConstKind(ty) => ty.is_parametrized(),
             Term::Variable(_) => true,
         }
     }

--- a/hugr-core/src/types/type_row.rs
+++ b/hugr-core/src/types/type_row.rs
@@ -249,10 +249,10 @@ impl FromIterator<Type> for TypeRow {
 /// Row of types and/or row variables, the number of actual types is thus
 /// unknown. Used for opdef signatures, and types of runtime function pointers.
 ///
-/// A [Term] that `check_term_type`s against [Term::ListKind] of [Term::RuntimeKind]
+/// A [Term] that `check_term_type`s against [Term::ListKind] of [Term::TypeKind]
 /// (of a [TypeBound]), i.e. one of
-/// * A [Term::Variable] of type [Term::ListKind] (of [Term::RuntimeKind]...)
-/// * A [Term::List], each of whose elements is of type some [Term::RuntimeKind]
+/// * A [Term::Variable] of type [Term::ListKind] (of [Term::TypeKind]...)
+/// * A [Term::List], each of whose elements is of type some [Term::TypeKind]
 /// * A [Term::ListConcat], each of whose sublists is one of these three
 ///
 /// [TypeBound]: crate::types::TypeBound

--- a/hugr-core/src/types/type_row.rs
+++ b/hugr-core/src/types/type_row.rs
@@ -12,7 +12,7 @@ use crate::{
     extension::SignatureError,
     types::{
         TypeBound,
-        type_param::{TermTypeError, check_term_type},
+        type_param::{TermTypeError, check_term_kind},
     },
     utils::display_list,
 };
@@ -249,7 +249,7 @@ impl FromIterator<Type> for TypeRow {
 /// Row of types and/or row variables, the number of actual types is thus
 /// unknown. Used for opdef signatures, and types of runtime function pointers.
 ///
-/// A [Term] that `check_term_type`s against [Term::ListKind] of [Term::TypeKind]
+/// A [Term] that `check_term_kind`s against [Term::ListKind] of [Term::TypeKind]
 /// (of a [TypeBound]), i.e. one of
 /// * A [Term::Variable] of type [Term::ListKind] (of [Term::TypeKind]...)
 /// * A [Term::List], each of whose elements is of type some [Term::TypeKind]
@@ -290,7 +290,7 @@ impl TypeRowLike for TypeRowRV {
     /// Checks that this is indeed a list of runtime types;
     /// and that all variables are as declared in the supplied list of params.
     fn validate(&self, vars: &[TypeParam]) -> Result<(), SignatureError> {
-        check_term_type(&self.0, &Term::new_list_type(TypeBound::Linear))?;
+        check_term_kind(&self.0, &Term::new_list_type(TypeBound::Linear))?;
         self.0.validate(vars)
     }
 
@@ -345,7 +345,7 @@ impl TryFrom<Term> for TypeRowRV {
     type Error = TermTypeError;
 
     fn try_from(t: Term) -> Result<Self, Self::Error> {
-        check_term_type(&t, &Term::new_list_type(TypeBound::Linear))?;
+        check_term_kind(&t, &Term::new_list_type(TypeBound::Linear))?;
         Ok(Self(t))
     }
 }

--- a/hugr-core/src/types/type_row.rs
+++ b/hugr-core/src/types/type_row.rs
@@ -249,10 +249,10 @@ impl FromIterator<Type> for TypeRow {
 /// Row of types and/or row variables, the number of actual types is thus
 /// unknown. Used for opdef signatures, and types of runtime function pointers.
 ///
-/// A [Term] that `check_term_type`s against [Term::ListType] of [Term::RuntimeType]
+/// A [Term] that `check_term_type`s against [Term::ListKind] of [Term::RuntimeKind]
 /// (of a [TypeBound]), i.e. one of
-/// * A [Term::Variable] of type [Term::ListType] (of [Term::RuntimeType]...)
-/// * A [Term::List], each of whose elements is of type some [Term::RuntimeType]
+/// * A [Term::Variable] of type [Term::ListKind] (of [Term::RuntimeKind]...)
+/// * A [Term::List], each of whose elements is of type some [Term::RuntimeKind]
 /// * A [Term::ListConcat], each of whose sublists is one of these three
 ///
 /// [TypeBound]: crate::types::TypeBound

--- a/hugr-core/src/types/type_row.rs
+++ b/hugr-core/src/types/type_row.rs
@@ -12,7 +12,7 @@ use crate::{
     extension::SignatureError,
     types::{
         TypeBound,
-        type_param::{TermTypeError, check_term_kind},
+        type_param::{TermKindError, check_term_kind},
     },
     utils::display_list,
 };
@@ -165,7 +165,7 @@ impl From<Vec<Type>> for TypeRow {
 }
 
 impl TryFrom<Vec<Term>> for TypeRow {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: Vec<Term>) -> Result<Self, Self::Error> {
         value
@@ -206,7 +206,7 @@ impl PartialEq<Term> for TypeRow {
 ///
 /// This will fail if `arg` is not a [Term::List] or any of the elements are not [Type]s
 impl TryFrom<Term> for TypeRow {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
         match value {
@@ -215,7 +215,7 @@ impl TryFrom<Term> for TypeRow {
                 .map(Type::try_from)
                 .collect::<Result<Vec<_>, _>>()?
                 .into()),
-            v => Err(TermTypeError::InvalidValue(Box::new(v))),
+            v => Err(TermKindError::InvalidValue(Box::new(v))),
         }
     }
 }
@@ -301,7 +301,7 @@ impl TypeRowLike for TypeRowRV {
 }
 
 impl TryFrom<TypeRowRV> for TypeRow {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: TypeRowRV) -> Result<Self, Self::Error> {
         value.0.try_into()
@@ -342,7 +342,7 @@ impl std::ops::Deref for TypeRowRV {
 }
 
 impl TryFrom<Term> for TypeRowRV {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(t: Term) -> Result<Self, Self::Error> {
         check_term_kind(&t, &Term::new_list_kind(TypeBound::Linear))?;

--- a/hugr-core/src/types/type_row.rs
+++ b/hugr-core/src/types/type_row.rs
@@ -290,7 +290,7 @@ impl TypeRowLike for TypeRowRV {
     /// Checks that this is indeed a list of runtime types;
     /// and that all variables are as declared in the supplied list of params.
     fn validate(&self, vars: &[TypeParam]) -> Result<(), SignatureError> {
-        check_term_kind(&self.0, &Term::new_list_type(TypeBound::Linear))?;
+        check_term_kind(&self.0, &Term::new_list_kind(TypeBound::Linear))?;
         self.0.validate(vars)
     }
 
@@ -345,7 +345,7 @@ impl TryFrom<Term> for TypeRowRV {
     type Error = TermTypeError;
 
     fn try_from(t: Term) -> Result<Self, Self::Error> {
-        check_term_kind(&t, &Term::new_list_type(TypeBound::Linear))?;
+        check_term_kind(&t, &Term::new_list_kind(TypeBound::Linear))?;
         Ok(Self(t))
     }
 }

--- a/hugr-llvm/src/utils/type_map.rs
+++ b/hugr-llvm/src/utils/type_map.rs
@@ -116,17 +116,17 @@ impl<'a, TM: TypeMapping + 'a> TypeMap<'a, TM> {
     /// and the auxiliary data `inv`.
     pub fn map_type<'c>(&self, hugr_type: &HugrType, inv: TM::InV<'c>) -> Result<TM::OutV<'c>> {
         match &**hugr_type {
-            Term::RuntimeExtension(custom_type) => {
+            Term::ExtensionType(custom_type) => {
                 let key = (custom_type.extension().clone(), custom_type.name().clone());
                 let Some(handler) = self.custom_hooks.get(&key) else {
                     return self.type_map.default_out(inv, &custom_type.clone().into());
                 };
                 handler.map_type(inv, custom_type)
             }
-            Term::RuntimeSum(sum_type) => self
+            Term::SumType(sum_type) => self
                 .map_sum_type(sum_type, inv)
                 .map(|x| self.type_map.sum_into_out(x)),
-            Term::RuntimeFunction(function_type) => self
+            Term::FunctionType(function_type) => self
                 .map_function_type(&function_type.as_ref().clone().try_into()?, inv)
                 .map(|x| self.type_map.func_into_out(x)),
             _ => self.type_map.default_out(inv, hugr_type),


### PR DESCRIPTION
[Note: this will textually conflict with #3022, will have to merge whichever is approved second but I think should b straightforward.]

Using `Type` to mean a static parameter (that accepts a static Term argument) is confusing; instead keep Type as meaning a type of *runtime values*

* `Term::RuntimeType` becomes `Term::TypeKind`
* `Term::XXXType` becomes `Term:::XXXKind` (e.g. `StringType` -> `StringKind`, `ListType` -> `ListKind`)
* `Term::RuntimeXXX` becomes `Term::XXXType` (e.g. `Term::RuntimeExtension` -> `Term::ExtensionType)`
* `check_term_type` -> `check_term_kind`
* `TermTypeError` -> `TermKindError`, variant `TypeMismatch` -> `KindMismatch` and field `type_` -> `kind`, reviewed separately in #3053

BREAKING CHANGE: many renames of variants of Term; ...Types are now Kinds, Runtime... are now Types. Also check_term_type is now check_term_kind, Term(Type->Kind)Error::(Type->Kind)Mismatch::{type_->kind}