### PR TITLE
feat(hugrv2)!: Rename TermTypeError -> TermKindError

### DIFF
--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -481,7 +481,7 @@ pub(crate) mod test {
     use crate::metadata::Metadata;
     use crate::ops::{FuncDecl, FuncDefn, OpParent, OpTag, OpTrait, Value, handle::NodeHandle};
     use crate::std_extensions::logic::test::and_op;
-    use crate::types::type_param::{TermTypeError, TypeParam};
+    use crate::types::type_param::{TermKindError, TypeParam};
     use crate::types::{EdgeKind, FuncValueType, Signature, Term, Type, TypeBound, TypeRowRV};
     use crate::utils::test_quantum_extension::h_gate;
     use crate::{Wire, builder::test::n_identity, type_row};
@@ -947,7 +947,7 @@ pub(crate) mod test {
         assert_eq!(
             ev,
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::InvalidValue(Box::new(rv.clone()))
+                TermKindError::InvalidValue(Box::new(rv.clone()))
             ))
         );
 
@@ -958,7 +958,7 @@ pub(crate) mod test {
         assert_eq!(
             ev,
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::KindMismatch {
+                TermKindError::KindMismatch {
                     term: Box::new(rv),
                     type_: Box::new(TypeBound::Linear.into())
                 }

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -958,7 +958,7 @@ pub(crate) mod test {
         assert_eq!(
             ev,
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::TypeMismatch {
+                TermTypeError::KindMismatch {
                     term: Box::new(rv),
                     type_: Box::new(TypeBound::Linear.into())
                 }

--- a/hugr-core/src/builder/dataflow.rs
+++ b/hugr-core/src/builder/dataflow.rs
@@ -960,7 +960,7 @@ pub(crate) mod test {
             Err(SignatureError::TypeArgMismatch(
                 TermKindError::KindMismatch {
                     term: Box::new(rv),
-                    type_: Box::new(TypeBound::Linear.into())
+                    kind: Box::new(TypeBound::Linear.into())
                 }
             ))
         );

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -125,7 +125,7 @@ use thiserror::Error;
 use crate::hugr::IdentList;
 use crate::ops::custom::{ExtensionOp, OpaqueOp};
 use crate::ops::{OpName, OpNameRef};
-use crate::types::type_param::{TermTypeError, TypeArg, TypeParam};
+use crate::types::type_param::{TermKindError, TypeArg, TypeParam};
 use crate::types::{CustomType, TypeBound, TypeName};
 use crate::types::{Signature, TypeNameRef};
 
@@ -490,7 +490,7 @@ pub enum SignatureError {
     ExtensionMismatch(ExtensionId, ExtensionId),
     /// When the type arguments of the node did not match the params declared by the `OpDef`
     #[error("Type arguments of node did not match params declared by definition: {0}")]
-    TypeArgMismatch(#[from] TermTypeError),
+    TypeArgMismatch(#[from] TermKindError),
     /// Invalid type arguments
     #[error("Invalid type arguments for operation")]
     InvalidTypeArgs,

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -867,7 +867,7 @@ pub(super) mod test {
                 def.compute_signature(std::slice::from_ref(&arg)),
                 Err(SignatureError::TypeArgMismatch(
                     TermKindError::KindMismatch {
-                        type_: Box::new(TypeBound::Linear.into()),
+                        kind: Box::new(TypeBound::Linear.into()),
                         term: Box::new(arg),
                     }
                 ))

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -866,7 +866,7 @@ pub(super) mod test {
             assert_eq!(
                 def.compute_signature(std::slice::from_ref(&arg)),
                 Err(SignatureError::TypeArgMismatch(
-                    TermTypeError::TypeMismatch {
+                    TermTypeError::KindMismatch {
                         type_: Box::new(TypeBound::Linear.into()),
                         term: Box::new(arg),
                     }

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -613,7 +613,7 @@ pub(super) mod test {
     use crate::ops::OpName;
     use crate::package::Package;
     use crate::std_extensions::collections::list;
-    use crate::types::type_param::{TermTypeError, TypeParam};
+    use crate::types::type_param::{TermKindError, TypeParam};
     use crate::types::{PolyFuncTypeRV, Signature, Term, Type, TypeArg, TypeBound};
     use crate::{Extension, const_extension_ids};
 
@@ -866,7 +866,7 @@ pub(super) mod test {
             assert_eq!(
                 def.compute_signature(std::slice::from_ref(&arg)),
                 Err(SignatureError::TypeArgMismatch(
-                    TermTypeError::KindMismatch {
+                    TermKindError::KindMismatch {
                         type_: Box::new(TypeBound::Linear.into()),
                         term: Box::new(arg),
                     }

--- a/hugr-core/src/extension/simple_op.rs
+++ b/hugr-core/src/extension/simple_op.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Weak};
 use strum::IntoEnumIterator;
 
 use crate::ops::{ExtensionOp, OpName, OpNameRef};
-use crate::types::type_param::TermTypeError;
+use crate::types::type_param::TermKindError;
 use crate::{Extension, ops::OpType, types::TypeArg};
 
 use super::{ExtensionBuildError, ExtensionId, OpDef, SignatureError, op_def::SignatureFunc};
@@ -27,8 +27,8 @@ pub enum OpLoadError {
     WrongExtension(ExtensionId, ExtensionId),
 }
 
-impl From<TermTypeError> for OpLoadError {
-    fn from(value: TermTypeError) -> Self {
+impl From<TermKindError> for OpLoadError {
+    fn from(value: TermKindError) -> Self {
         SignatureError::from(value).into()
     }
 }

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -272,7 +272,7 @@ mod test {
             Err(SignatureError::TypeArgMismatch(
                 TermKindError::KindMismatch {
                     term: Box::new(qb_t().into()),
-                    type_: Box::new(TypeBound::Copyable.into())
+                    kind: Box::new(TypeBound::Copyable.into())
                 }
             ))
         );

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -270,7 +270,7 @@ mod test {
         assert_eq!(
             def.instantiate([qb_t().into()]),
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::TypeMismatch {
+                TermTypeError::KindMismatch {
                     term: Box::new(qb_t().into()),
                     type_: Box::new(TypeBound::Copyable.into())
                 }

--- a/hugr-core/src/extension/type_def.rs
+++ b/hugr-core/src/extension/type_def.rs
@@ -240,7 +240,7 @@ mod test {
     use crate::extension::SignatureError;
     use crate::extension::prelude::{qb_t, usize_t};
     use crate::std_extensions::arithmetic::float_types::float64_type;
-    use crate::types::type_param::{TermTypeError, TypeParam};
+    use crate::types::type_param::{TermKindError, TypeParam};
     use crate::types::{Signature, Type, TypeBound};
 
     use super::{TypeDef, TypeDefBound};
@@ -270,7 +270,7 @@ mod test {
         assert_eq!(
             def.instantiate([qb_t().into()]),
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::KindMismatch {
+                TermKindError::KindMismatch {
                     term: Box::new(qb_t().into()),
                     type_: Box::new(TypeBound::Copyable.into())
                 }
@@ -279,13 +279,13 @@ mod test {
         // Too few arguments:
         assert_eq!(
             def.instantiate([]).unwrap_err(),
-            SignatureError::TypeArgMismatch(TermTypeError::WrongNumberArgs(0, 1))
+            SignatureError::TypeArgMismatch(TermKindError::WrongNumberArgs(0, 1))
         );
         // Too many arguments:
         assert_eq!(
             def.instantiate([float64_type().into(), float64_type().into(),])
                 .unwrap_err(),
-            SignatureError::TypeArgMismatch(TermTypeError::WrongNumberArgs(2, 1))
+            SignatureError::TypeArgMismatch(TermKindError::WrongNumberArgs(2, 1))
         );
     }
 }

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -344,7 +344,7 @@ fn invalid_types() {
     assert_eq!(
         validate_to_sig_error(element_outside_bound),
         SignatureError::TypeArgMismatch(TermKindError::KindMismatch {
-            type_: Box::new(TypeBound::Copyable.into()),
+            kind: Box::new(TypeBound::Copyable.into()),
             term: Box::new(valid.into())
         })
     );

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -343,7 +343,7 @@ fn invalid_types() {
     );
     assert_eq!(
         validate_to_sig_error(element_outside_bound),
-        SignatureError::TypeArgMismatch(TermTypeError::TypeMismatch {
+        SignatureError::TypeArgMismatch(TermTypeError::KindMismatch {
             type_: Box::new(TypeBound::Copyable.into()),
             term: Box::new(valid.into())
         })

--- a/hugr-core/src/hugr/validate/test.rs
+++ b/hugr-core/src/hugr/validate/test.rs
@@ -22,7 +22,7 @@ use crate::ops::handle::NodeHandle;
 use crate::ops::{self, FuncDecl, FuncDefn, OpType, Value};
 use crate::std_extensions::logic::LogicOp;
 use crate::std_extensions::logic::test::{and_op, or_op};
-use crate::types::type_param::{TermTypeError, TypeArg};
+use crate::types::type_param::{TermKindError, TypeArg};
 use crate::types::{
     CustomType, FuncValueType, PolyFuncType, PolyFuncTypeRV, Signature, Term, Type, TypeBound,
     TypeRow, TypeRowRV,
@@ -343,7 +343,7 @@ fn invalid_types() {
     );
     assert_eq!(
         validate_to_sig_error(element_outside_bound),
-        SignatureError::TypeArgMismatch(TermTypeError::KindMismatch {
+        SignatureError::TypeArgMismatch(TermKindError::KindMismatch {
             type_: Box::new(TypeBound::Copyable.into()),
             term: Box::new(valid.into())
         })
@@ -389,7 +389,7 @@ fn invalid_types() {
     );
     assert_eq!(
         validate_to_sig_error(too_many_type_args),
-        SignatureError::TypeArgMismatch(TermTypeError::WrongNumberArgs(2, 1))
+        SignatureError::TypeArgMismatch(TermKindError::WrongNumberArgs(2, 1))
     );
 }
 

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::envelope::description::{ExtensionDesc, GeneratorDesc, ModuleDesc};
 use crate::metadata::{self, Metadata, RawMetadataValue};
-use crate::types::type_param::{SeqPart, TermTypeError, TypeParam};
+use crate::types::type_param::{SeqPart, TermKindError, TypeParam};
 use crate::types::{
     CustomType, FuncTypeBase, PolyFuncType, Signature, Term, Type, TypeArg, TypeBound, TypeName,
     TypeRow, TypeRowLike, TypeRowRV,
@@ -112,8 +112,8 @@ enum ImportErrorInner {
     ExtensionResolution(#[from] ExtensionResolutionError),
 }
 
-impl From<TermTypeError> for ImportErrorInner {
-    fn from(err: TermTypeError) -> Self {
+impl From<TermKindError> for ImportErrorInner {
+    fn from(err: TermKindError) -> Self {
         SignatureError::from(err).into()
     }
 }

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -80,7 +80,7 @@ pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TermKindError> {
         TypeArg::BoundedNat(n) if is_valid_log_width(*n as u8) => Ok(*n as u8),
         _ => Err(TermKindError::KindMismatch {
             term: Box::new(arg.clone()),
-            type_: Box::new(LOG_WIDTH_TYPE_PARAM),
+            kind: Box::new(LOG_WIDTH_TYPE_PARAM),
         }),
     }
 }

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -11,7 +11,7 @@ use crate::{
     ops::constant::CustomConst,
     types::{
         ConstTypeError, CustomType, Type, TypeBound,
-        type_param::{TermTypeError, TypeArg, TypeParam},
+        type_param::{TermKindError, TypeArg, TypeParam},
     },
 };
 /// The extension identifier.
@@ -75,10 +75,10 @@ pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::bounded_nat_kind({
 
 /// Get the log width  of the specified type argument or error if the argument
 /// is invalid.
-pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TermTypeError> {
+pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TermKindError> {
     match arg {
         TypeArg::BoundedNat(n) if is_valid_log_width(*n as u8) => Ok(*n as u8),
-        _ => Err(TermTypeError::KindMismatch {
+        _ => Err(TermKindError::KindMismatch {
             term: Box::new(arg.clone()),
             type_: Box::new(LOG_WIDTH_TYPE_PARAM),
         }),
@@ -240,7 +240,7 @@ mod test {
         let type_arg_128 = TypeArg::BoundedNat(7);
         assert_matches!(
             get_log_width(&type_arg_128),
-            Err(TermTypeError::KindMismatch { .. })
+            Err(TermKindError::KindMismatch { .. })
         );
     }
 

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -78,7 +78,7 @@ pub const LOG_WIDTH_TYPE_PARAM: TypeParam = TypeParam::bounded_nat_kind({
 pub(super) fn get_log_width(arg: &TypeArg) -> Result<u8, TermTypeError> {
     match arg {
         TypeArg::BoundedNat(n) if is_valid_log_width(*n as u8) => Ok(*n as u8),
-        _ => Err(TermTypeError::TypeMismatch {
+        _ => Err(TermTypeError::KindMismatch {
             term: Box::new(arg.clone()),
             type_: Box::new(LOG_WIDTH_TYPE_PARAM),
         }),
@@ -240,7 +240,7 @@ mod test {
         let type_arg_128 = TypeArg::BoundedNat(7);
         assert_matches!(
             get_log_width(&type_arg_128),
-            Err(TermTypeError::TypeMismatch { .. })
+            Err(TermTypeError::KindMismatch { .. })
         );
     }
 

--- a/hugr-core/src/std_extensions/collections/static_array.rs
+++ b/hugr-core/src/std_extensions/collections/static_array.rs
@@ -311,7 +311,7 @@ impl HasConcrete for StaticArrayOpDef {
         match type_args {
             [arg] => {
                 if !arg.copyable() {
-                    Err(SignatureError::from(TermTypeError::TypeMismatch {
+                    Err(SignatureError::from(TermTypeError::KindMismatch {
                         type_: Box::new(Copyable.into()),
                         term: Box::new(arg.clone()),
                     }))?

--- a/hugr-core/src/std_extensions/collections/static_array.rs
+++ b/hugr-core/src/std_extensions/collections/static_array.rs
@@ -38,7 +38,7 @@ use crate::{
     types::{
         ConstTypeError, CustomCheckFailure, CustomType, PolyFuncType, Signature, Type, TypeArg,
         TypeBound, TypeName,
-        type_param::{TermTypeError, TypeParam},
+        type_param::{TermKindError, TypeParam},
     },
 };
 
@@ -311,7 +311,7 @@ impl HasConcrete for StaticArrayOpDef {
         match type_args {
             [arg] => {
                 if !arg.copyable() {
-                    Err(SignatureError::from(TermTypeError::KindMismatch {
+                    Err(SignatureError::from(TermKindError::KindMismatch {
                         type_: Box::new(Copyable.into()),
                         term: Box::new(arg.clone()),
                     }))?
@@ -324,7 +324,7 @@ impl HasConcrete for StaticArrayOpDef {
                 })
             }
             _ => Err(
-                SignatureError::TypeArgMismatch(TermTypeError::WrongNumberArgs(type_args.len(), 1))
+                SignatureError::TypeArgMismatch(TermKindError::WrongNumberArgs(type_args.len(), 1))
                     .into(),
             ),
         }

--- a/hugr-core/src/std_extensions/collections/static_array.rs
+++ b/hugr-core/src/std_extensions/collections/static_array.rs
@@ -312,7 +312,7 @@ impl HasConcrete for StaticArrayOpDef {
             [arg] => {
                 if !arg.copyable() {
                     Err(SignatureError::from(TermKindError::KindMismatch {
-                        type_: Box::new(Copyable.into()),
+                        kind: Box::new(Copyable.into()),
                         term: Box::new(arg.clone()),
                     }))?
                 }

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -12,7 +12,7 @@ use crate::extension::resolution::{
     ExtensionCollectionError, WeakExtensionRegistry, collect_term_exts,
 };
 pub use crate::ops::constant::{ConstTypeError, CustomCheckFailure};
-use crate::types::type_param::{TermTypeError, check_term_kind};
+use crate::types::type_param::{TermKindError, check_term_kind};
 use crate::utils::display_list_with_separator;
 pub use check::SumTypeError;
 pub use custom::CustomType;
@@ -503,12 +503,12 @@ impl Deref for Type {
 }
 
 impl TryFrom<Term> for Type {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
-    fn try_from(t: Term) -> Result<Self, TermTypeError> {
+    fn try_from(t: Term) -> Result<Self, TermKindError> {
         match t.least_upper_bound() {
             Some(b) => Ok(Self(t, b)),
-            None => Err(TermTypeError::KindMismatch {
+            None => Err(TermKindError::KindMismatch {
                 term: Box::new(t),
                 type_: Box::new(TypeBound::Linear.into()),
             }),
@@ -608,7 +608,7 @@ pub(crate) mod test {
     use crate::extension::prelude::{option_type, qb_t, usize_t};
     use crate::std_extensions::collections::array::{array_type, array_type_parametric};
     use crate::std_extensions::collections::list::list_type;
-    use crate::types::type_param::TermTypeError;
+    use crate::types::type_param::TermKindError;
     use crate::{Extension, hugr::IdentList, type_row};
 
     #[test]
@@ -783,7 +783,7 @@ pub(crate) mod test {
         let mut t = Type::new_extension(c_of_cpy.clone());
         assert_eq!(
             t.transform(&cpy_to_qb),
-            Err(SignatureError::from(TermTypeError::KindMismatch {
+            Err(SignatureError::from(TermKindError::KindMismatch {
                 type_: Box::new(TypeBound::Copyable.into()),
                 term: Box::new(qb_t().into())
             }))
@@ -795,7 +795,7 @@ pub(crate) mod test {
         );
         assert_eq!(
             t.transform(&cpy_to_qb),
-            Err(SignatureError::from(TermTypeError::KindMismatch {
+            Err(SignatureError::from(TermKindError::KindMismatch {
                 type_: Box::new(TypeBound::Copyable.into()),
                 term: Box::new(mk_opt(qb_t()).into())
             }))

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -510,7 +510,7 @@ impl TryFrom<Term> for Type {
             Some(b) => Ok(Self(t, b)),
             None => Err(TermKindError::KindMismatch {
                 term: Box::new(t),
-                type_: Box::new(TypeBound::Linear.into()),
+                kind: Box::new(TypeBound::Linear.into()),
             }),
         }
     }
@@ -784,7 +784,7 @@ pub(crate) mod test {
         assert_eq!(
             t.transform(&cpy_to_qb),
             Err(SignatureError::from(TermKindError::KindMismatch {
-                type_: Box::new(TypeBound::Copyable.into()),
+                kind: Box::new(TypeBound::Copyable.into()),
                 term: Box::new(qb_t().into())
             }))
         );
@@ -796,7 +796,7 @@ pub(crate) mod test {
         assert_eq!(
             t.transform(&cpy_to_qb),
             Err(SignatureError::from(TermKindError::KindMismatch {
-                type_: Box::new(TypeBound::Copyable.into()),
+                kind: Box::new(TypeBound::Copyable.into()),
                 term: Box::new(mk_opt(qb_t()).into())
             }))
         );

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -508,7 +508,7 @@ impl TryFrom<Term> for Type {
     fn try_from(t: Term) -> Result<Self, TermTypeError> {
         match t.least_upper_bound() {
             Some(b) => Ok(Self(t, b)),
-            None => Err(TermTypeError::TypeMismatch {
+            None => Err(TermTypeError::KindMismatch {
                 term: Box::new(t),
                 type_: Box::new(TypeBound::Linear.into()),
             }),
@@ -783,7 +783,7 @@ pub(crate) mod test {
         let mut t = Type::new_extension(c_of_cpy.clone());
         assert_eq!(
             t.transform(&cpy_to_qb),
-            Err(SignatureError::from(TermTypeError::TypeMismatch {
+            Err(SignatureError::from(TermTypeError::KindMismatch {
                 type_: Box::new(TypeBound::Copyable.into()),
                 term: Box::new(qb_t().into())
             }))
@@ -795,7 +795,7 @@ pub(crate) mod test {
         );
         assert_eq!(
             t.transform(&cpy_to_qb),
-            Err(SignatureError::from(TermTypeError::TypeMismatch {
+            Err(SignatureError::from(TermTypeError::KindMismatch {
                 type_: Box::new(TypeBound::Copyable.into()),
                 term: Box::new(mk_opt(qb_t()).into())
             }))

--- a/hugr-core/src/types/check.rs
+++ b/hugr-core/src/types/check.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use super::{Type, TypeRow};
 use crate::{
     ops::Value,
-    types::{Term, type_param::TermTypeError},
+    types::{Term, type_param::TermKindError},
 };
 
 /// Errors that arise from typechecking constants
@@ -72,7 +72,7 @@ impl super::SumType {
                 num_variants: self.num_variants(),
             })?;
         let variant: TypeRow = variant.clone().try_into().map_err(|e| {
-            let TermTypeError::KindMismatch { term, .. } = e else {
+            let TermKindError::KindMismatch { term, .. } = e else {
                 panic!("Unexpected error {e}")
             };
             let Term::Variable(tv) = &*term else {

--- a/hugr-core/src/types/check.rs
+++ b/hugr-core/src/types/check.rs
@@ -72,7 +72,7 @@ impl super::SumType {
                 num_variants: self.num_variants(),
             })?;
         let variant: TypeRow = variant.clone().try_into().map_err(|e| {
-            let TermTypeError::TypeMismatch { term, .. } = e else {
+            let TermTypeError::KindMismatch { term, .. } = e else {
                 panic!("Unexpected error {e}")
             };
             let Term::Variable(tv) = &*term else {

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -162,7 +162,7 @@ pub(crate) mod test {
     use crate::std_extensions::collections::array::{self, array_type_parametric};
     use crate::std_extensions::collections::list;
     use crate::types::signature::FuncTypeBase;
-    use crate::types::type_param::{TermTypeError, TypeArg, TypeParam};
+    use crate::types::type_param::{TermKindError, TypeArg, TypeParam};
     use crate::types::{
         CustomType, FuncValueType, PolyFuncTypeBase, Signature, Term, Type, TypeBound, TypeName,
         TypeRowLike, TypeRowRV,
@@ -250,7 +250,7 @@ pub(crate) mod test {
         assert_eq!(
             wrong_args,
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::KindMismatch {
+                TermKindError::KindMismatch {
                     type_: Box::new(type_params[0].clone()),
                     term: Box::new(usize_t().into()),
                 }
@@ -258,7 +258,7 @@ pub(crate) mod test {
         );
 
         // (Try to) make a schema with the args in the wrong order
-        let arg_err = SignatureError::TypeArgMismatch(TermTypeError::KindMismatch {
+        let arg_err = SignatureError::TypeArgMismatch(TermKindError::KindMismatch {
             type_: Box::new(type_params[0].clone()),
             term: Box::new(ty_var.clone()),
         });
@@ -355,7 +355,7 @@ pub(crate) mod test {
             assert_eq!(
                 make_scheme(decl.clone()).err(),
                 Some(SignatureError::TypeArgMismatch(
-                    TermTypeError::KindMismatch {
+                    TermKindError::KindMismatch {
                         type_: Box::new(bound.clone()),
                         term: Box::new(TypeArg::new_var_use(0, decl.clone()))
                     }

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -251,7 +251,7 @@ pub(crate) mod test {
             wrong_args,
             Err(SignatureError::TypeArgMismatch(
                 TermKindError::KindMismatch {
-                    type_: Box::new(type_params[0].clone()),
+                    kind: Box::new(type_params[0].clone()),
                     term: Box::new(usize_t().into()),
                 }
             ))
@@ -259,7 +259,7 @@ pub(crate) mod test {
 
         // (Try to) make a schema with the args in the wrong order
         let arg_err = SignatureError::TypeArgMismatch(TermKindError::KindMismatch {
-            type_: Box::new(type_params[0].clone()),
+            kind: Box::new(type_params[0].clone()),
             term: Box::new(ty_var.clone()),
         });
         assert_eq!(
@@ -356,7 +356,7 @@ pub(crate) mod test {
                 make_scheme(decl.clone()).err(),
                 Some(SignatureError::TypeArgMismatch(
                     TermKindError::KindMismatch {
-                        type_: Box::new(bound.clone()),
+                        kind: Box::new(bound.clone()),
                         term: Box::new(TypeArg::new_var_use(0, decl.clone()))
                     }
                 ))

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -250,7 +250,7 @@ pub(crate) mod test {
         assert_eq!(
             wrong_args,
             Err(SignatureError::TypeArgMismatch(
-                TermTypeError::TypeMismatch {
+                TermTypeError::KindMismatch {
                     type_: Box::new(type_params[0].clone()),
                     term: Box::new(usize_t().into()),
                 }
@@ -258,7 +258,7 @@ pub(crate) mod test {
         );
 
         // (Try to) make a schema with the args in the wrong order
-        let arg_err = SignatureError::TypeArgMismatch(TermTypeError::TypeMismatch {
+        let arg_err = SignatureError::TypeArgMismatch(TermTypeError::KindMismatch {
             type_: Box::new(type_params[0].clone()),
             term: Box::new(ty_var.clone()),
         });
@@ -355,7 +355,7 @@ pub(crate) mod test {
             assert_eq!(
                 make_scheme(decl.clone()).err(),
                 Some(SignatureError::TypeArgMismatch(
-                    TermTypeError::TypeMismatch {
+                    TermTypeError::KindMismatch {
                         type_: Box::new(bound.clone()),
                         term: Box::new(TypeArg::new_var_use(0, decl.clone()))
                     }

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -10,7 +10,7 @@ use super::custom::CustomType;
 use crate::extension::prelude::{qb_t, usize_t};
 use crate::ops::AliasDecl;
 use crate::types::TypeRowRV;
-use crate::types::type_param::{SeqPart, TermTypeError, TermVar, UpperBound};
+use crate::types::type_param::{SeqPart, TermKindError, TermVar, UpperBound};
 
 #[derive(Serialize, serde::Deserialize, Clone, Debug)]
 #[serde(tag = "t")]
@@ -51,7 +51,7 @@ impl From<Type> for SerSimpleType {
 
 // Row Variables can also be serialized as "simple types"
 impl TryFrom<Term> for SerSimpleType {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
         if let Term::Variable(tv) = &value
@@ -83,7 +83,7 @@ impl From<SerSimpleType> for Term {
 }
 
 impl TryFrom<SerSimpleType> for Type {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: SerSimpleType) -> Result<Self, Self::Error> {
         Term::from(value).try_into()

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -785,7 +785,7 @@ pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
         (Term::TypeKind(_), Term::StaticKind) => Ok(()),
         (Term::ConstKind(_), Term::StaticKind) => Ok(()),
 
-        _ => Err(TermTypeError::TypeMismatch {
+        _ => Err(TermTypeError::KindMismatch {
             term: Box::new(value.clone()),
             type_: Box::new(kind.clone()),
         }),
@@ -808,11 +808,11 @@ pub fn check_term_kinds(terms: &[Term], types: &[Term]) -> Result<(), TermTypeEr
 #[non_exhaustive]
 pub enum TermTypeError {
     #[allow(missing_docs)]
-    /// For now, general case of a term not fitting a type.
+    /// For now, general case of a term not fitting a kind.
     /// We'll have more cases when we allow general Containers.
     // TODO It may become possible to combine this with ConstTypeError.
-    #[error("Term {term} does not fit declared type {type_}")]
-    TypeMismatch { term: Box<Term>, type_: Box<Term> },
+    #[error("Term {term} does not fit declared kind {type_}")]
+    KindMismatch { term: Box<Term>, type_: Box<Term> },
     /// Wrong number of type arguments (actual vs expected).
     // For now this only happens at the top level (TypeArgs of op/type vs TypeParams of Op/TypeDef).
     // However in the future it may be applicable to e.g. contents of Tuples too.
@@ -1113,7 +1113,7 @@ mod test {
         elems.push(t);
         assert_eq!(
             check_term_kind(&Term::new_list(elems), &outer_param),
-            Err(TermTypeError::TypeMismatch {
+            Err(TermTypeError::KindMismatch {
                 term: Box::new(usize_t().into()),
                 // The error reports the type expected for each element of the list:
                 type_: Box::new(TypeParam::new_list_kind(TypeBound::Linear))

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -726,7 +726,7 @@ impl TermVar {
 /// Checks that a [`Term`] (value) is a valid instance of another [`Term`] (kind)
 ///
 /// I.e. the former is acceptable as an argument to a parameter of the latter.
-pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
+pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermKindError> {
     match (value, kind) {
         (Term::Variable(TermVar { cached_decl, .. }), _) if kind.is_supertype(cached_decl) => {
             Ok(())
@@ -761,7 +761,7 @@ pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
             }
 
             if term_parts.len() != type_parts.len() {
-                return Err(TermTypeError::WrongNumberTuple(
+                return Err(TermKindError::WrongNumberTuple(
                     term_parts.len(),
                     type_parts.len(),
                 ));
@@ -785,7 +785,7 @@ pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
         (Term::TypeKind(_), Term::StaticKind) => Ok(()),
         (Term::ConstKind(_), Term::StaticKind) => Ok(()),
 
-        _ => Err(TermTypeError::KindMismatch {
+        _ => Err(TermKindError::KindMismatch {
             term: Box::new(value.clone()),
             type_: Box::new(kind.clone()),
         }),
@@ -793,9 +793,9 @@ pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermTypeError> {
 }
 
 /// Check a list of [`Term`]s is valid for a list of types.
-pub fn check_term_kinds(terms: &[Term], types: &[Term]) -> Result<(), TermTypeError> {
+pub fn check_term_kinds(terms: &[Term], types: &[Term]) -> Result<(), TermKindError> {
     if terms.len() != types.len() {
-        return Err(TermTypeError::WrongNumberArgs(terms.len(), types.len()));
+        return Err(TermKindError::WrongNumberArgs(terms.len(), types.len()));
     }
     for (term, type_) in terms.iter().zip(types.iter()) {
         check_term_kind(term, type_)?;
@@ -803,10 +803,10 @@ pub fn check_term_kinds(terms: &[Term], types: &[Term]) -> Result<(), TermTypeEr
     Ok(())
 }
 
-/// Errors that can occur when checking that a [`Term`] has an expected type.
+/// Errors that can occur when checking that a [`Term`] has an expected kind.
 #[derive(Clone, Debug, PartialEq, Eq, Error)]
 #[non_exhaustive]
-pub enum TermTypeError {
+pub enum TermKindError {
     #[allow(missing_docs)]
     /// For now, general case of a term not fitting a kind.
     /// We'll have more cases when we allow general Containers.
@@ -916,7 +916,7 @@ mod test {
     use super::{Substitution, TypeArg, TypeParam, check_term_kind};
     use crate::extension::prelude::{bool_t, usize_t};
     use crate::types::type_param::SeqPart;
-    use crate::types::{Term, Type, TypeBound, TypeRow, type_param::TermTypeError};
+    use crate::types::{Term, Type, TypeBound, TypeRow, type_param::TermKindError};
 
     #[test]
     fn new_list_from_parts_items() {
@@ -978,13 +978,13 @@ mod test {
     #[test]
     fn type_arg_fits_param() {
         let rowvar = Term::new_row_var_use;
-        fn check(arg: impl Into<TypeArg>, param: &TypeParam) -> Result<(), TermTypeError> {
+        fn check(arg: impl Into<TypeArg>, param: &TypeParam) -> Result<(), TermKindError> {
             check_term_kind(&arg.into(), param)
         }
         fn check_seq<T: Clone + Into<TypeArg>>(
             args: &[T],
             param: &TypeParam,
-        ) -> Result<(), TermTypeError> {
+        ) -> Result<(), TermKindError> {
             check_term_kind(&Term::new_list(args.to_vec()), param)
         }
         // Simple cases: Term::XXXTypes are Term::TypeKind's
@@ -1113,7 +1113,7 @@ mod test {
         elems.push(t);
         assert_eq!(
             check_term_kind(&Term::new_list(elems), &outer_param),
-            Err(TermTypeError::KindMismatch {
+            Err(TermKindError::KindMismatch {
                 term: Box::new(usize_t().into()),
                 // The error reports the type expected for each element of the list:
                 type_: Box::new(TypeParam::new_list_kind(TypeBound::Linear))

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -787,7 +787,7 @@ pub fn check_term_kind(value: &Term, kind: &Term) -> Result<(), TermKindError> {
 
         _ => Err(TermKindError::KindMismatch {
             term: Box::new(value.clone()),
-            type_: Box::new(kind.clone()),
+            kind: Box::new(kind.clone()),
         }),
     }
 }
@@ -811,24 +811,24 @@ pub enum TermKindError {
     /// For now, general case of a term not fitting a kind.
     /// We'll have more cases when we allow general Containers.
     // TODO It may become possible to combine this with ConstTypeError.
-    #[error("Term {term} does not fit declared kind {type_}")]
-    KindMismatch { term: Box<Term>, type_: Box<Term> },
-    /// Wrong number of type arguments (actual vs expected).
-    // For now this only happens at the top level (TypeArgs of op/type vs TypeParams of Op/TypeDef).
-    // However in the future it may be applicable to e.g. contents of Tuples too.
-    #[error("Wrong number of type arguments: {0} vs expected {1} declared type parameters")]
+    #[error("Term {term} does not fit declared kind {kind}")]
+    KindMismatch { term: Box<Term>, kind: Box<Term> },
+    /// Wrong number of term arguments (actual vs expected).
+    // For now this is just args of op/type vs params declared by Op/TypeDef,
+    // however in the future it may be applicable to e.g. contents of Tuples too.
+    #[error("Wrong number of term arguments: {0} vs expected {1} declared parameters")]
     WrongNumberArgs(usize, usize),
 
-    /// Wrong number of type arguments in tuple (actual vs expected).
+    /// Wrong number of terms in tuple (actual vs expected).
     #[error(
-        "Wrong number of type arguments to tuple parameter: {0} vs expected {1} declared type parameters"
+        "Wrong number of terms in tuple: {0} vs expected {1} declared by parameter"
     )]
     WrongNumberTuple(usize, usize),
     /// Opaque value type check error.
     #[error("Opaque type argument does not fit declared parameter type: {0}")]
     OpaqueTypeMismatch(#[from] crate::types::CustomCheckFailure),
     /// Invalid value
-    #[error("Invalid value of type argument")]
+    #[error("Invalid value of term argument")]
     InvalidValue(Box<TypeArg>),
 }
 
@@ -1116,7 +1116,7 @@ mod test {
             Err(TermKindError::KindMismatch {
                 term: Box::new(usize_t().into()),
                 // The error reports the type expected for each element of the list:
-                type_: Box::new(TypeParam::new_list_kind(TypeBound::Linear))
+                kind: Box::new(TypeParam::new_list_kind(TypeBound::Linear))
             })
         );
 

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -824,9 +824,6 @@ pub enum TermKindError {
         "Wrong number of terms in tuple: {0} vs expected {1} declared by parameter"
     )]
     WrongNumberTuple(usize, usize),
-    /// Opaque value type check error.
-    #[error("Opaque type argument does not fit declared parameter type: {0}")]
-    OpaqueTypeMismatch(#[from] crate::types::CustomCheckFailure),
     /// Invalid value
     #[error("Invalid value of term argument")]
     InvalidValue(Box<TypeArg>),

--- a/hugr-core/src/types/type_row.rs
+++ b/hugr-core/src/types/type_row.rs
@@ -12,7 +12,7 @@ use crate::{
     extension::SignatureError,
     types::{
         TypeBound,
-        type_param::{TermTypeError, check_term_kind},
+        type_param::{TermKindError, check_term_kind},
     },
     utils::display_list,
 };
@@ -165,7 +165,7 @@ impl From<Vec<Type>> for TypeRow {
 }
 
 impl TryFrom<Vec<Term>> for TypeRow {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: Vec<Term>) -> Result<Self, Self::Error> {
         value
@@ -206,7 +206,7 @@ impl PartialEq<Term> for TypeRow {
 ///
 /// This will fail if `arg` is not a [Term::List] or any of the elements are not [Type]s
 impl TryFrom<Term> for TypeRow {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: Term) -> Result<Self, Self::Error> {
         match value {
@@ -215,7 +215,7 @@ impl TryFrom<Term> for TypeRow {
                 .map(Type::try_from)
                 .collect::<Result<Vec<_>, _>>()?
                 .into()),
-            v => Err(TermTypeError::InvalidValue(Box::new(v))),
+            v => Err(TermKindError::InvalidValue(Box::new(v))),
         }
     }
 }
@@ -301,7 +301,7 @@ impl TypeRowLike for TypeRowRV {
 }
 
 impl TryFrom<TypeRowRV> for TypeRow {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(value: TypeRowRV) -> Result<Self, Self::Error> {
         value.0.try_into()
@@ -342,7 +342,7 @@ impl std::ops::Deref for TypeRowRV {
 }
 
 impl TryFrom<Term> for TypeRowRV {
-    type Error = TermTypeError;
+    type Error = TermKindError;
 
     fn try_from(t: Term) -> Result<Self, Self::Error> {
         check_term_kind(&t, &Term::new_list_kind(TypeBound::Linear))?;


### PR DESCRIPTION
Continuing from #3019 where I suggested renaming the "TypeMismatch" variant of this enum to "KindMismatch". Well it seems like we should do that, but in which case we should do a bit more too....

Will merge this into #3019 before merging that into main.