### PR TITLE
chore(deps-rs): Upgrade inkwell to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1378,22 +1378,22 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1def4112dfb2ce2993db7027f7acdb43c1f4ee1c70a082a2eef306ed5d0df365"
+checksum = "7decbc9dfa45a4a827a6ff7b822c113b1285678a937e84213417d4ca8a095782"
 dependencies = [
+ "bitflags",
  "inkwell_internals",
  "libc",
  "llvm-sys",
- "once_cell",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63736175c9a30ea123f7018de9f26163e0b39cd6978990ae486b510c4f3bad69"
+checksum = "6cfe97ee860815a90ed17e09639513269e39420a7440f3f4c996f238c514cf8d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -25,7 +25,7 @@ llvm21-1 = ["inkwell/llvm21-1"]
 workspace = true
 
 [dependencies]
-inkwell = { version = ">=0.7.1, <0.9", default-features = false }
+inkwell = { version = ">=0.7.1, <0.10", default-features = false }
 hugr-core = { path = "../hugr-core", version = "0.27.0" }
 anyhow.workspace = true
 itertools.workspace = true

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -25,7 +25,7 @@ llvm21-1 = ["inkwell/llvm21-1"]
 workspace = true
 
 [dependencies]
-inkwell = { version = ">=0.7.1, <0.10", default-features = false }
+inkwell = { version = ">=0.9.0, <0.10", default-features = false }
 hugr-core = { path = "../hugr-core", version = "0.27.0" }
 anyhow.workspace = true
 itertools.workspace = true

--- a/hugr-llvm/src/emit/test.rs
+++ b/hugr-llvm/src/emit/test.rs
@@ -63,7 +63,7 @@ impl<'c> Emission<'c> {
 
     /// Run passes on the inner module.
     #[deprecated(
-        since = "0.9.0",
+        since = "0.27.0",
         note = "Use the new pass manager API to run on the module exposed via [`Emission::module`] directly. This functon will be removed once inkwell drops support for LLVM 16."
     )]
     #[allow(deprecated)]

--- a/hugr-llvm/src/emit/test.rs
+++ b/hugr-llvm/src/emit/test.rs
@@ -12,6 +12,7 @@ use hugr_core::ops::handle::FuncID;
 use hugr_core::types::TypeRow;
 use hugr_core::{Hugr, HugrView, Node};
 use inkwell::module::{Linkage, Module};
+#[allow(deprecated)]
 use inkwell::passes::PassManager;
 use inkwell::values::{BasicValueEnum, GlobalValue, PointerValue};
 
@@ -61,6 +62,11 @@ impl<'c> Emission<'c> {
     }
 
     /// Run passes on the inner module.
+    #[deprecated(
+        since = "0.9.0",
+        note = "Use the new pass manager API to run on the module exposed via [`Emission::module`] directly. This functon will be removed once inkwell drops support for LLVM 16."
+    )]
+    #[allow(deprecated)]
     pub fn opt(&self, go: impl FnOnce() -> PassManager<Module<'c>>) {
         go().run_on(&self.module);
     }

--- a/hugr-llvm/src/sum.rs
+++ b/hugr-llvm/src/sum.rs
@@ -1,8 +1,8 @@
 mod layout;
 
-use std::{iter, slice};
-
 use crate::types::{HugrSumType, TypingSession};
+use std::num::NonZeroU32;
+use std::{iter, slice};
 
 use anyhow::{Result, anyhow, bail, ensure};
 use delegate::delegate;
@@ -263,12 +263,12 @@ enum LLVMSumTypeEnum<'c> {
 }
 
 /// Returns the smallest width for an integer type to be able to represent values smaller than `num_variants
-fn tag_width_for_num_variants(num_variants: usize) -> u32 {
+fn tag_width_for_num_variants(num_variants: usize) -> NonZeroU32 {
     debug_assert!(num_variants >= 1);
     if num_variants == 1 {
-        return 1;
+        return NonZeroU32::new(1).unwrap();
     }
-    (num_variants - 1).ilog2() + 1
+    NonZeroU32::new((num_variants - 1).ilog2() + 1).unwrap()
 }
 
 impl<'c> LLVMSumTypeEnum<'c> {
@@ -316,8 +316,9 @@ impl<'c> LLVMSumTypeEnum<'c> {
             }
             num_variants => {
                 let (mut fields, field_indices) = layout::layout_variants(&variant_types);
-                let tag_type =
-                    context.custom_width_int_type(tag_width_for_num_variants(num_variants));
+                let tag_type = context
+                    .custom_width_int_type(tag_width_for_num_variants(num_variants))
+                    .unwrap();
                 if fields.is_empty() {
                     Self::NoFields {
                         variant_types,
@@ -706,7 +707,10 @@ mod test {
     #[case(8, 3)]
     #[case(9, 4)]
     fn tag_width(#[case] num_variants: usize, #[case] expected: u32) {
-        assert_eq!(tag_width_for_num_variants(num_variants), expected);
+        assert_eq!(
+            tag_width_for_num_variants(num_variants),
+            NonZeroU32::new(expected).unwrap()
+        );
     }
 
     #[rstest]
@@ -718,7 +722,10 @@ mod test {
         let iwc = ts.iw_context();
         let empty_struct = iwc.struct_type(&[], false).as_basic_type_enum();
         let i1 = iwc.bool_type().as_basic_type_enum();
-        let i2 = iwc.custom_width_int_type(2).as_basic_type_enum();
+        let i2 = iwc
+            .custom_width_int_type(NonZeroU32::new(2).unwrap())
+            .unwrap()
+            .as_basic_type_enum();
         let i64 = iwc.i64_type().as_basic_type_enum();
 
         {


### PR DESCRIPTION
Updates inkwell to 0.9.0 and deprecates functions in the process (thus, once merged, this should be modified to perhaps show up in the changelog?).

Concretely, the following upgrade decisions were made:
- Where bit width is now checked, non-zeroness structs are used and unwrapped since we use literals or constructs for which it is mathematically impossible to be zero. Also, there is an assumption that we never go beyond the maximum supported bit width (and the existing message from inkwell is useful enough if we do).
- The `PassManager` is deprecated in inkwell. Since the replacement is a bit more involved and can be run directly on the module that the using struct exposes via `::module`, the function using it was deprecated (no usage was detected, but it is public). *We could also just remove it imo.*
- The minimum inkwell version is raised to `0.9.0`, since the new API is not backward compatible.

Closes #3038

BEGIN_COMMIT_OVERRIDE
feat: Upgrade inkwell to 0.9.0, and deprecate `hugr-llvm::emit::test::Emission::opt`. Use the new inkwell passes on the module exposed via `::Emission::module` instead.
END_COMMIT_OVERRIDE