### PR TITLE
feat: Return new nodes patch for inlining function calls

### DIFF
--- a/hugr-core/src/hugr/patch/inline_call.rs
+++ b/hugr-core/src/hugr/patch/inline_call.rs
@@ -1,11 +1,11 @@
 //! Rewrite to inline a Call to a `FuncDefn` by copying the body of the function
 //! into a DFG which replaces the Call node.
-use derive_more::{Display, Error};
-
 use crate::core::HugrNode;
 use crate::ops::{DFG, OpType};
 use crate::types::Substitution;
 use crate::{Direction, HugrView, Node};
+use derive_more::{Display, Error};
+use itertools::Itertools;
 
 use super::{HugrMut, PatchHugrMut, PatchVerification};
 
@@ -58,8 +58,10 @@ impl<N: HugrNode> PatchVerification for InlineCall<N> {
 }
 
 impl<N: HugrNode> PatchHugrMut for InlineCall<N> {
-    type Outcome = ();
-    fn apply_hugr_mut(self, h: &mut impl HugrMut<Node = N>) -> Result<(), Self::Error> {
+    /// The new nodes inserted into the Hugr on success
+    type Outcome = Vec<N>;
+
+    fn apply_hugr_mut(self, h: &mut impl HugrMut<Node = N>) -> Result<Self::Outcome, Self::Error> {
         self.verify(h)?; // Now we know we have a Call to a FuncDefn.
         let orig_func = h.static_source(self.0).unwrap();
 
@@ -93,12 +95,12 @@ impl<N: HugrNode> PatchHugrMut for InlineCall<N> {
             h.connect(src, srcp, self.0, new_order_in);
         }
 
-        h.copy_descendants(
+        let mapped_nodes = h.copy_descendants(
             orig_func,
             self.0,
             (!ty_args.is_empty()).then_some(Substitution::new(&ty_args)),
         );
-        Ok(())
+        Ok(mapped_nodes.into_values().collect_vec())
     }
 
     /// Failure only occurs if the node is not a Call, or the target not a `FuncDefn`.
@@ -110,8 +112,6 @@ impl<N: HugrNode> PatchHugrMut for InlineCall<N> {
 mod test {
     use std::iter::successors;
 
-    use itertools::Itertools;
-
     use crate::builder::{
         Container, Dataflow, DataflowHugr, DataflowSubContainer, FunctionBuilder, HugrBuilder,
         ModuleBuilder,
@@ -122,6 +122,7 @@ mod test {
     use crate::ops::{Input, OpType, Value};
     use crate::std_extensions::arithmetic::int_types::INT_TYPES;
     use crate::std_extensions::arithmetic::{int_ops::IntOpDef, int_types::ConstInt};
+    use itertools::Itertools;
 
     use crate::types::{PolyFuncType, Signature, Type, TypeBound};
     use crate::{HugrView, Node};
@@ -177,7 +178,7 @@ mod test {
             .count(),
             1
         );
-        hugr.apply_patch(InlineCall(call1.node())).unwrap();
+        let new_nodes = hugr.apply_patch(InlineCall(call1.node())).unwrap();
         hugr.validate().unwrap();
         assert_eq!(hugr.output_neighbours(func.node()).collect_vec(), [call2]);
         assert_eq!(calls(&hugr), [call2]);
@@ -190,11 +191,15 @@ mod test {
             .count(),
             1
         );
-        hugr.apply_patch(InlineCall(call2.node())).unwrap();
+        // Expect the direct function children, plus an input/output node, and a wrapping DFG
+        let expected_new_nodes = hugr.children(func.node()).collect_vec().len() + 3;
+        assert_eq!(new_nodes.len(), expected_new_nodes);
+        let new_nodes_2 = hugr.apply_patch(InlineCall(call2.node())).unwrap();
         hugr.validate().unwrap();
         assert_eq!(hugr.output_neighbours(func.node()).next(), None);
         assert_eq!(calls(&hugr), []);
         assert_eq!(extension_ops(&hugr).len(), 3);
+        assert_eq!(new_nodes_2.len(), expected_new_nodes);
 
         Ok(())
     }


### PR DESCRIPTION
Returns new nodes from the patch that is used for inlining function calls, similar to how the `InlineDFG` patch returns the removed nodes. This is useful to determine added nodes efficiently, without creating node diffs before and after.

BEGIN_COMMIT_OVERRIDE
feat: Return new nodes in patch for inlining function calls
END_COMMIT_OVERRIDE