### PR TITLE
feat: Add qualified opdef id to `MakeOpDef`

### DIFF
--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -8,6 +8,7 @@ use crate::ops::{ExtensionOp, OpName, OpNameRef};
 use crate::{Extension, ops::OpType, types::TypeArg};
 
 use super::{ExtensionBuildError, ExtensionId, OpDef, SignatureError, op_def::SignatureFunc};
+use crate::ops::custom::qualify_name;
 use delegate::delegate;
 use thiserror::Error;
 
@@ -50,6 +51,12 @@ pub trait MakeOpDef {
 
     /// The ID of the extension this operation is defined in.
     fn extension(&self) -> ExtensionId;
+
+    /// Returns the qualified id of the operation. e.g. 'arithmetic.iadd'.
+    /// See [`MakeOpDef::opdef_id`] for more information.
+    fn qualified_opdef_id(&self) -> OpName {
+        qualify_name(&self.extension(), &self.opdef_id())
+    }
 
     /// Returns a weak reference to the extension this operation is defined in.
     fn extension_ref(&self) -> Weak<Extension>;

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -398,6 +398,7 @@ mod test {
             DummyEnum::from_optype(&o.clone().to_extension_op().unwrap().into()).unwrap(),
             o
         );
+        assert_eq!(format!("{EXT_ID}.Dumb"), o.qualified_opdef_id());
         let registered: RegisteredOp<_> = o.clone().into();
         assert_eq!(registered.to_inner(), o);
 

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -245,7 +245,8 @@ pub struct OpaqueOp {
     signature: Signature,
 }
 
-fn qualify_name(res_id: &ExtensionId, name: &OpNameRef) -> OpName {
+/// Qualifies an operation name with its extension, e.g. 'iadd' -> 'arithmetic.iadd'.
+pub fn qualify_name(res_id: &ExtensionId, name: &OpNameRef) -> OpName {
     format!("{res_id}.{name}").into()
 }
 

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -246,7 +246,7 @@ pub struct OpaqueOp {
 }
 
 /// Qualifies an operation name with its extension, e.g. 'iadd' -> 'arithmetic.iadd'.
-pub fn qualify_name(res_id: &ExtensionId, name: &OpNameRef) -> OpName {
+pub(crate) fn qualify_name(res_id: &ExtensionId, name: &OpNameRef) -> OpName {
     format!("{res_id}.{name}").into()
 }
 


### PR DESCRIPTION
Exposes the qualified opdef id as a convenience on a trait that already has enough information to supply it. This will be used for upcoming functionality in tket2.