### PR TITLE
ci: Build WASM wheels for emscripten v5

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -273,13 +273,14 @@ jobs:
         # Ideally this should match both the version used by rustc and the pyodide ABI.
         # See <https://doc.rust-lang.org/beta/rustc/platform-support/wasm32-unknown-emscripten.html>
         # and <https://github.com/pyodide/pyodide/blob/main/docs/development/abi.md>
-        # Pyodide `0.28` and `0.29` use 4.0.9
-        # We fix a rustc version compatible with it.
+        #
+        # We instead use the emsdk chosen by the `pyemscripten_2026_0` ABI.
+        # See <https://github.com/pyodide/pyodide/blob/main/docs/development/abi/314.md>
         run: |
           git clone --depth 1 https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk install 4.0.9
-          ./emsdk activate 4.0.9
+          ./emsdk install 5.0.3
+          ./emsdk activate 5.0.3
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
         with:


### PR DESCRIPTION
Updates the target pyodide ABI from [pyodide_2025_0](https://github.com/pyodide/pyodide/blob/main/docs/development/abi/313.md) to [pyemscripten_2026_0](https://github.com/pyodide/pyodide/blob/main/docs/development/abi/314.md).

We're not actually specifying the ABI anywhere, just building compatible wheels.

We no longer require rust nightly to build the ABI-compatible wheels (see the linked ABI docs), but it's still a good idea to do so, so we can pass `-Z build-std` to the compiler and ensure the rust ABI is correct (see https://doc.rust-lang.org/beta/rustc/platform-support/wasm32-unknown-emscripten.html#emscripten-abi-compatibility).

Test run: https://github.com/Quantinuum/hugr/actions/runs/25214250043/job/73931092528