### PR TITLE
chore: Fix cyclic dev dependency in hugr-model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,6 @@ dependencies = [
  "bumpalo",
  "capnp",
  "derive_more 2.1.1",
- "hugr-core",
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "ordered-float",

--- a/hugr-core/tests/model.rs
+++ b/hugr-core/tests/model.rs
@@ -31,6 +31,14 @@ fn roundtrip(source: &str) -> Result<String> {
     Ok(exported_ast.to_string())
 }
 
+/// Ensure a fixture edn represents a valid HUGR.
+fn validate_fixture(mut source: String) -> Result<()> {
+    source.insert_str(0, "HUGRiHJv(@");
+    let package = Package::load_str(source, None)?;
+    package.validate()?;
+    Ok(())
+}
+
 macro_rules! test_roundtrip {
     ($name: ident, $file: expr) => {
         #[test]
@@ -128,4 +136,15 @@ fn import_package_with_extensions(#[case] format: EnvelopeFormat, simple_dfg_hug
     assert_eq!(read_ext.name(), &"miniquantum".try_into().unwrap());
 
     assert_eq!(package, loaded_pkg);
+}
+
+/// Check that the fixtures in `hugr-model` are valid HUGR packages.
+#[rstest]
+#[cfg_attr(miri, ignore)] // Opening files is not supported in (isolated) miri
+pub fn test_fixtures_validate(
+    #[files("../hugr-model/tests/fixtures/*.edn")]
+    #[mode = str]
+    source: &str,
+) -> Result<()> {
+    validate_fixture(source.to_string())
 }

--- a/hugr-model/Cargo.toml
+++ b/hugr-model/Cargo.toml
@@ -40,7 +40,6 @@ workspace = true
 
 [dev-dependencies]
 anyhow = { workspace = true }
-hugr-core = { version = "0.27.1", path = "../hugr-core", default-features = false }
 rstest = { workspace = true }
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }

--- a/hugr-model/tests/text.rs
+++ b/hugr-model/tests/text.rs
@@ -1,16 +1,8 @@
 #![allow(missing_docs)]
 
-use hugr_core::package::Package;
 use hugr_model::v0::ast;
 use rstest::rstest;
 use std::str::FromStr as _;
-
-fn validate_hugr(mut source: String) -> Result<(), anyhow::Error> {
-    source.insert_str(0, "HUGRiHJv(@");
-    let pkg = Package::load_str(source, None)?;
-    pkg.validate()?;
-    Ok(())
-}
 
 fn roundtrip(source: &str) -> String {
     let package = ast::Package::from_str(source).unwrap();
@@ -24,7 +16,6 @@ pub fn test_roundtrip(
     #[mode = str]
     expected: &str,
 ) -> Result<(), anyhow::Error> {
-    validate_hugr(expected.to_string())?;
     let actual = roundtrip(expected);
     // Trim whitespace from the strings to compare them
     let expected_trim = expected


### PR DESCRIPTION
#3016 introduced a cyclic dev dependency between `hugr-model` and `hugr-core` to validate the `.edn`s used for testing.

Crates.io does not allow such cycles, so this caused an error when releasing `0.27.1`.

This PR fixes that by moving the validation test to `hugr-core` instead.