### PR TITLE
feat: Metadata key aliases for non-breaking migrations

### DIFF
--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -895,6 +895,13 @@ pub(super) mod test {
             type Type<'hugr> = MetaSelf;
         }
 
+        struct MetaAliased;
+        impl Metadata for MetaAliased {
+            const KEY: &'static str = "meta_aliased";
+            const ALIASES: &'static [&'static str] = &["meta_aliased_old", "meta_aliased_older"];
+            type Type<'hugr> = &'hugr str;
+        }
+
         assert_eq!(hugr.get_metadata::<MetaString>(root), None);
         *hugr.get_metadata_any_mut(root, MetaString::KEY) = "test".into();
         assert_eq!(hugr.get_metadata::<MetaString>(root), Some("test"));
@@ -909,6 +916,18 @@ pub(super) mod test {
 
         hugr.remove_metadata::<MetaSelf>(root);
         assert_eq!(hugr.get_metadata::<MetaSelf>(root), None);
+
+        *hugr.get_metadata_any_mut(root, "meta_aliased_older") = "older".into();
+        assert_eq!(hugr.get_metadata::<MetaAliased>(root), Some("older"));
+
+        *hugr.get_metadata_any_mut(root, "meta_aliased_old") = "old".into();
+        assert_eq!(hugr.get_metadata::<MetaAliased>(root), Some("old"));
+
+        hugr.set_metadata::<MetaAliased>(root, "new");
+        assert_eq!(hugr.get_metadata::<MetaAliased>(root), Some("new"));
+
+        *hugr.get_metadata_any_mut(root, MetaAliased::KEY) = 42.into();
+        assert_eq!(hugr.get_metadata::<MetaAliased>(root), None);
     }
 
     #[test]

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -105,10 +105,14 @@ pub trait HugrView: HugrInternals {
 
     /// Returns the metadata associated with a node.
     ///
+    /// Looks up metadata under `M::KEY`, then under `M::ALIASES` in order.
+    ///
     /// For a non type-safe accessor use [`HugrView::get_metadata_any`] instead.
     #[inline]
     fn get_metadata<M: Metadata>(&self, node: Self::Node) -> Option<<M as Metadata>::Type<'_>> {
-        self.get_metadata_any(node, <M as Metadata>::KEY)
+        std::iter::once(<M as Metadata>::KEY)
+            .chain(<M as Metadata>::ALIASES.iter().copied())
+            .find_map(|key| self.get_metadata_any(node, key))
             .and_then(|value| <<M as Metadata>::Type<'_> as Deserialize>::deserialize(value).ok())
     }
 

--- a/hugr-core/src/hugr/views.rs
+++ b/hugr-core/src/hugr/views.rs
@@ -105,7 +105,7 @@ pub trait HugrView: HugrInternals {
 
     /// Returns the metadata associated with a node.
     ///
-    /// Looks up metadata under `M::KEY`, then under `M::ALIASES` in order.
+    /// Looks up metadata under `M::KEY`, then under entries of `M::ALIASES` in order.
     ///
     /// For a non type-safe accessor use [`HugrView::get_metadata_any`] instead.
     #[inline]

--- a/hugr-core/src/metadata.rs
+++ b/hugr-core/src/metadata.rs
@@ -42,6 +42,8 @@ pub trait Metadata {
     /// Typed metadata reads use these, in order, as fallbacks when [`Metadata::KEY`]
     /// is not present. This is intended for backward compatibility when renaming
     /// metadata keys.
+    ///
+    /// Metadata writes ignore this field and only write to [`Metadata::KEY`].
     const ALIASES: &'static [&'static str] = &[];
     /// The type of the metadata value.
     type Type<'hugr>: serde::de::Deserialize<'hugr> + serde::ser::Serialize;

--- a/hugr-core/src/metadata.rs
+++ b/hugr-core/src/metadata.rs
@@ -37,6 +37,12 @@ pub type RawMetadataValue = serde_json::Value;
 pub trait Metadata {
     /// Key associated with the metadata entry.
     const KEY: &'static str;
+    /// Other aliases of the metadata key.
+    ///
+    /// Typed metadata reads use these, in order, as fallbacks when [`Metadata::KEY`]
+    /// is not present. This is intended for backward compatibility when renaming
+    /// metadata keys.
+    const ALIASES: &'static [&'static str] = &[];
     /// The type of the metadata value.
     type Type<'hugr>: serde::de::Deserialize<'hugr> + serde::ser::Serialize;
 }

--- a/hugr-py/src/hugr/metadata.py
+++ b/hugr-py/src/hugr/metadata.py
@@ -37,18 +37,22 @@ class Metadata(Protocol[Meta]):
     primitive type, `to_json` and `from_json` must be implemented to serialize
     and deserialize the value.
 
-    Class variables:
-        KEY: The unique key associated with the metadata entry.
-        ALIASES: Other aliases of the metadata key. Typed metadata reads use
-            these, in order, as fallbacks when KEY is not present. This is used
-            for backward compatibility when renaming metadata keys.
-
     Args:
         value: The value of the metadata.
     """
 
     KEY: ClassVar[str]
+    """The unique key associated with the metadata entry."""
+
     ALIASES: ClassVar[list[str]] = []
+    """Other aliases of the metadata key.
+
+    Typed metadata reads use these, in order, as fallbacks when KEY is not
+    present. This is used for backward compatibility when renaming metadata
+    keys.
+
+    Writes ignore this field and only write to KEY.
+    """
 
     @classmethod
     def to_json(cls, value: Meta) -> JsonType:
@@ -76,6 +80,7 @@ class NodeMetadata:
     _dict: dict[str, JsonType]
 
     def __init__(self, metadata: dict[str, JsonType] | None = None) -> None:
+        """Create a metadata record from an optional raw metadata dictionary."""
         if metadata is None:
             metadata = {}
         # Only a shallow copy, values may still be shared with the original dictionary.
@@ -83,9 +88,11 @@ class NodeMetadata:
 
     @staticmethod
     def _keys_for_metadata(key: type[Metadata[Meta]]) -> Iterable[str]:
+        """Return the raw metadata keys used when reading typed metadata."""
         return (key.KEY, *key.ALIASES)
 
     def _typed_json(self, key: type[Metadata[Meta]]) -> JsonType:
+        """Return the stored JSON value for a typed metadata entry."""
         for raw_key in self._keys_for_metadata(key):
             if raw_key in self._dict:
                 return self._dict[raw_key]
@@ -100,6 +107,16 @@ class NodeMetadata:
     def get(
         self, key: str | type[Metadata[Meta]], default: Any | None = None
     ) -> Meta | JsonType | None:
+        """Return a metadata value, or a default if the key is missing.
+
+        When `key` is a string, it is looked up directly in the raw metadata
+        dictionary. When `key` is a typed `Metadata` class, the metadata is
+        looked up using `key.KEY` first, then each entry in `key.ALIASES` in
+        order.
+
+        Typed values are deserialized with `key.from_json` before being
+        returned.
+        """
         if isinstance(key, str):
             return self._dict.get(key, default)
         else:
@@ -110,9 +127,11 @@ class NodeMetadata:
             return key.from_json(val)
 
     def items(self) -> Iterable[tuple[str, JsonType]]:
+        """Return an iterable over the raw metadata key-value pairs."""
         return self._dict.items()
 
     def as_dict(self) -> dict[str, JsonType]:
+        """Return the underlying raw metadata dictionary."""
         return self._dict
 
     @overload
@@ -120,6 +139,12 @@ class NodeMetadata:
     @overload
     def __getitem__(self, key: type[Metadata[Meta]]) -> Meta: ...
     def __getitem__(self, key: str | type[Metadata[Meta]]) -> JsonType | Meta:
+        """Return a raw or typed metadata value.
+
+        String keys are looked up directly. Typed metadata keys use their
+        primary key and aliases, and deserialize the stored JSON value before
+        returning it.
+        """
         if isinstance(key, str):
             return self._dict[key]
         else:
@@ -133,6 +158,12 @@ class NodeMetadata:
     def __setitem__(
         self, key: str | type[Metadata[Meta]], value: JsonType | Meta
     ) -> None:
+        """Set a raw or typed metadata value.
+
+        String keys store JSON values directly. Typed metadata keys serialize
+        values with `key.to_json` and always write to `key.KEY`; aliases are
+        ignored when writing.
+        """
         if isinstance(key, str):
             # Recursive types cannot be checked by isinstance, so we can only use a
             # surface level check.
@@ -147,12 +178,18 @@ class NodeMetadata:
             self._dict[key.KEY] = json_value
 
     def __iter__(self) -> Iterator[str]:
+        """Iterate over the raw metadata keys."""
         return iter(self._dict)
 
     def __len__(self) -> int:
+        """Return the number of raw metadata entries."""
         return len(self._dict)
 
     def __contains__(self, key: str | type[Metadata[Meta]]) -> bool:
+        """Return whether a raw or typed metadata key is present.
+
+        Typed metadata keys match either their primary key or any alias.
+        """
         if isinstance(key, str):
             return key in self._dict
         return any(raw_key in self._dict for raw_key in self._keys_for_metadata(key))

--- a/hugr-py/src/hugr/metadata.py
+++ b/hugr-py/src/hugr/metadata.py
@@ -37,11 +37,18 @@ class Metadata(Protocol[Meta]):
     primitive type, `to_json` and `from_json` must be implemented to serialize
     and deserialize the value.
 
+    Class variables:
+        KEY: The unique key associated with the metadata entry.
+        ALIASES: Other aliases of the metadata key. Typed metadata reads use
+            these, in order, as fallbacks when KEY is not present. This is used
+            for backward compatibility when renaming metadata keys.
+
     Args:
         value: The value of the metadata.
     """
 
     KEY: ClassVar[str]
+    ALIASES: ClassVar[list[str]] = []
 
     @classmethod
     def to_json(cls, value: Meta) -> JsonType:
@@ -74,6 +81,16 @@ class NodeMetadata:
         # Only a shallow copy, values may still be shared with the original dictionary.
         self._dict = copy.copy(metadata)
 
+    @staticmethod
+    def _keys_for_metadata(key: type[Metadata[Meta]]) -> Iterable[str]:
+        return (key.KEY, *key.ALIASES)
+
+    def _typed_json(self, key: type[Metadata[Meta]]) -> JsonType:
+        for raw_key in self._keys_for_metadata(key):
+            if raw_key in self._dict:
+                return self._dict[raw_key]
+        raise KeyError(key.KEY)
+
     @overload
     def get(self, key: type[Metadata[Meta]], default: Meta) -> Meta: ...
     @overload
@@ -85,11 +102,12 @@ class NodeMetadata:
     ) -> Meta | JsonType | None:
         if isinstance(key, str):
             return self._dict.get(key, default)
-        elif key.KEY in self._dict:
-            val = self._dict[key.KEY]
-            return key.from_json(val)
         else:
-            return default
+            try:
+                val = self._typed_json(key)
+            except KeyError:
+                return default
+            return key.from_json(val)
 
     def items(self) -> Iterable[tuple[str, JsonType]]:
         return self._dict.items()
@@ -105,7 +123,7 @@ class NodeMetadata:
         if isinstance(key, str):
             return self._dict[key]
         else:
-            val = self._dict[key.KEY]
+            val = self._typed_json(key)
             return key.from_json(val)
 
     @overload
@@ -135,9 +153,9 @@ class NodeMetadata:
         return len(self._dict)
 
     def __contains__(self, key: str | type[Metadata[Meta]]) -> bool:
-        if not isinstance(key, str):
-            key = key.KEY
-        return key in self._dict
+        if isinstance(key, str):
+            return key in self._dict
+        return any(raw_key in self._dict for raw_key in self._keys_for_metadata(key))
 
     def __repr__(self) -> str:
         return f"NodeMetadata({self._dict})"

--- a/hugr-py/tests/test_metadata.py
+++ b/hugr-py/tests/test_metadata.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 
+import pytest
 from semver import Version
 
 from hugr import ops, tys
@@ -14,12 +15,25 @@ from hugr.metadata import (
     HugrGenerator,
     HugrUsedExtensions,
     Metadata,
+    NodeMetadata,
 )
 from hugr.utils import JsonType
 
 
 class CustomMetadata(Metadata[list[JsonType]]):
     KEY = "custom.metadata"
+
+
+class AliasedMetadata(Metadata[int]):
+    KEY = "custom.metadata.new"
+    ALIASES: ClassVar[list[str]] = ["custom.metadata.old", "custom.metadata.older"]
+
+    @classmethod
+    def from_json(cls, value: JsonType) -> int:
+        if not isinstance(value, int):
+            msg = f"Expected aliased metadata to be an int, but got {type(value)}"
+            raise TypeError(msg)
+        return value
 
 
 def test_metadata_properties() -> None:
@@ -94,6 +108,28 @@ def test_metadata_default() -> None:
     ) == GeneratorDesc("hugr-py-test", Version.parse("1.2.3"))
     assert node.metadata.get("missing.metadata") is None
     assert node.metadata.get("missing.metadata", [1, 2, 3]) == [1, 2, 3]
+
+
+def test_metadata_aliases() -> None:
+    metadata = NodeMetadata(
+        {
+            "custom.metadata.older": 1,
+            "custom.metadata.old": 2,
+        }
+    )
+
+    assert AliasedMetadata in metadata
+    assert metadata[AliasedMetadata] == 2
+    assert metadata.get(AliasedMetadata) == 2
+    assert metadata.get(AliasedMetadata.KEY) is None
+
+    metadata[AliasedMetadata] = 3
+    assert metadata[AliasedMetadata] == 3
+    assert metadata[AliasedMetadata.KEY] == 3
+
+    metadata[AliasedMetadata.KEY] = "not an int"
+    with pytest.raises(TypeError):
+        metadata[AliasedMetadata]
 
 
 def test_debug_info_roundtrip() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -409,7 +409,7 @@ requires-dist = [
     { name = "semver", specifier = "~=3.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1.3,<10" },
     { name = "sphinx-favicon", marker = "extra == 'docs'", specifier = "~=1.1.0" },
-    { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'", specifier = ">=2.0.2,<3" },
+    { name = "sphinxcontrib-mermaid", marker = "extra == 'docs'", specifier = ">=1,<3" },
     { name = "typing-extensions", specifier = "~=4.12" },
 ]
 provides-extras = ["docs", "pytket"]


### PR DESCRIPTION
Adds a new `ALIASES` array to both the rust and python `Metadata` trait/protocol definitions.

When reading the metadata value for a node, we use the new aliases as alternative keys if the main one is not found.
This allows us to do backwards-compatible renames of the metadata keys.