### PR TITLE
feat: SiblingSubgraphs with polymorphic signatures

### DIFF
--- a/hugr-core/src/hugr/patch/simple_replace.rs
+++ b/hugr-core/src/hugr/patch/simple_replace.rs
@@ -45,6 +45,11 @@ impl<HostNode: HugrNode> SimpleReplacement<HostNode> {
 
     /// Create a new [`SimpleReplacement`] specification.
     ///
+    /// The given replacement should have an entrypoint that is a dataflow container (such as a DFG
+    /// or a function definition). If the entrypoint is a function, its (potentially polymorphic)
+    /// signature will be checked against the subgraph signature, otherwise the inner function type
+    /// of the entrypoint will be checked against the subgraph signature.
+    ///
     /// Return a [`InvalidReplacement::InvalidSignature`] error if `subgraph`
     /// and `replacement` have different signatures.
     pub fn try_new(
@@ -52,18 +57,24 @@ impl<HostNode: HugrNode> SimpleReplacement<HostNode> {
         host: &impl HugrView<Node = HostNode>,
         replacement: Hugr,
     ) -> Result<Self, InvalidReplacement> {
-        let subgraph_sig = subgraph.signature(host);
-        let repl_sig =
-            replacement
-                .inner_function_type()
-                .ok_or(InvalidReplacement::InvalidDataflowGraph {
-                    node: replacement.entrypoint(),
-                    op: Box::new(replacement.get_optype(replacement.entrypoint()).to_owned()),
-                })?;
-        if &subgraph_sig != repl_sig.as_ref() {
+        let subgraph_sig = subgraph.poly_func_type(host);
+        let repl_sig = replacement
+            .poly_func_type()
+            .or(Some(
+                replacement
+                    .inner_function_type()
+                    .unwrap()
+                    .into_owned()
+                    .into(),
+            ))
+            .ok_or(InvalidReplacement::InvalidDataflowGraph {
+                node: replacement.entrypoint(),
+                op: Box::new(replacement.get_optype(replacement.entrypoint()).to_owned()),
+            })?;
+        if subgraph_sig != repl_sig {
             return Err(InvalidReplacement::InvalidSignature {
                 expected: Box::new(subgraph_sig),
-                actual: Some(Box::new(repl_sig.into_owned())),
+                actual: Some(Box::new(repl_sig)),
             });
         }
         Ok(Self {
@@ -157,7 +168,13 @@ impl<HostNode: HugrNode> SimpleReplacement<HostNode> {
         host: &impl HugrView<Node = HostNode>,
         boundary: BoundaryMode,
     ) -> BoundaryPort<HostNode, OutgoingPort> {
-        debug_assert!(pos < self.subgraph().signature(host).output_count());
+        debug_assert!(
+            pos < self
+                .subgraph()
+                .poly_func_type(host)
+                .into_body()
+                .output_count()
+        );
 
         // The outgoing ports at the output boundary of `replacement`
         let [repl_inp, repl_out] = self.get_replacement_io();
@@ -245,7 +262,13 @@ impl<HostNode: HugrNode> SimpleReplacement<HostNode> {
         host: &impl HugrView<Node = HostNode>,
         boundary: BoundaryMode,
     ) -> impl Iterator<Item = BoundaryPort<HostNode, IncomingPort>> {
-        debug_assert!(pos < self.subgraph().signature(host).input_count());
+        debug_assert!(
+            pos < self
+                .subgraph()
+                .poly_func_type(host)
+                .into_body()
+                .input_count()
+        );
 
         let [repl_inp, repl_out] = self.get_replacement_io();
         self.replacement

--- a/hugr-core/src/hugr/patch/simple_replace.rs
+++ b/hugr-core/src/hugr/patch/simple_replace.rs
@@ -60,16 +60,18 @@ impl<HostNode: HugrNode> SimpleReplacement<HostNode> {
         let subgraph_sig = subgraph.poly_func_type(host);
         let repl_sig = replacement
             .poly_func_type()
-            .or(Some(
-                replacement
-                    .inner_function_type()
-                    .unwrap()
-                    .into_owned()
-                    .into(),
-            ))
+            .or_else(|| {
+                Some(
+                    replacement
+                        .inner_function_type()
+                        .unwrap()
+                        .into_owned()
+                        .into(),
+                )
+            })
             .ok_or(InvalidReplacement::InvalidDataflowGraph {
                 node: replacement.entrypoint(),
-                op: Box::new(replacement.get_optype(replacement.entrypoint()).to_owned()),
+                op: Box::new(replacement.entrypoint_optype().to_owned()),
             })?;
         if subgraph_sig != repl_sig {
             return Err(InvalidReplacement::InvalidSignature {

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -13,6 +13,7 @@ use portgraph::{PortView, algorithms::CreateConvexChecker, boundary::Boundary};
 use rustc_hash::FxHashSet;
 use thiserror::Error;
 
+use super::{RootChecked, SchedulingGraph, SynEdgeWrapper};
 use crate::builder::{Container, FunctionBuilder};
 use crate::core::HugrNode;
 use crate::hugr::internal::{HugrInternals, PortgraphNodeMap};
@@ -20,10 +21,8 @@ use crate::hugr::{HugrMut, HugrView};
 use crate::ops::dataflow::DataflowOpTrait;
 use crate::ops::handle::{ContainerHandle, DataflowOpID};
 use crate::ops::{NamedOp, OpTag, OpTrait, OpType};
-use crate::types::{Signature, Type};
+use crate::types::{PolyFuncType, Signature, Type};
 use crate::{Hugr, IncomingPort, Node, OutgoingPort, Port, SimpleReplacement};
-
-use super::{RootChecked, SchedulingGraph, SynEdgeWrapper};
 
 mod convex;
 
@@ -550,7 +549,7 @@ impl<N: HugrNode> SiblingSubgraph<N> {
     }
 
     /// Check the validity of the subgraph, as described in the docs of
-    /// [`SiblingSubgraph::try_new`], but do not check convexity.    
+    /// [`SiblingSubgraph::try_new`], but do not check convexity.
     pub fn validate_skip_convexity(
         &self,
         hugr: &impl HugrView<Node = N>,
@@ -652,7 +651,17 @@ impl<N: HugrNode> SiblingSubgraph<N> {
     }
 
     /// The signature of the subgraph.
+    ///
+    /// Panics if the signature contains unresolved type variables, i.e. is polymorphic. Use
+    /// [`SiblingSubgraph::poly_func_type`] instead.
     pub fn signature(&self, hugr: &impl HugrView<Node = N>) -> Signature {
+        let poly_func_type = self.poly_func_type(hugr);
+        assert_eq!(poly_func_type.params(), &[]);
+        poly_func_type.into_body()
+    }
+
+    /// The (potentially polymorphic) signature of the subgraph.
+    pub fn poly_func_type(&self, hugr: &impl HugrView<Node = N>) -> PolyFuncType {
         let input = self
             .inputs
             .iter()
@@ -670,7 +679,26 @@ impl<N: HugrNode> SiblingSubgraph<N> {
                 sig.port_type(p).cloned().expect("must be dataflow edge")
             })
             .collect_vec();
-        Signature::new(input, output)
+
+        // Discover type variable declarations from the closest function definition, if type
+        // variable usages are found.
+        let params = if input.iter().any(|t| t.is_parametrized())
+            || output.iter().any(|t| t.is_parametrized())
+        {
+            let mut parent = self.get_parent(hugr);
+            while !hugr.get_optype(parent).is_func_defn() {
+                parent = hugr.get_parent(parent).unwrap();
+            }
+            hugr.get_optype(parent)
+                .as_func_defn()
+                .unwrap()
+                .signature()
+                .params()
+        } else {
+            &[]
+        };
+
+        PolyFuncType::new(params, Signature::new(input, output))
     }
 
     /// The parent of the sibling subgraph.
@@ -768,7 +796,7 @@ impl<N: HugrNode> SiblingSubgraph<N> {
         hugr: &impl HugrView<Node = N>,
         name: impl Into<String>,
     ) -> Hugr {
-        let mut builder = FunctionBuilder::new(name, self.signature(hugr)).unwrap();
+        let mut builder = FunctionBuilder::new(name, self.poly_func_type(hugr)).unwrap();
         // Take the unfinished Hugr from the builder, to avoid unnecessary
         // validation checks that require connecting the inputs and outputs.
         let mut extracted = mem::take(builder.hugr_mut());
@@ -1460,9 +1488,9 @@ pub enum InvalidReplacement {
     ]
     InvalidSignature {
         /// The expected signature.
-        expected: Box<Signature>,
+        expected: Box<PolyFuncType>,
         /// The actual signature.
-        actual: Option<Box<Signature>>,
+        actual: Option<Box<PolyFuncType>>,
     },
     /// `SiblingSubgraph` is not convex.
     #[error("SiblingSubgraph is not convex.")]

--- a/hugr-core/src/hugr/views/sibling_subgraph/tests.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph/tests.rs
@@ -1,3 +1,6 @@
+use crate::std_extensions::collections::array::array_type_parametric;
+use crate::types::TypeArg;
+use crate::types::type_param::TypeParam;
 use std::collections::BTreeSet;
 
 use cool_asserts::assert_matches;
@@ -181,6 +184,45 @@ fn test_signature() -> Result<(), InvalidSubgraph> {
     assert_eq!(
         sub.signature(&func),
         Signature::new_endo([qb_t(), qb_t(), qb_t()])
+    );
+    Ok(())
+}
+
+#[test]
+fn test_polymorphic_signature() -> Result<(), InvalidSubgraph> {
+    let mut mod_builder = ModuleBuilder::new();
+    let arr_type =
+        array_type_parametric(TypeArg::new_var_use(0, TypeParam::max_nat_type()), bool_t())
+            .unwrap();
+    let func_id = {
+        let mut h = mod_builder
+            .define_function(
+                "test",
+                PolyFuncType::new(
+                    vec![TypeParam::max_nat_type()],
+                    Signature::new_endo(vec![arr_type.clone()]),
+                ),
+            )
+            .unwrap();
+        let [arr] = h.input_wires_arr();
+        let tuple = h.make_tuple([arr]).unwrap();
+        let op = UnpackTuple::new(vec![arr_type.clone()].into());
+        let [arr] = h.add_dataflow_op(op, [tuple]).unwrap().outputs_arr();
+        h.finish_with_outputs([arr]).unwrap()
+    };
+    let hugr = mod_builder.finish_hugr().unwrap();
+
+    let func = hugr.with_entrypoint(func_id.node());
+    let sub = SiblingSubgraph::try_new_dataflow_subgraph::<_, FuncID<true>>(
+        RootChecked::try_new(&func).expect("Root should be FuncDefn."),
+    )?;
+    assert!(sub.validate_default(&func).is_ok());
+    assert_eq!(
+        sub.poly_func_type(&func),
+        PolyFuncType::new(
+            vec![TypeParam::max_nat_type()],
+            Signature::new_endo(vec![arr_type]),
+        ),
     );
     Ok(())
 }

--- a/hugr-core/src/hugr/views/sibling_subgraph/tests.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph/tests.rs
@@ -228,6 +228,53 @@ fn test_polymorphic_signature() -> Result<(), InvalidSubgraph> {
 }
 
 #[test]
+fn test_polymorphic_signature_nested() -> Result<(), InvalidSubgraph> {
+    let mut mod_builder = ModuleBuilder::new();
+    let arr_type =
+        array_type_parametric(TypeArg::new_var_use(0, TypeParam::max_nat_type()), bool_t())
+            .unwrap();
+    let dfg_node = {
+        let mut h = mod_builder
+            .define_function(
+                "test",
+                PolyFuncType::new(
+                    vec![TypeParam::max_nat_type()],
+                    Signature::new_endo(vec![arr_type.clone()]),
+                ),
+            )
+            .unwrap();
+        let [arr] = h.input_wires_arr();
+        // Nest target subgraph inside a DFG
+        let mut dfg = h
+            .dfg_builder(Signature::new_endo(vec![arr_type.clone()]), [arr])
+            .unwrap();
+        let [arr] = dfg.input_wires_arr();
+        let tuple = dfg.make_tuple([arr]).unwrap();
+        let op = UnpackTuple::new(vec![arr_type.clone()].into());
+        let [arr] = dfg.add_dataflow_op(op, [tuple]).unwrap().outputs_arr();
+        let dfg = dfg.finish_with_outputs([arr]).unwrap();
+        let [arr] = dfg.outputs_arr();
+        h.finish_with_outputs([arr]).unwrap();
+
+        dfg.node()
+    };
+    let hugr = mod_builder.finish_hugr().unwrap();
+
+    // Skip the input and output nodes of the dfg
+    let nodes = hugr.children(dfg_node).skip(2).collect_vec();
+    let sub = SiblingSubgraph::try_from_nodes(nodes, &hugr)?;
+    assert!(sub.validate_default(&hugr).is_ok(),);
+    assert_eq!(
+        sub.poly_func_type(&hugr),
+        PolyFuncType::new(
+            vec![TypeParam::max_nat_type()],
+            Signature::new_endo(vec![arr_type]),
+        ),
+    );
+    Ok(())
+}
+
+#[test]
 fn construct_simple_replacement_invalid_signature() -> Result<(), InvalidSubgraph> {
     let (hugr, dfg) = build_hugr().unwrap();
     let func = hugr.with_entrypoint(dfg);

--- a/hugr-core/src/types/poly_func.rs
+++ b/hugr-core/src/types/poly_func.rs
@@ -144,6 +144,11 @@ impl<T: TypeRowLike> PolyFuncTypeBase<T> {
     pub fn body_mut(&mut self) -> &mut FuncTypeBase<T> {
         &mut self.body
     }
+
+    /// Consumes the function type to extract the body.
+    pub fn into_body(self) -> FuncTypeBase<T> {
+        self.body
+    }
 }
 
 // Do not implement Substitutable: we never need to substitute into a PolyFuncType

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -460,7 +460,7 @@ impl Term {
                 rows.iter().any(|row| row.is_parametrized())
             }
             Term::RuntimeSum(SumType::Unit { .. }) => false, // No leaves there
-            Term::RuntimeExtension(custy) => !custy.args().is_empty(),
+            Term::RuntimeExtension(custy) => custy.args().iter().any(Term::is_parametrized),
             Term::RuntimeFunction(ft) => ft.input.is_parametrized() || ft.output.is_parametrized(),
             Term::List(elems) => elems.iter().any(Term::is_parametrized),
             Term::Tuple(elems) => elems.iter().any(Term::is_parametrized),

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -453,6 +453,30 @@ impl Term {
         }
     }
 
+    /// Checks whether the term is parametric, i.e. it (recursively) contains variables.
+    pub(crate) fn is_parametrized(&self) -> bool {
+        match self {
+            Term::RuntimeSum(SumType::General { rows }) => {
+                rows.iter().any(|row| row.is_parametrized())
+            }
+            Term::RuntimeSum(SumType::Unit { .. }) => false, // No leaves there
+            Term::RuntimeExtension(custy) => !custy.args().is_empty(),
+            Term::RuntimeFunction(ft) => ft.input.is_parametrized() || ft.output.is_parametrized(),
+            Term::List(elems) => elems.iter().any(Term::is_parametrized),
+            Term::Tuple(elems) => elems.iter().any(Term::is_parametrized),
+            TypeArg::ListConcat(lists) => lists.iter().any(Term::is_parametrized),
+            TypeArg::TupleConcat(tuples) => tuples.iter().any(Term::is_parametrized),
+            Term::BoundedNat(_) | Term::String(_) | Term::Float(_) | Term::Bytes(_) => false,
+            Term::BoundedNatType(_) | Term::StringType | Term::BytesType | Term::FloatType => false,
+            Term::RuntimeType(_) => false,
+            Term::StaticType => false,
+            Term::ListType(item_type) => item_type.is_parametrized(),
+            Term::TupleType(item_types) => item_types.is_parametrized(),
+            Term::ConstType(ty) => ty.is_parametrized(),
+            Term::Variable(_) => true,
+        }
+    }
+
     pub(crate) fn substitute(&self, t: &Substitution) -> Self {
         match self {
             TypeArg::RuntimeSum(SumType::Unit { .. }) => self.clone(),


### PR DESCRIPTION
In some situations (e.g. when removing tuple/untuple where at least one element contains a type argument), a SiblingSubgraph may need to represent itself using a polymorphic signature. This PR enables this, keeping the old `::signature` with a check that the type parameters are empty.

Related to: https://github.com/Quantinuum/tket2/issues/1486