### PR TITLE
ci: Build free threaded wheels for python 3.14t rather than 3.13t

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -111,7 +111,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --profile release-py --strip --out ../dist -i python3.13t
+          args: --profile release-py --strip --out ../dist -i python3.14t
           sccache: "true"
           manylinux: ${{ matrix.platform.manylinux }}
           working-directory: ${{ env.MODULE_DIR }}
@@ -153,7 +153,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --profile release-py --strip --out ../dist -i python3.13t
+          args: --profile release-py --strip --out ../dist -i python3.14t
           sccache: "true"
           manylinux: musllinux_1_2
           working-directory: ${{ env.MODULE_DIR }}
@@ -220,7 +220,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --profile release-py --strip --out ../dist -i python3.13t
+          args: --profile release-py --strip --out ../dist -i python3.14t
           sccache: "true"
           working-directory: ${{ env.MODULE_DIR }}
       - name: Upload wheels


### PR DESCRIPTION
> As of April 2026, we suggest not enabling builds for Free-threaded Python 3.13 going forward. The 3.13t release was considered experimental, is approximately 30% slower in single-threaded performance than 3.14t, and does not include a number of safety fixes for builtins and the standard library that were included in 3.14t. Free-threaded 3.14 also has better ecosystem compatibility than 3.13.

([source](https://py-free-threading.github.io/ci/))