### PR TITLE
feat!: Keep multiple incompatible extension versions in ExtensionRegistry

### DIFF
--- a/.github/workflows/ci-rs.yml
+++ b/.github/workflows/ci-rs.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Generate the updated definitions
         run: |
           chmod +x target/debug/hugr
-          ./target/debug/hugr gen-extensions -o resources/std_extensions
+          ./target/debug/hugr gen-extensions -o resources/std_extensions --unversioned
       - name: Check if the declarations are up to date
         run: |
           git diff --exit-code --name-only resources/std_extensions/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1093,6 +1093,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ static_assertions = "1.1.0"
 tempfile = "3.27"
 thiserror = "2.0.18"
 typetag = "0.2.21"
+walkdir = "2.5.0"
 clap = { version = "4.6.0" }
 clio = "0.3.5"
 clap-verbosity-flag = "3.0.4"

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -50,7 +50,8 @@ assert_cmd = { workspace = true }
 assert_fs = { workspace = true }
 predicates = { workspace = true }
 tempfile = { workspace = true }
-rstest.workspace = true
+rstest = { workspace = true }
+walkdir = { workspace = true }
 
 [[bin]]
 name = "hugr"

--- a/hugr-cli/src/extensions.rs
+++ b/hugr-cli/src/extensions.rs
@@ -1,6 +1,7 @@
 //! Dump standard extensions in serialized form.
 use anyhow::Result;
 use clap::Parser;
+use hugr::Extension;
 use hugr::extension::ExtensionRegistry;
 use std::{io::Write, path::PathBuf};
 
@@ -20,32 +21,66 @@ pub struct ExtArgs {
         help = "Output directory."
     )]
     pub outdir: PathBuf,
+    /// Add the extension version to the output filename, e.g. "foo-1.2.3.json".
+    #[arg(
+        long,
+        help = "Add the extension version to the output filename.",
+        default_value_t = false
+    )]
+    pub versioned: bool,
 }
 
 impl ExtArgs {
     /// Write out the standard extensions in serialized form.
+    ///
     /// Qualified names of extensions used to generate directories under the specified output directory.
-    /// E.g. extension "foo.bar.baz" will be written to "OUTPUT/foo/bar/baz.json".
+    /// The extension version is added to the json filename.
+    ///
+    /// E.g. extension "foo.bar.baz" will be written to "OUTPUT/foo/bar/baz-1.2.3.json".
     pub fn run_dump(&self, registry: &ExtensionRegistry) -> Result<()> {
-        let base_dir = &self.outdir;
-
-        for ext in registry {
-            let mut path = base_dir.clone();
-            for part in ext.name().split('.') {
-                path.push(part);
-            }
-            path.set_extension("json");
-
-            std::fs::create_dir_all(path.clone().parent().unwrap())?;
-            // file buffer
-            let mut file = std::fs::File::create(&path)?;
-
-            serde_json::to_writer_pretty(&mut file, &ext)?;
-
-            // write newline, for pre-commit end of file check that edits the file to
-            // add newlines if missing.
-            file.write_all(b"\n")?;
+        if self.versioned {
+            registry
+                .iter_all()
+                .try_for_each(|ext| self.dump_extension(ext))?;
+        } else {
+            // The STD registry should only contain one version of each
+            // extension, so we can just take the latest version for each
+            // extension name and avoid overriding files.
+            registry
+                .iter()
+                .map(|ext| ext.latest())
+                .try_for_each(|ext| self.dump_extension(ext))?;
         }
+
+        Ok(())
+    }
+
+    fn dump_extension(&self, ext: &Extension) -> Result<()> {
+        let mut path = self.outdir.clone();
+        let mut parts = ext.name().split('.').peekable();
+        while let Some(part) = parts.next() {
+            if parts.peek().is_some() {
+                path.push(part);
+                continue;
+            }
+
+            // Optionally add the extension version to the output filename, e.g. "foo-1.2.3.json".
+            if self.versioned {
+                path.push(format!("{part}-{}.json", ext.version()));
+            } else {
+                path.push(format!("{part}.json"));
+            }
+        }
+
+        std::fs::create_dir_all(path.clone().parent().unwrap())?;
+        // file buffer
+        let mut file = std::fs::File::create(&path)?;
+
+        serde_json::to_writer_pretty(&mut file, &ext)?;
+
+        // write newline, for pre-commit end of file check that edits the file to
+        // add newlines if missing.
+        file.write_all(b"\n")?;
 
         Ok(())
     }

--- a/hugr-cli/src/extensions.rs
+++ b/hugr-cli/src/extensions.rs
@@ -21,13 +21,17 @@ pub struct ExtArgs {
         help = "Output directory."
     )]
     pub outdir: PathBuf,
-    /// Add the extension version to the output filename, e.g. "foo-1.2.3.json".
+    /// Do not add the extension version to the output filename, e.g. "foo.json".
+    ///
+    /// Only writes the latest version of each extension.
+    ///
+    /// If this flag is not present, extensions are written with the version in the filename, e.g. "foo-1.2.3.json".
     #[arg(
         long,
-        help = "Add the extension version to the output filename.",
+        help = "Do not add the extension version to the output filename.",
         default_value_t = false
     )]
-    pub versioned: bool,
+    pub unversioned: bool,
 }
 
 impl ExtArgs {
@@ -38,14 +42,12 @@ impl ExtArgs {
     ///
     /// E.g. extension "foo.bar.baz" will be written to "OUTPUT/foo/bar/baz-1.2.3.json".
     pub fn run_dump(&self, registry: &ExtensionRegistry) -> Result<()> {
-        if self.versioned {
+        if !self.unversioned {
             registry
                 .iter_all()
                 .try_for_each(|ext| self.dump_extension(ext))?;
         } else {
-            // The STD registry should only contain one version of each
-            // extension, so we can just take the latest version for each
-            // extension name and avoid overriding files.
+            // Only one version of each extension can be written out, so we take the latest version of each.
             registry
                 .iter()
                 .map(|ext| ext.latest())
@@ -64,11 +66,12 @@ impl ExtArgs {
                 continue;
             }
 
-            // Optionally add the extension version to the output filename, e.g. "foo-1.2.3.json".
-            if self.versioned {
-                path.push(format!("{part}-{}.json", ext.version()));
-            } else {
+            // Choose whether to add the extension version to the output
+            // filename or leave it without.
+            if self.unversioned {
                 path.push(format!("{part}.json"));
+            } else {
+                path.push(format!("{part}-{}.json", ext.version()));
             }
         }
 

--- a/hugr-cli/tests/gen_extensions.rs
+++ b/hugr-cli/tests/gen_extensions.rs
@@ -33,7 +33,42 @@ fn test_extension_dump(mut cmd: Command) {
         "arithmetic/float.json",
         "arithmetic/conversions.json",
         "collections/array.json",
+        "collections/borrow_arr.json",
         "collections/list.json",
+        "collections/static_array.json",
+    ];
+    // check all paths exist
+    for path in &expected_paths {
+        let full_path = temp_dir.join(path);
+        assert!(full_path.exists());
+    }
+
+    // temp dir deleted when dropped here
+}
+
+#[rstest]
+fn test_extension_versioned_dump(mut cmd: Command) {
+    let temp_dir = assert_fs::TempDir::new()
+        .expect("temp dir creation failure.")
+        .into_persistent_if(std::env::var_os("HUGR_CLI_TEST_PERSIST_FILES").is_some());
+    cmd.arg("-o");
+    cmd.arg(temp_dir.path());
+    cmd.arg("--versioned");
+    cmd.assert().success();
+
+    let expected_paths = [
+        "logic-0.1.0.json",
+        "prelude-0.2.2.json",
+        "ptr-0.1.1.json",
+        "arithmetic/int/types-0.1.0.json",
+        "arithmetic/float/types-0.1.0.json",
+        "arithmetic/int-0.1.1.json",
+        "arithmetic/float-0.1.1.json",
+        "arithmetic/conversions-0.1.1.json",
+        "collections/array-0.1.2.json",
+        "collections/borrow_arr-0.2.1.json",
+        "collections/list-0.1.1.json",
+        "collections/static_array-0.1.1.json",
     ];
     // check all paths exist
     for path in &expected_paths {

--- a/hugr-cli/tests/gen_extensions.rs
+++ b/hugr-cli/tests/gen_extensions.rs
@@ -18,31 +18,31 @@ fn cmd() -> Command {
 }
 
 #[rstest]
-fn test_extension_dump(mut cmd: Command) {
+#[case::versioned(false)]
+#[case::unversioned(true)]
+fn test_extension_dump(mut cmd: Command, #[case] unversioned: bool) {
     let temp_dir = assert_fs::TempDir::new()
         .expect("temp dir creation failure.")
         .into_persistent_if(std::env::var_os("HUGR_CLI_TEST_PERSIST_FILES").is_some());
     cmd.arg("-o");
     cmd.arg(temp_dir.path());
+    if unversioned {
+        cmd.arg("--unversioned");
+    }
     cmd.assert().success();
 
-    let expected_paths = BTreeSet::from(
-        [
-            "logic.json",
-            "prelude.json",
-            "ptr.json",
-            "arithmetic/int/types.json",
-            "arithmetic/float/types.json",
-            "arithmetic/int.json",
-            "arithmetic/float.json",
-            "arithmetic/conversions.json",
-            "collections/array.json",
-            "collections/borrow_arr.json",
-            "collections/list.json",
-            "collections/static_array.json",
-        ]
-        .map(std::path::PathBuf::from),
-    );
+    let expected_paths = hugr::std_extensions::STD_REG
+        .iter()
+        .map(|ext| {
+            let mut path = ext.id().replace('.', "/");
+            if unversioned {
+                path.push_str(".json");
+            } else {
+                path.push_str(&format!("-{}.json", ext.latest().version()));
+            }
+            std::path::PathBuf::from(path)
+        })
+        .collect::<BTreeSet<_>>();
 
     let existing_paths = WalkDir::new(&temp_dir)
         .into_iter()
@@ -70,39 +70,6 @@ fn test_extension_dump(mut cmd: Command) {
             }
         }
         panic!("Extension dump did not match expected paths.");
-    }
-
-    // temp dir deleted when dropped here
-}
-
-#[rstest]
-fn test_extension_versioned_dump(mut cmd: Command) {
-    let temp_dir = assert_fs::TempDir::new()
-        .expect("temp dir creation failure.")
-        .into_persistent_if(std::env::var_os("HUGR_CLI_TEST_PERSIST_FILES").is_some());
-    cmd.arg("-o");
-    cmd.arg(temp_dir.path());
-    cmd.arg("--versioned");
-    cmd.assert().success();
-
-    let expected_paths = [
-        "logic-0.1.0.json",
-        "prelude-0.2.2.json",
-        "ptr-0.1.1.json",
-        "arithmetic/int/types-0.1.0.json",
-        "arithmetic/float/types-0.1.0.json",
-        "arithmetic/int-0.1.1.json",
-        "arithmetic/float-0.1.1.json",
-        "arithmetic/conversions-0.1.1.json",
-        "collections/array-0.1.2.json",
-        "collections/borrow_arr-0.2.1.json",
-        "collections/list-0.1.1.json",
-        "collections/static_array-0.1.1.json",
-    ];
-    // check all paths exist
-    for path in &expected_paths {
-        let full_path = temp_dir.join(path);
-        assert!(full_path.exists());
     }
 
     // temp dir deleted when dropped here

--- a/hugr-cli/tests/gen_extensions.rs
+++ b/hugr-cli/tests/gen_extensions.rs
@@ -4,8 +4,11 @@
 //! calling the CLI binary, which Miri doesn't support.
 #![cfg(all(test, not(miri)))]
 
+use std::collections::BTreeSet;
+
 use assert_cmd::Command;
 use rstest::{fixture, rstest};
+use walkdir::WalkDir;
 
 #[fixture]
 fn cmd() -> Command {
@@ -23,24 +26,50 @@ fn test_extension_dump(mut cmd: Command) {
     cmd.arg(temp_dir.path());
     cmd.assert().success();
 
-    let expected_paths = [
-        "logic.json",
-        "prelude.json",
-        "ptr.json",
-        "arithmetic/int/types.json",
-        "arithmetic/float/types.json",
-        "arithmetic/int.json",
-        "arithmetic/float.json",
-        "arithmetic/conversions.json",
-        "collections/array.json",
-        "collections/borrow_arr.json",
-        "collections/list.json",
-        "collections/static_array.json",
-    ];
-    // check all paths exist
-    for path in &expected_paths {
-        let full_path = temp_dir.join(path);
-        assert!(full_path.exists());
+    let expected_paths = BTreeSet::from(
+        [
+            "logic.json",
+            "prelude.json",
+            "ptr.json",
+            "arithmetic/int/types.json",
+            "arithmetic/float/types.json",
+            "arithmetic/int.json",
+            "arithmetic/float.json",
+            "arithmetic/conversions.json",
+            "collections/array.json",
+            "collections/borrow_arr.json",
+            "collections/list.json",
+            "collections/static_array.json",
+        ]
+        .map(std::path::PathBuf::from),
+    );
+
+    let existing_paths = WalkDir::new(&temp_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_type().is_file())
+        .map(|e| e.path().strip_prefix(&temp_dir).unwrap().to_owned())
+        .collect::<BTreeSet<_>>();
+
+    // Check differences and print any missing or unexpected paths.
+    if expected_paths != existing_paths {
+        let missing_paths: Vec<_> = expected_paths.difference(&existing_paths).collect();
+        let unexpected_paths: Vec<_> = existing_paths.difference(&expected_paths).collect();
+
+        if !missing_paths.is_empty() {
+            eprintln!("Missing paths:");
+            for path in missing_paths {
+                eprintln!("  {}", path.display());
+            }
+        }
+
+        if !unexpected_paths.is_empty() {
+            eprintln!("Unexpected paths:");
+            for path in unexpected_paths {
+                eprintln!("  {}", path.display());
+            }
+        }
+        panic!("Extension dump did not match expected paths.");
     }
 
     // temp dir deleted when dropped here

--- a/hugr-core/src/builder/circuit.rs
+++ b/hugr-core/src/builder/circuit.rs
@@ -337,7 +337,7 @@ mod test {
             .unwrap();
 
         let mut registry = test_quantum_extension::REG.clone();
-        registry.register(my_ext).unwrap();
+        registry.register(my_ext);
         let build_res = module_builder.finish_hugr();
 
         assert_matches!(build_res, Ok(_));

--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -265,7 +265,7 @@ pub(crate) mod test {
         extensions: &'a ExtensionRegistry,
         other: &ExtensionRegistry,
     ) -> Cow<'a, ExtensionRegistry> {
-        if other.iter().all(|e| extensions.contains(e.name())) {
+        if other.iter_all().all(|e| extensions.contains(e.name())) {
             Cow::Borrowed(extensions)
         } else {
             let mut extensions = extensions.clone();

--- a/hugr-core/src/envelope/description.rs
+++ b/hugr-core/src/envelope/description.rs
@@ -457,7 +457,7 @@ impl ModuleDesc {
     pub(crate) fn load_used_extensions_resolved(&mut self, hugr: &impl HugrView) {
         self.set_used_extensions_resolved(
             hugr.extensions()
-                .iter()
+                .iter_all()
                 .map(|ext| ExtensionDesc::new(&ext.name, ext.version.clone())),
         )
     }

--- a/hugr-core/src/envelope/package_json.rs
+++ b/hugr-core/src/envelope/package_json.rs
@@ -17,7 +17,10 @@ pub(super) fn to_json_writer<'h>(
 ) -> Result<(), PackageEncodingError> {
     let pkg_ser = PackageSer {
         modules: hugrs.into_iter().map(HugrSer).collect(),
-        extensions: extensions.iter().map(std::convert::AsRef::as_ref).collect(),
+        extensions: extensions
+            .iter_all()
+            .map(std::convert::AsRef::as_ref)
+            .collect(),
     };
 
     // Validate the hugr serializations against the schema.

--- a/hugr-core/src/envelope/reader.rs
+++ b/hugr-core/src/envelope/reader.rs
@@ -150,7 +150,7 @@ impl<R: BufRead> EnvelopeReader<R> {
             desc.load_from_hugr(&module);
         }
 
-        for (index, ext) in package.extensions.iter().enumerate() {
+        for (index, ext) in package.extensions.iter_all().enumerate() {
             self.description.set_packaged_extension(index, ext);
         }
         Ok(package)
@@ -485,8 +485,7 @@ mod test {
 
         simple_package
             .extensions
-            .register(std::sync::Arc::new(extension))
-            .unwrap();
+            .register(std::sync::Arc::new(extension));
 
         let header = EnvelopeHeader {
             format: EnvelopeFormat::SExpressionWithExtensions,

--- a/hugr-core/src/envelope/serde_with.rs
+++ b/hugr-core/src/envelope/serde_with.rs
@@ -216,9 +216,9 @@ macro_rules! impl_serde_as_string_envelope {
                 // Include any additional extension required to load the HUGR in the envelope.
                 let extensions: &$crate::extension::ExtensionRegistry = $extension_reg;
                 let mut extra_extensions = $crate::extension::ExtensionRegistry::default();
-                for ext in $crate::hugr::views::HugrView::extensions(source).iter() {
+                for ext in $crate::hugr::views::HugrView::extensions(source).iter_all() {
                     if !extensions.contains(ext.name()) {
-                        extra_extensions.register_updated(ext.clone());
+                        extra_extensions.register(ext.clone());
                     }
                 }
 
@@ -394,9 +394,9 @@ macro_rules! impl_serde_as_binary_envelope {
                 // Include any additional extension required to load the HUGR in the envelope.
                 let extensions: &$crate::extension::ExtensionRegistry = $extension_reg;
                 let mut extra_extensions = $crate::extension::ExtensionRegistry::default();
-                for ext in $crate::hugr::views::HugrView::extensions(source).iter() {
+                for ext in $crate::hugr::views::HugrView::extensions(source).iter_all() {
                     if !extensions.contains(ext.name()) {
-                        extra_extensions.register_updated(ext.clone());
+                        extra_extensions.register(ext.clone());
                     }
                 }
                 use $crate::envelope::serde_with::base64::{EncoderStringWriter, STANDARD};

--- a/hugr-core/src/envelope/writer.rs
+++ b/hugr-core/src/envelope/writer.rs
@@ -82,7 +82,7 @@ fn encode_model_binary<'h>(
 
     // Append extensions for binary model.
     if format == EnvelopeFormat::ModelWithExtensions {
-        serde_json::to_writer(writer, &extensions.iter().collect_vec())?;
+        serde_json::to_writer(writer, &extensions.iter_all().collect_vec())?;
     }
 
     Ok(())
@@ -101,7 +101,7 @@ fn encode_model_text<'h>(
 
     // Prepend extensions for text model.
     if format == EnvelopeFormat::SExpressionWithExtensions {
-        serde_json::to_writer(&mut writer, &extensions.iter().collect_vec())?;
+        serde_json::to_writer(&mut writer, &extensions.iter_all().collect_vec())?;
     }
 
     let bump = Bump::default();

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -110,6 +110,7 @@
 use itertools::Itertools;
 use resolution::{ExtensionResolutionError, WeakExtensionRegistry};
 pub use semver::Version;
+use semver::{Comparator, Op as SemverOp};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::cell::UnsafeCell;
 use std::collections::btree_map;
@@ -152,7 +153,7 @@ pub mod declarative;
 #[display("ExtensionRegistry[{}]", exts.keys().join(", "))]
 pub struct ExtensionRegistry {
     /// The extensions in the registry.
-    exts: BTreeMap<ExtensionId, Arc<Extension>>,
+    exts: BTreeMap<ExtensionId, ExtensionVersions>,
     /// A flag indicating whether the current set of extensions has been
     /// validated.
     ///
@@ -177,12 +178,187 @@ impl Clone for ExtensionRegistry {
     }
 }
 
+/// Retained versions for one extension id.
+///
+/// The registry keeps at most one extension per semver-compatible group: when a
+/// newer compatible version is registered, it replaces the older compatible
+/// definition. Incompatible versions are retained side by side so older HUGRs can
+/// still resolve against the appropriate definition.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExtensionVersions {
+    id: ExtensionId,
+    versions: BTreeMap<Version, Arc<Extension>>,
+}
+
+impl ExtensionVersions {
+    /// Create a version collection containing one extension.
+    pub fn new(extension: Arc<Extension>) -> Self {
+        let id = extension.name().clone();
+        let versions = [(extension.version().clone(), extension)].into();
+        Self { id, versions }
+    }
+
+    /// The extension id shared by all versions in this collection.
+    #[must_use]
+    pub fn id(&self) -> &ExtensionId {
+        &self.id
+    }
+
+    /// Return the latest retained extension version.
+    #[must_use]
+    pub fn latest(&self) -> &Arc<Extension> {
+        self.versions
+            .last_key_value()
+            .expect("ExtensionVersions always contains at least one extension")
+            .1
+    }
+
+    /// Return the exact retained extension version, if available.
+    #[must_use]
+    pub fn exact(&self, version: &Version) -> Option<&Arc<Extension>> {
+        self.versions.get(version)
+    }
+
+    /// Return the highest retained extension compatible with `requested`.
+    #[must_use]
+    pub fn compatible(&self, requested: &Version) -> Option<&Arc<Extension>> {
+        let (version, extension) = self.versions.range(requested..).next()?;
+        semver_compatible(version, requested).then_some(extension)
+    }
+
+    /// Return the extension that should satisfy an optional serialized version.
+    ///
+    /// If `requested` is `Some(version)`, returns the highest retained
+    /// extension compatible with `version`. If `requested` is `None`, returns
+    /// the latest retained extension.
+    ///
+    /// This is used when deserializing older HUGRs that may not have a version
+    /// specified for their extensions.
+    #[must_use]
+    pub(crate) fn get_req(&self, requested: Option<&Version>) -> Option<&Arc<Extension>> {
+        requested
+            .and_then(|version| self.compatible(version))
+            .or_else(|| requested.is_none().then(|| self.latest()))
+    }
+
+    /// Register an extension version and report what happened.
+    ///
+    /// If we already have a compatible version, the extension with the higher
+    /// version is kept. If versions match exactly, the new extension replaces
+    /// the existing entry.
+    ///
+    /// Panics if the extension id does not match the collection's id.
+    pub fn register(&mut self, extension: Arc<Extension>) -> ExtensionRegisterResult {
+        assert_eq!(
+            extension.name(),
+            &self.id,
+            "extension id does not match ExtensionVersions id"
+        );
+
+        let version = extension.version().clone();
+        let compatible_version = self.compatible_registered_version(&version);
+
+        let Some(compatible_version) = compatible_version else {
+            self.versions.insert(version, extension);
+            return ExtensionRegisterResult::Inserted;
+        };
+
+        if compatible_version > version {
+            return ExtensionRegisterResult::KeptExisting {
+                version: compatible_version,
+            };
+        }
+
+        self.versions.remove(&compatible_version);
+        let replaced = compatible_version < version;
+        self.versions.insert(version, extension);
+        if replaced {
+            ExtensionRegisterResult::Replaced {
+                version: compatible_version,
+            }
+        } else {
+            ExtensionRegisterResult::ReplacedExact
+        }
+    }
+
+    // Find a registered extension version that is in the same semver
+    // compatibility group as `version`, if any.
+    fn compatible_registered_version(&self, version: &Version) -> Option<Version> {
+        if let Some((candidate, _)) = self.versions.range(..=version).next_back()
+            && semver_compatible(version, candidate)
+        {
+            return Some(candidate.clone());
+        }
+        self.versions
+            .range(version..)
+            .next()
+            .filter(|(candidate, _)| semver_compatible(candidate, version))
+            .map(|(candidate, _)| candidate.clone())
+    }
+
+    /// Return every retained version.
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Arc<Extension>> {
+        self.versions.values()
+    }
+
+    /// Return the retained version numbers.
+    pub fn versions(&self) -> impl DoubleEndedIterator<Item = &Version> {
+        self.versions.keys()
+    }
+
+    /// Return the number of retained versions.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.versions.len()
+    }
+
+    /// Returns `true` if there are no retained versions.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.versions.is_empty()
+    }
+}
+
+/// The result of registering an extension.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExtensionRegisterResult {
+    /// A new incompatible version group was inserted.
+    Inserted,
+    /// An older compatible version was replaced by this extension.
+    Replaced {
+        /// The replaced version.
+        version: Version,
+    },
+    /// An exact version entry was replaced.
+    ReplacedExact,
+    /// A newer compatible version was already present and was kept.
+    KeptExisting {
+        /// The version that was kept.
+        version: Version,
+    },
+}
+
+/// Returns `true` if `candidate` is semver-compatible with `requested`.
+///
+/// That is, `candidate` is the same or a newer version than `requested`, without
+/// breaking changes according to semver rules.
+pub(crate) fn semver_compatible(candidate: &Version, requested: &Version) -> bool {
+    Comparator {
+        op: SemverOp::Caret,
+        major: requested.major,
+        minor: Some(requested.minor),
+        patch: Some(requested.patch),
+        pre: requested.pre.clone(),
+    }
+    .matches(candidate)
+}
+
 impl ExtensionRegistry {
     /// Create a new empty extension registry.
     pub fn new(extensions: impl IntoIterator<Item = Arc<Extension>>) -> Self {
         let mut res = Self::default();
         for ext in extensions {
-            res.register_updated(ext);
+            res.register(ext);
         }
         res
     }
@@ -207,6 +383,26 @@ impl ExtensionRegistry {
 
     /// Gets the Extension with the given name
     pub fn get(&self, name: &str) -> Option<&Arc<Extension>> {
+        self.exts.get(name).map(ExtensionVersions::latest)
+    }
+
+    /// Gets the exact Extension version with the given name.
+    pub fn get_exact(&self, name: &str, version: &Version) -> Option<&Arc<Extension>> {
+        self.exts.get(name).and_then(|ext| ext.exact(version))
+    }
+
+    /// Gets the highest Extension version compatible with `version`.
+    pub fn get_compatible(&self, name: &str, version: &Version) -> Option<&Arc<Extension>> {
+        self.exts.get(name).and_then(|ext| ext.compatible(version))
+    }
+
+    /// Gets the Extension matching an optional serialized version requirement.
+    pub fn get_req(&self, name: &str, version: Option<&Version>) -> Option<&Arc<Extension>> {
+        self.exts.get(name).and_then(|ext| ext.get_req(version))
+    }
+
+    /// Gets retained versions for the given extension name.
+    pub fn versions(&self, name: &str) -> Option<&ExtensionVersions> {
         self.exts.get(name)
     }
 
@@ -220,7 +416,7 @@ impl ExtensionRegistry {
         if self.valid.load(Ordering::Relaxed) {
             return Ok(());
         }
-        for ext in self.exts.values() {
+        for ext in self.iter_all() {
             ext.validate()
                 .map_err(|e| ExtensionRegistryError::InvalidSignature(ext.name().clone(), e))?;
         }
@@ -230,80 +426,33 @@ impl ExtensionRegistry {
 
     /// Registers a new extension to the registry.
     ///
-    /// Returns a reference to the registered extension if successful.
-    pub fn register(
-        &mut self,
-        extension: impl Into<Arc<Extension>>,
-    ) -> Result<(), ExtensionRegistryError> {
-        let extension = extension.into();
-        match self.exts.entry(extension.name().clone()) {
-            btree_map::Entry::Occupied(prev) => Err(ExtensionRegistryError::AlreadyRegistered(
-                extension.name().clone(),
-                Box::new(prev.get().version().clone()),
-                Box::new(extension.version().clone()),
-            )),
-            btree_map::Entry::Vacant(ve) => {
-                ve.insert(extension);
-                // Clear the valid flag so that the registry is re-validated.
-                self.valid.store(false, Ordering::Relaxed);
-
-                Ok(())
-            }
-        }
-    }
-
-    /// Registers a new extension to the registry, keeping the one most up to
-    /// date if the extension already exists.
+    /// If we already have a compatible version, the extension with the higher
+    /// version is kept. If versions match exactly, the new extension replaces
+    /// the existing entry.
     ///
-    /// If extension IDs match, the extension with the higher version is kept.
-    /// If versions match, the original extension is kept. Returns a reference
-    /// to the registered extension if successful.
-    ///
-    /// Takes an Arc to the extension. To avoid cloning Arcs unless necessary,
-    /// see [`ExtensionRegistry::register_updated_ref`].
-    pub fn register_updated(&mut self, extension: impl Into<Arc<Extension>>) {
+    pub fn register(&mut self, extension: impl Into<Arc<Extension>>) -> ExtensionRegisterResult {
+        use btree_map::Entry::*;
         let extension = extension.into();
-        match self.exts.entry(extension.name().clone()) {
-            btree_map::Entry::Occupied(mut prev) => {
-                if prev.get().version() < extension.version() {
-                    *prev.get_mut() = extension;
-                }
+        let result = match self.exts.entry(extension.name().clone()) {
+            Occupied(mut prev) => prev.get_mut().register(extension),
+            Vacant(ve) => {
+                ve.insert(ExtensionVersions::new(extension));
+                ExtensionRegisterResult::Inserted
             }
-            btree_map::Entry::Vacant(ve) => {
-                ve.insert(extension);
-            }
-        }
+        };
         // Clear the valid flag so that the registry is re-validated.
         self.valid.store(false, Ordering::Relaxed);
-    }
-
-    /// Registers a new extension to the registry, keeping the one most up to
-    /// date if the extension already exists.
-    ///
-    /// If extension IDs match, the extension with the higher version is kept.
-    /// If versions match, the original extension is kept. Returns a reference
-    /// to the registered extension if successful.
-    ///
-    /// Clones the Arc only when required. For no-cloning version see
-    /// [`ExtensionRegistry::register_updated`].
-    pub fn register_updated_ref(&mut self, extension: &Arc<Extension>) {
-        match self.exts.entry(extension.name().clone()) {
-            btree_map::Entry::Occupied(mut prev) => {
-                if prev.get().version() < extension.version() {
-                    *prev.get_mut() = extension.clone();
-                }
-            }
-            btree_map::Entry::Vacant(ve) => {
-                ve.insert(extension.clone());
-            }
-        }
-        // Clear the valid flag so that the registry is re-validated.
-        self.valid.store(false, Ordering::Relaxed);
+        result
     }
 
     /// Returns the number of extensions in the registry.
     pub fn len(&self) -> usize {
         self.exts.len()
+    }
+
+    /// Returns the number of retained extension versions in the registry.
+    pub fn len_all_versions(&self) -> usize {
+        self.exts.values().map(ExtensionVersions::len).sum()
     }
 
     /// Returns `true` if the registry contains no extensions.
@@ -312,8 +461,15 @@ impl ExtensionRegistry {
     }
 
     /// Returns an iterator over the extensions in the registry.
-    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
+    ///
+    /// For each extension id, it yields the set of non-compatible versions retained for it.
+    pub fn iter(&self) -> impl Iterator<Item = &ExtensionVersions> {
         self.exts.values()
+    }
+
+    /// Returns an iterator over every retained extension version in the registry.
+    pub fn iter_all(&self) -> impl Iterator<Item = &Arc<Extension>> {
+        self.exts.values().flat_map(ExtensionVersions::iter)
     }
 
     /// Returns an iterator over the extensions ids in the registry.
@@ -321,8 +477,8 @@ impl ExtensionRegistry {
         self.exts.keys()
     }
 
-    /// Delete an extension from the registry and return it if it was present.
-    pub fn remove_extension(&mut self, name: &ExtensionId) -> Option<Arc<Extension>> {
+    /// Delete an extension from the registry and return the [`ExtensionVersions`] sets if it was present.
+    pub fn remove_extension(&mut self, name: &ExtensionId) -> Option<ExtensionVersions> {
         // Clear the valid flag so that the registry is re-validated.
         self.valid.store(false, Ordering::Relaxed);
 
@@ -411,9 +567,9 @@ impl ExtensionRegistry {
 }
 
 impl IntoIterator for ExtensionRegistry {
-    type Item = Arc<Extension>;
+    type Item = ExtensionVersions;
 
-    type IntoIter = std::collections::btree_map::IntoValues<ExtensionId, Arc<Extension>>;
+    type IntoIter = std::collections::btree_map::IntoValues<ExtensionId, ExtensionVersions>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.exts.into_values()
@@ -421,9 +577,9 @@ impl IntoIterator for ExtensionRegistry {
 }
 
 impl<'a> IntoIterator for &'a ExtensionRegistry {
-    type Item = &'a Arc<Extension>;
+    type Item = &'a ExtensionVersions;
 
-    type IntoIter = std::collections::btree_map::Values<'a, ExtensionId, Arc<Extension>>;
+    type IntoIter = std::collections::btree_map::Values<'a, ExtensionId, ExtensionVersions>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.exts.values()
@@ -433,7 +589,7 @@ impl<'a> IntoIterator for &'a ExtensionRegistry {
 impl<'a> Extend<&'a Arc<Extension>> for ExtensionRegistry {
     fn extend<T: IntoIterator<Item = &'a Arc<Extension>>>(&mut self, iter: T) {
         for ext in iter {
-            self.register_updated_ref(ext);
+            self.register(ext.clone());
         }
     }
 }
@@ -441,7 +597,23 @@ impl<'a> Extend<&'a Arc<Extension>> for ExtensionRegistry {
 impl Extend<Arc<Extension>> for ExtensionRegistry {
     fn extend<T: IntoIterator<Item = Arc<Extension>>>(&mut self, iter: T) {
         for ext in iter {
-            self.register_updated(ext);
+            self.register(ext);
+        }
+    }
+}
+
+impl<'a> Extend<&'a ExtensionVersions> for ExtensionRegistry {
+    fn extend<T: IntoIterator<Item = &'a ExtensionVersions>>(&mut self, iter: T) {
+        for versions in iter {
+            self.extend(versions.iter());
+        }
+    }
+}
+
+impl Extend<ExtensionVersions> for ExtensionRegistry {
+    fn extend<T: IntoIterator<Item = ExtensionVersions>>(&mut self, iter: T) {
+        for versions in iter {
+            self.extend(versions.versions.into_values());
         }
     }
 }
@@ -465,7 +637,7 @@ impl Serialize for ExtensionRegistry {
     where
         S: serde::Serializer,
     {
-        let extensions: Vec<Arc<Extension>> = self.exts.values().cloned().collect();
+        let extensions: Vec<Arc<Extension>> = self.iter_all().cloned().collect();
         extensions.serialize(serializer)
     }
 }
@@ -975,7 +1147,6 @@ pub mod test {
     #[test]
     fn test_register_update() {
         // Two registers that should remain the same.
-        // We use them to test both `register_updated` and `register_updated_ref`.
         let mut reg = ExtensionRegistry::default();
         let mut reg_ref = ExtensionRegistry::default();
 
@@ -984,39 +1155,83 @@ pub mod test {
         let ext1 = Arc::new(Extension::new(ext_1_id.clone(), Version::new(1, 0, 0)));
         let ext1_1 = Arc::new(Extension::new(ext_1_id.clone(), Version::new(1, 1, 0)));
         let ext1_2 = Arc::new(Extension::new(ext_1_id.clone(), Version::new(0, 2, 0)));
+        let ext1_1_1 = Arc::new(Extension::new(ext_1_id.clone(), Version::new(1, 1, 1)));
         let ext2 = Arc::new(Extension::new(ext_2_id, Version::new(1, 0, 0)));
 
-        reg.register(ext1.clone()).unwrap();
-        reg_ref.register(ext1.clone()).unwrap();
+        assert_eq!(
+            reg.register(ext1.clone()),
+            ExtensionRegisterResult::Inserted
+        );
+        assert_eq!(
+            reg_ref.register(ext1.clone()),
+            ExtensionRegisterResult::Inserted
+        );
         assert_eq!(&reg, &reg_ref);
 
-        // normal registration fails
+        // Compatible registration replaces the older compatible group.
         assert_eq!(
             reg.register(ext1_1.clone()),
-            Err(ExtensionRegistryError::AlreadyRegistered(
-                ext_1_id.clone(),
-                Box::new(Version::new(1, 0, 0)),
-                Box::new(Version::new(1, 1, 0))
-            ))
+            ExtensionRegisterResult::Replaced {
+                version: Version::new(1, 0, 0)
+            }
+        );
+        assert_eq!(reg.get("ext1").unwrap().version(), &Version::new(1, 1, 0));
+        assert_eq!(reg.len_all_versions(), 1);
+
+        reg_ref.register(ext1_1.clone());
+        assert_eq!(reg.get("ext1").unwrap().version(), &Version::new(1, 1, 0));
+        assert_eq!(&reg, &reg_ref);
+
+        // Compatible lower versions do not replace a newer compatible entry.
+        assert_eq!(
+            reg.register(ext1.clone()),
+            ExtensionRegisterResult::KeptExisting {
+                version: Version::new(1, 1, 0)
+            }
+        );
+        assert_eq!(reg.get("ext1").unwrap().version(), &Version::new(1, 1, 0));
+
+        // Incompatible versions are retained.
+        reg.register(ext1_2.clone());
+        reg_ref.register(ext1_2.clone());
+        assert_eq!(reg.get("ext1").unwrap().version(), &Version::new(1, 1, 0));
+        assert_eq!(
+            reg.get_exact("ext1", &Version::new(0, 2, 0))
+                .unwrap()
+                .version(),
+            &Version::new(0, 2, 0)
+        );
+        assert_eq!(reg.len(), 1);
+        assert_eq!(reg.len_all_versions(), 2);
+        assert_eq!(&reg, &reg_ref);
+
+        // Newer compatible patch versions replace older compatible entries.
+        assert_eq!(
+            reg.register(ext1_1_1.clone()),
+            ExtensionRegisterResult::Replaced {
+                version: Version::new(1, 1, 0)
+            }
+        );
+        assert_eq!(
+            reg.get_compatible("ext1", &Version::new(1, 1, 0))
+                .unwrap()
+                .version(),
+            &Version::new(1, 1, 1)
+        );
+        assert_eq!(
+            reg.get_compatible("ext1", &Version::new(0, 2, 0))
+                .unwrap()
+                .version(),
+            &Version::new(0, 2, 0)
         );
 
-        // register with update works
-        reg_ref.register_updated_ref(&ext1_1);
-        reg.register_updated(ext1_1.clone());
-        assert_eq!(reg.get("ext1").unwrap().version(), &Version::new(1, 1, 0));
-        assert_eq!(&reg, &reg_ref);
-
-        // register with lower version does not change version
-        reg_ref.register_updated_ref(&ext1_2);
-        reg.register_updated(ext1_2.clone());
-        assert_eq!(reg.get("ext1").unwrap().version(), &Version::new(1, 1, 0));
-        assert_eq!(&reg, &reg_ref);
-
-        reg.register(ext2.clone()).unwrap();
+        reg.register(ext2.clone());
         assert_eq!(reg.get("ext2").unwrap().version(), &Version::new(1, 0, 0));
         assert_eq!(reg.len(), 2);
 
-        assert!(reg.remove_extension(&ext_1_id).unwrap().version() == &Version::new(1, 1, 0));
+        assert!(
+            reg.remove_extension(&ext_1_id).unwrap().latest().version() == &Version::new(1, 1, 1)
+        );
         assert_eq!(reg.len(), 1);
     }
 

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -219,9 +219,9 @@ impl ExtensionVersions {
         self.versions.get(version)
     }
 
-    /// Return the highest retained extension compatible with `requested`.
+    /// Return the highest retained extension compatible with `requested`, if any.
     #[must_use]
-    pub fn compatible(&self, requested: &Version) -> Option<&Arc<Extension>> {
+    pub fn get_compatible(&self, requested: &Version) -> Option<&Arc<Extension>> {
         let (version, extension) = self.versions.range(requested..).next()?;
         semver_compatible(version, requested).then_some(extension)
     }
@@ -236,9 +236,10 @@ impl ExtensionVersions {
     /// specified for their extensions.
     #[must_use]
     pub(crate) fn get_req(&self, requested: Option<&Version>) -> Option<&Arc<Extension>> {
-        requested
-            .and_then(|version| self.compatible(version))
-            .or_else(|| requested.is_none().then(|| self.latest()))
+        match requested {
+            Some(version) => self.get_compatible(version),
+            None => Some(self.latest()),
+        }
     }
 
     /// Register an extension version and report what happened.
@@ -281,8 +282,12 @@ impl ExtensionVersions {
         }
     }
 
-    // Find a registered extension version that is in the same semver
-    // compatibility group as `version`, if any.
+    /// Returns a registered version that is in the same semver-compatibility group as the requested version, if any.
+    ///
+    /// The registry keeps at most one extension per semver-compatible group: when a
+    /// newer compatible version is registered, it replaces the older compatible
+    /// definition. Incompatible versions are retained side by side so older HUGRs can
+    /// still resolve against the appropriate definition.
     fn compatible_registered_version(&self, version: &Version) -> Option<Version> {
         if let Some((candidate, _)) = self.versions.range(..=version).next_back()
             && semver_compatible(version, candidate)
@@ -393,7 +398,9 @@ impl ExtensionRegistry {
 
     /// Gets the highest Extension version compatible with `version`.
     pub fn get_compatible(&self, name: &str, version: &Version) -> Option<&Arc<Extension>> {
-        self.exts.get(name).and_then(|ext| ext.compatible(version))
+        self.exts
+            .get(name)
+            .and_then(|ext| ext.get_compatible(version))
     }
 
     /// Gets the Extension matching an optional serialized version requirement.
@@ -542,7 +549,7 @@ impl ExtensionRegistry {
 
         let mut weak_registry = WeakExtensionRegistry::default();
         for (ext, weak) in extensions.iter().zip(weaks) {
-            weak_registry.register(ext.name().clone(), weak);
+            weak_registry.register(ext.name().clone(), ext.version().clone(), weak);
         }
 
         // Actual initialization here

--- a/hugr-core/src/extension/declarative.rs
+++ b/hugr-core/src/extension/declarative.rs
@@ -124,7 +124,7 @@ impl ExtensionSetDeclaration {
 
         // The prelude is auto-imported.
         if !registry.contains(&PRELUDE_ID) {
-            registry.register(PRELUDE.clone())?;
+            registry.register(PRELUDE.clone());
         }
         if !scope.contains(&PRELUDE_ID) {
             scope.insert(PRELUDE_ID);
@@ -138,7 +138,7 @@ impl ExtensionSetDeclaration {
             };
             let ext = decl.make_extension(&self.imports, ctx)?;
             scope.insert(ext.name().clone());
-            registry.register(ext)?;
+            registry.register(ext);
         }
 
         Ok(())
@@ -410,7 +410,7 @@ extensions:
         reg: &'a ExtensionRegistry,
         dependencies: &'a ExtensionRegistry,
     ) -> impl Iterator<Item = &'a Arc<Extension>> {
-        reg.iter()
+        reg.iter_all()
             .filter(move |ext| !dependencies.contains(ext.name()) && ext.name() != &PRELUDE_ID)
     }
 }

--- a/hugr-core/src/extension/resolution/extension.rs
+++ b/hugr-core/src/extension/resolution/extension.rs
@@ -33,7 +33,7 @@ impl ExtensionRegistry {
     ) -> Result<ExtensionRegistry, ExtensionResolutionError> {
         Self::new_cyclic(extensions, |mut exts, weak_registry| {
             let mut weak_registry = weak_registry.clone();
-            for (other_id, other) in other_extensions.iter() {
+            for (other_id, other) in other_extensions.iter_all() {
                 weak_registry.register(other_id.clone(), other.clone());
             }
             for ext in &mut exts {
@@ -48,15 +48,18 @@ impl ExtensionRegistry {
     /// This includes all extensions required to define the types in the
     /// operation signatures.
     pub fn extend_with_dependencies(&mut self) -> Result<(), ExtensionCollectionError> {
-        let mut queue: Vec<Arc<Extension>> = self.exts.values().cloned().collect();
-        let mut seen: std::collections::BTreeSet<ExtensionId> = self.exts.keys().cloned().collect();
+        let mut queue: Vec<Arc<Extension>> = self.iter_all().cloned().collect();
+        let mut seen: std::collections::BTreeSet<(ExtensionId, crate::extension::Version)> = self
+            .iter_all()
+            .map(|ext| (ext.name().clone(), ext.version().clone()))
+            .collect();
 
         while let Some(ext) = queue.pop() {
             let deps = collect_extension_deps(&ext)?;
-            for dep in deps {
-                let dep_id = dep.name().clone();
-                if seen.insert(dep_id.clone()) {
-                    self.register_updated(dep.clone());
+            for dep in deps.iter_all().cloned() {
+                let dep_key = (dep.name().clone(), dep.version().clone());
+                if seen.insert(dep_key) {
+                    self.register(dep.clone());
                     queue.push(dep);
                 }
             }

--- a/hugr-core/src/extension/resolution/extension.rs
+++ b/hugr-core/src/extension/resolution/extension.rs
@@ -7,6 +7,8 @@
 use std::mem;
 use std::sync::Arc;
 
+use semver::Version;
+
 use crate::extension::resolution::types::collect_func_type_exts;
 use crate::extension::{
     Extension, ExtensionId, ExtensionRegistry, ExtensionSet, OpDef, SignatureFunc, TypeDef,
@@ -33,8 +35,8 @@ impl ExtensionRegistry {
     ) -> Result<ExtensionRegistry, ExtensionResolutionError> {
         Self::new_cyclic(extensions, |mut exts, weak_registry| {
             let mut weak_registry = weak_registry.clone();
-            for (other_id, other) in other_extensions.iter_all() {
-                weak_registry.register(other_id.clone(), other.clone());
+            for (other_id, other_version, other) in other_extensions.iter_all() {
+                weak_registry.register(other_id.clone(), other_version.clone(), other.clone());
             }
             for ext in &mut exts {
                 ext.resolve_references(&weak_registry)?;
@@ -112,7 +114,13 @@ impl Extension {
         let mut used_extensions = WeakExtensionRegistry::default();
 
         for type_def in self.types.values_mut() {
-            resolve_typedef_exts(&self.name, type_def, extensions, &mut used_extensions)?;
+            resolve_typedef_exts(
+                &self.name,
+                &self.version,
+                type_def,
+                extensions,
+                &mut used_extensions,
+            )?;
         }
 
         let ops = mem::take(&mut self.operations);
@@ -120,7 +128,13 @@ impl Extension {
             // TODO: We should be able to clone the definition if needed by using `make_mut`,
             // but `OpDef` does not implement clone -.-
             let op_ref = Arc::<OpDef>::get_mut(&mut op_def).expect("OpDef is not unique");
-            resolve_opdef_exts(&self.name, op_ref, extensions, &mut used_extensions)?;
+            resolve_opdef_exts(
+                &self.name,
+                &self.version,
+                op_ref,
+                extensions,
+                &mut used_extensions,
+            )?;
             self.operations.insert(op_id, op_def);
         }
 
@@ -134,15 +148,14 @@ impl Extension {
 /// Adds the extensions used in the type to the `used_extensions` registry.
 pub(super) fn resolve_typedef_exts(
     extension: &ExtensionId,
+    version: &Version,
     def: &mut TypeDef,
     extensions: &WeakExtensionRegistry,
     used_extensions: &mut WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    match extensions.get(def.extension_id()) {
-        Some(ext) => {
-            if let Some(extension) = ext.upgrade() {
-                def.fill_extension_version(extension.version());
-            }
+    match extensions.get_req(def.extension_id(), Some(version)) {
+        Some((_, ext)) => {
+            def.fill_extension_version(version);
             *def.extension_mut() = ext.clone();
         }
         None => {
@@ -163,15 +176,14 @@ pub(super) fn resolve_typedef_exts(
 /// Adds the extensions used in the type to the `used_extensions` registry.
 pub(super) fn resolve_opdef_exts(
     extension: &ExtensionId,
+    version: &Version,
     def: &mut OpDef,
     extensions: &WeakExtensionRegistry,
     used_extensions: &mut WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    match extensions.get(def.extension_id()) {
-        Some(ext) => {
-            if let Some(extension) = ext.upgrade() {
-                def.fill_extension_version(extension.version());
-            }
+    match extensions.get_req(def.extension_id(), Some(version)) {
+        Some((_, ext)) => {
+            def.fill_extension_version(version);
             *def.extension_mut() = ext.clone();
         }
         None => {

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -118,15 +118,23 @@ fn operation_extension<'e>(
     op: &OpType,
     extensions: &'e ExtensionRegistry,
 ) -> Result<Option<&'e Arc<Extension>>, ExtensionResolutionError> {
-    let Some(ext) = op.extension_id() else {
+    let Some(ext_id) = op.extension_id() else {
         return Ok(None);
     };
-    match extensions.get(ext) {
+    let extension = match op {
+        OpType::OpaqueOp(opaque) => extensions.get_req(ext_id, opaque.extension_version()),
+        OpType::ExtensionOp(ext_op) => {
+            let version = ext_op.extension_version();
+            extensions.get_exact(ext_id, &version)
+        }
+        _ => extensions.get(ext_id),
+    };
+    match extension {
         Some(e) => Ok(Some(e)),
         None => Err(ExtensionResolutionError::missing_op_extension(
             Some(node),
             op,
-            ext,
+            ext_id,
             extensions,
         )),
     }

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -15,11 +15,12 @@ use crate::extension::prelude::{ConstUsize, bool_t, usize_custom_t, usize_t};
 use crate::extension::resolution::WeakExtensionRegistry;
 use crate::extension::resolution::{resolve_op_extensions, resolve_op_types_extensions};
 use crate::extension::{
-    ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE, PRELUDE_REGISTRY, TypeDefBound,
+    ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE, PRELUDE_REGISTRY, TypeDefBound, Version,
 };
 use crate::ops::constant::CustomConst;
 use crate::ops::constant::test::CustomTestValue;
-use crate::ops::{CallIndirect, ExtensionOp, Input, NamedOp, OpType, Tag, Value};
+use crate::ops::dataflow::IOTrait;
+use crate::ops::{CallIndirect, ExtensionOp, Input, NamedOp, OpType, OpaqueOp, Tag, Value};
 use crate::package::Package;
 use crate::std_extensions::arithmetic::conversions::{self, ConvertOpDef};
 use crate::std_extensions::arithmetic::float_types::{self, ConstF64, float64_type};
@@ -28,7 +29,7 @@ use crate::std_extensions::arithmetic::int_types::{self, int_type};
 use crate::std_extensions::collections::list::ListValue;
 use crate::std_extensions::std_reg;
 use crate::types::type_param::TypeParam;
-use crate::types::{PolyFuncType, Signature, Type, TypeBound};
+use crate::types::{CustomType, PolyFuncType, Signature, Term, Type, TypeBound};
 use crate::{Extension, Hugr, HugrView, type_row};
 
 #[rstest]
@@ -71,6 +72,79 @@ fn resolve_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: Ex
         deser_extensions, extensions,
         "{deser_extensions} != {extensions}"
     );
+}
+
+fn make_versioned_extension(id: &ExtensionId, version: Version) -> Arc<Extension> {
+    Extension::new_arc(id.clone(), version, |ext, extension_ref| {
+        ext.add_type(
+            "MyType".into(),
+            vec![],
+            String::new(),
+            TypeDefBound::copyable(),
+            extension_ref,
+        )
+        .unwrap();
+        ext.add_op(
+            "my_op".into(),
+            String::new(),
+            Signature::new_endo([bool_t()]),
+            extension_ref,
+        )
+        .unwrap();
+    })
+}
+
+#[test]
+fn resolve_opaque_op_uses_highest_compatible_extension() {
+    let ext_id = ExtensionId::new_unchecked("versioned_ext");
+    let ext_0_2_5 = make_versioned_extension(&ext_id, Version::new(0, 2, 5));
+    let ext_0_3_0 = make_versioned_extension(&ext_id, Version::new(0, 3, 0));
+    let registry = ExtensionRegistry::new([ext_0_2_5, ext_0_3_0]);
+
+    let mut op: OpType = OpaqueOp::new(
+        ext_id.clone(),
+        Version::new(0, 2, 3),
+        "my_op",
+        [],
+        Signature::new_endo([bool_t()]),
+    )
+    .into();
+
+    let dummy_node = portgraph::NodeIndex::new(0).into();
+    resolve_op_extensions(dummy_node, &mut op, &registry).unwrap();
+
+    let ext_op = op.as_extension_op().unwrap();
+    assert_eq!(ext_op.extension_version(), Version::new(0, 2, 5));
+}
+
+#[test]
+fn resolve_custom_type_uses_highest_compatible_extension() {
+    let ext_id = ExtensionId::new_unchecked("versioned_type_ext");
+    let ext_0_2_5 = make_versioned_extension(&ext_id, Version::new(0, 2, 5));
+    let ext_0_3_0 = make_versioned_extension(&ext_id, Version::new(0, 3, 0));
+    let registry = ExtensionRegistry::new([ext_0_2_5, ext_0_3_0]);
+    let weak_registry = WeakExtensionRegistry::from(&registry);
+    let mut op = OpType::Input(Input::new(vec![Type::new_extension(CustomType::new(
+        "MyType",
+        [],
+        ext_id,
+        Version::new(0, 2, 3),
+        TypeBound::Copyable,
+        &Default::default(),
+    ))]));
+
+    let dummy_node = portgraph::NodeIndex::new(0).into();
+    resolve_op_types_extensions(Some(dummy_node), &mut op, &weak_registry)
+        .unwrap()
+        .for_each(|_| ());
+
+    let OpType::Input(input) = op else {
+        panic!("expected input op");
+    };
+    let Term::ExtensionType(custom) = &*input.types[0] else {
+        panic!("expected custom type");
+    };
+    assert_eq!(custom.extension_version(), Some(&Version::new(0, 2, 5)));
 }
 
 /// Create a new test extension with a single operation.
@@ -128,12 +202,10 @@ fn check_extension_resolution(mut hugr: Hugr) {
     resolution_extensions.extend(&build_extensions);
 
     // Check that the read-only methods collect the same extensions.
-    let collected_exts = ExtensionRegistry::new(hugr.nodes().flat_map(|node| {
-        hugr.get_optype(node)
-            .used_extensions()
-            .unwrap_or_default()
-            .into_iter()
-    }));
+    let mut collected_exts = ExtensionRegistry::default();
+    for node in hugr.nodes() {
+        collected_exts.extend(hugr.get_optype(node).used_extensions().unwrap_or_default());
+    }
     assert_eq!(
         collected_exts, build_extensions,
         "{collected_exts} != {build_extensions}"
@@ -413,7 +485,7 @@ fn resolve_lower_func_extensions() {
 
     // The lower func is stored as a Package so its extension definitions travel with it.
     let mut lower_pkg = Package::from_hugr(lower_hugr);
-    lower_pkg.extensions.register_updated(inner_ext.clone());
+    lower_pkg.extensions.register(inner_ext.clone());
 
     // Create an outer extension whose op has the lower func.
     let inner_ext_name = inner_ext.name().clone();
@@ -438,7 +510,7 @@ fn resolve_lower_func_extensions() {
     // Build a package containing only the outer extension.
     // The inner extension is embedded inside the lower func's Package.
     let mut outer_pkg = Package::default();
-    outer_pkg.extensions.register_updated(outer_ext.clone());
+    outer_pkg.extensions.register(outer_ext.clone());
 
     // Serialize and reload using only the standard extensions as the external registry.
     // The inner extension must be recovered from the embedded lower func package.

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -194,7 +194,7 @@ pub(crate) fn collect_term_exts(
             // Check if the extension reference is still valid.
             match ext_ref.upgrade() {
                 Some(ext) => {
-                    used_extensions.register(ext.name().clone(), ext_ref);
+                    used_extensions.register(ext.name().clone(), ext.version().clone(), ext_ref);
                 }
                 None => {
                     missing_extensions.insert(custom.extension().clone());

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -197,9 +197,16 @@ pub(super) fn resolve_custom_type_exts(
     }
 
     let ext_id = custom.extension();
-    let ext = extensions.get(ext_id).ok_or_else(|| {
-        ExtensionResolutionError::missing_type_extension(node, custom.name(), ext_id, extensions)
-    })?;
+    let ext = extensions
+        .get_req(ext_id, custom.extension_version())
+        .ok_or_else(|| {
+            ExtensionResolutionError::missing_type_extension(
+                node,
+                custom.name(),
+                ext_id,
+                extensions,
+            )
+        })?;
 
     // Add the extension to the used extensions registry,
     // and update the CustomType with the valid pointer.

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -121,7 +121,7 @@ pub fn resolve_op_types_extensions(
         // Ignore optypes that do not store a signature.
         OpType::Module(_) | OpType::AliasDecl(_) | OpType::AliasDefn(_) => {}
     }
-    Ok(used.into_iter())
+    Ok(used.into_iter().map(|(_, _, ext)| ext))
 }
 
 /// Update all weak Extension pointers in the [`CustomType`]s inside a [Signature].
@@ -197,7 +197,7 @@ pub(super) fn resolve_custom_type_exts(
     }
 
     let ext_id = custom.extension();
-    let ext = extensions
+    let (version, ext) = extensions
         .get_req(ext_id, custom.extension_version())
         .ok_or_else(|| {
             ExtensionResolutionError::missing_type_extension(
@@ -210,7 +210,7 @@ pub(super) fn resolve_custom_type_exts(
 
     // Add the extension to the used extensions registry,
     // and update the CustomType with the valid pointer.
-    used_extensions.register(ext_id.clone(), ext.clone());
+    used_extensions.register(ext_id.clone(), version.clone(), ext.clone());
     custom.update_extension(ext.clone());
 
     Ok(())

--- a/hugr-core/src/extension/resolution/weak_registry.rs
+++ b/hugr-core/src/extension/resolution/weak_registry.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use derive_more::Display;
 
 use crate::Extension;
-use crate::extension::{ExtensionId, ExtensionRegistry};
+use crate::extension::{ExtensionId, ExtensionRegistry, Version, semver_compatible};
 
 /// The equivalent to an [`ExtensionRegistry`] that only contains weak
 /// references.
@@ -17,7 +17,94 @@ use crate::extension::{ExtensionId, ExtensionRegistry};
 #[display("WeakExtensionRegistry[{}]", exts.keys().join(", "))]
 pub struct WeakExtensionRegistry {
     /// The extensions in the registry.
-    exts: BTreeMap<ExtensionId, Weak<Extension>>,
+    exts: BTreeMap<ExtensionId, WeakExtensionVersions>,
+}
+
+/// Weak references retained for one extension id.
+#[derive(Debug, Clone)]
+pub struct WeakExtensionVersions {
+    id: ExtensionId,
+    versions: BTreeMap<Version, Weak<Extension>>,
+}
+
+impl WeakExtensionVersions {
+    fn new(id: ExtensionId, ext: Weak<Extension>) -> Self {
+        let version = ext
+            .upgrade()
+            .expect("weak extension must be upgradeable when registered")
+            .version()
+            .clone();
+        Self {
+            id,
+            versions: [(version, ext)].into(),
+        }
+    }
+
+    fn latest(&self) -> &Weak<Extension> {
+        self.versions
+            .last_key_value()
+            .expect("WeakExtensionVersions always contains at least one extension")
+            .1
+    }
+
+    fn compatible(&self, requested: &Version) -> Option<&Weak<Extension>> {
+        let (version, extension) = self.versions.range(requested..).next()?;
+        semver_compatible(version, requested).then_some(extension)
+    }
+
+    fn get_req(&self, requested: Option<&Version>) -> Option<&Weak<Extension>> {
+        requested
+            .and_then(|version| self.compatible(version))
+            .or_else(|| requested.is_none().then(|| self.latest()))
+    }
+
+    fn register(&mut self, ext: Weak<Extension>) -> bool {
+        let extension = ext
+            .upgrade()
+            .expect("weak extension must be upgradeable when registered");
+        assert_eq!(
+            extension.name(),
+            &self.id,
+            "extension id does not match WeakExtensionVersions id"
+        );
+        let version = extension.version().clone();
+        drop(extension);
+
+        let compatible_version = self.compatible_registered_version(&version);
+
+        let Some(compatible_version) = compatible_version else {
+            self.versions.insert(version, ext);
+            return true;
+        };
+        if compatible_version > version {
+            return false;
+        }
+
+        self.versions.remove(&compatible_version);
+        self.versions.insert(version, ext);
+        true
+    }
+
+    fn compatible_registered_version(&self, version: &Version) -> Option<Version> {
+        if let Some((candidate, _)) = self.versions.range(..=version).next_back()
+            && semver_compatible(version, candidate)
+        {
+            return Some(candidate.clone());
+        }
+        self.versions
+            .range(version..)
+            .next()
+            .filter(|(candidate, _)| semver_compatible(candidate, version))
+            .map(|(candidate, _)| candidate.clone())
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &Weak<Extension>> {
+        self.versions.values()
+    }
+
+    fn into_all(self) -> impl Iterator<Item = Weak<Extension>> {
+        self.versions.into_values()
+    }
 }
 
 impl WeakExtensionRegistry {
@@ -33,7 +120,13 @@ impl WeakExtensionRegistry {
     /// Gets the Extension with the given name
     #[must_use]
     pub fn get(&self, name: &str) -> Option<&Weak<Extension>> {
-        self.exts.get(name)
+        self.exts.get(name).map(WeakExtensionVersions::latest)
+    }
+
+    /// Gets the Extension satisfying an optional serialized version requirement.
+    #[must_use]
+    pub fn get_req(&self, name: &str, version: Option<&Version>) -> Option<&Weak<Extension>> {
+        self.exts.get(name).and_then(|ext| ext.get_req(version))
     }
 
     /// Returns `true` if the registry contains an extension with the given name.
@@ -46,17 +139,40 @@ impl WeakExtensionRegistry {
     ///
     /// Returns `true` if the extension was added, `false` if it was already present.
     pub fn register(&mut self, id: ExtensionId, ext: impl Into<Weak<Extension>>) -> bool {
-        self.exts.insert(id, ext.into()).is_none()
+        let ext = ext.into();
+        match self.exts.entry(id.clone()) {
+            std::collections::btree_map::Entry::Occupied(mut occupied) => {
+                occupied.get_mut().register(ext)
+            }
+            std::collections::btree_map::Entry::Vacant(vacant) => {
+                vacant.insert(WeakExtensionVersions::new(id, ext));
+                true
+            }
+        }
     }
 
     /// Returns an iterator over the weak references in the registry and their ids.
     pub fn iter(&self) -> impl Iterator<Item = (&ExtensionId, &Weak<Extension>)> {
-        self.exts.iter()
+        self.exts
+            .iter()
+            .map(|(id, versions)| (id, versions.latest()))
+    }
+
+    /// Returns an iterator over all retained weak references and their ids.
+    pub fn iter_all(&self) -> impl Iterator<Item = (&ExtensionId, &Weak<Extension>)> {
+        self.exts
+            .iter()
+            .flat_map(|(id, versions)| versions.iter().map(move |ext| (id, ext)))
     }
 
     /// Returns an iterator over the weak references in the registry.
     pub fn extensions(&self) -> impl Iterator<Item = &Weak<Extension>> {
-        self.exts.values()
+        self.exts.values().map(WeakExtensionVersions::latest)
+    }
+
+    /// Returns an iterator over all retained weak references.
+    pub fn all_extensions(&self) -> impl Iterator<Item = &Weak<Extension>> {
+        self.exts.values().flat_map(WeakExtensionVersions::iter)
     }
 
     /// Returns an iterator over the extension ids in the registry.
@@ -67,10 +183,14 @@ impl WeakExtensionRegistry {
 
 impl IntoIterator for WeakExtensionRegistry {
     type Item = Weak<Extension>;
-    type IntoIter = std::collections::btree_map::IntoValues<ExtensionId, Weak<Extension>>;
+    type IntoIter = std::vec::IntoIter<Weak<Extension>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.exts.into_values()
+        self.exts
+            .into_values()
+            .flat_map(WeakExtensionVersions::into_all)
+            .collect_vec()
+            .into_iter()
     }
 }
 
@@ -79,7 +199,7 @@ impl<'a> TryFrom<&'a WeakExtensionRegistry> for ExtensionRegistry {
 
     fn try_from(weak: &'a WeakExtensionRegistry) -> Result<Self, Self::Error> {
         let exts: Vec<Arc<Extension>> = weak
-            .extensions()
+            .all_extensions()
             .map(|w| w.upgrade().ok_or(()))
             .try_collect()?;
         Ok(ExtensionRegistry::new(exts))
@@ -100,10 +220,9 @@ impl TryFrom<WeakExtensionRegistry> for ExtensionRegistry {
 
 impl<'a> From<&'a ExtensionRegistry> for WeakExtensionRegistry {
     fn from(reg: &'a ExtensionRegistry) -> Self {
-        let exts = reg
-            .iter()
-            .map(|ext| (ext.name().clone(), Arc::downgrade(ext)))
-            .collect();
-        Self { exts }
+        Self::new(
+            reg.iter_all()
+                .map(|ext| (ext.name().clone(), Arc::downgrade(ext))),
+        )
     }
 }

--- a/hugr-core/src/extension/resolution/weak_registry.rs
+++ b/hugr-core/src/extension/resolution/weak_registry.rs
@@ -20,7 +20,15 @@ pub struct WeakExtensionRegistry {
     exts: BTreeMap<ExtensionId, WeakExtensionVersions>,
 }
 
-/// Weak references retained for one extension id.
+/// Retained versions for one extension id.
+///
+/// Contains a set of versions for a given extension, and the corresponding [Weak]
+/// references to each [Extension].
+///
+/// The registry keeps at most one extension per semver-compatible group: when a
+/// newer compatible version is registered, it replaces the older compatible
+/// definition. Incompatible versions are retained side by side so older HUGRs can
+/// still resolve against the appropriate definition.
 #[derive(Debug, Clone)]
 pub struct WeakExtensionVersions {
     id: ExtensionId,
@@ -28,47 +36,62 @@ pub struct WeakExtensionVersions {
 }
 
 impl WeakExtensionVersions {
-    fn new(id: ExtensionId, ext: Weak<Extension>) -> Self {
-        let version = ext
-            .upgrade()
-            .expect("weak extension must be upgradeable when registered")
-            .version()
-            .clone();
+    /// Create a new `WeakExtensionVersions` with a single entry.
+    fn new(id: ExtensionId, version: Version, ext: Weak<Extension>) -> Self {
         Self {
             id,
             versions: [(version, ext)].into(),
         }
     }
 
-    fn latest(&self) -> &Weak<Extension> {
+    /// Returns the highest version extension registered for this id.
+    #[must_use]
+    fn latest(&self) -> (&Version, &Weak<Extension>) {
         self.versions
             .last_key_value()
             .expect("WeakExtensionVersions always contains at least one extension")
-            .1
     }
 
-    fn compatible(&self, requested: &Version) -> Option<&Weak<Extension>> {
+    /// Return the highest retained extension compatible with `requested`, if any.
+    #[must_use]
+    fn get_compatible(&self, requested: &Version) -> Option<(&Version, &Weak<Extension>)> {
         let (version, extension) = self.versions.range(requested..).next()?;
-        semver_compatible(version, requested).then_some(extension)
+        semver_compatible(version, requested).then_some((version, extension))
     }
 
-    fn get_req(&self, requested: Option<&Version>) -> Option<&Weak<Extension>> {
-        requested
-            .and_then(|version| self.compatible(version))
-            .or_else(|| requested.is_none().then(|| self.latest()))
+    /// Gets the extension satisfying an optional serialized version requirement.
+    ///
+    /// If `requested` is `Some(version)`, returns the highest retained
+    /// extension compatible with `version`. If `requested` is `None`, returns
+    /// the latest retained extension.
+    ///
+    /// This is used when deserializing older HUGRs that may not have a version
+    /// specified for their extensions.
+    #[must_use]
+    fn get_req(&self, requested: Option<&Version>) -> Option<(&Version, &Weak<Extension>)> {
+        match requested {
+            Some(version) => self.get_compatible(version),
+            None => Some(self.latest()),
+        }
     }
 
-    fn register(&mut self, ext: Weak<Extension>) -> bool {
-        let extension = ext
-            .upgrade()
-            .expect("weak extension must be upgradeable when registered");
-        assert_eq!(
-            extension.name(),
-            &self.id,
-            "extension id does not match WeakExtensionVersions id"
-        );
-        let version = extension.version().clone();
-        drop(extension);
+    /// Register a new extension in the versions for this id.
+    ///
+    /// Returns `true` if the extension was added.
+    /// Returns `false` if the same version, or a later compatible one was already present.
+    fn register(&mut self, version: Version, ext: Weak<Extension>) -> bool {
+        #[cfg(debug_assertions)]
+        {
+            let extension = ext
+                .upgrade()
+                .expect("weak extension ARC must be upgradeable when registered");
+            assert_eq!(
+                extension.name(),
+                &self.id,
+                "extension id does not match WeakExtensionVersions id"
+            );
+            drop(extension);
+        }
 
         let compatible_version = self.compatible_registered_version(&version);
 
@@ -85,6 +108,12 @@ impl WeakExtensionVersions {
         true
     }
 
+    /// Returns a registered version that is in the same semver-compatibility group as the requested version, if any.
+    ///
+    /// The registry keeps at most one extension per semver-compatible group: when a
+    /// newer compatible version is registered, it replaces the older compatible
+    /// definition. Incompatible versions are retained side by side so older HUGRs can
+    /// still resolve against the appropriate definition.
     fn compatible_registered_version(&self, version: &Version) -> Option<Version> {
         if let Some((candidate, _)) = self.versions.range(..=version).next_back()
             && semver_compatible(version, candidate)
@@ -98,34 +127,46 @@ impl WeakExtensionVersions {
             .map(|(candidate, _)| candidate.clone())
     }
 
-    fn iter(&self) -> impl Iterator<Item = &Weak<Extension>> {
-        self.versions.values()
+    /// Iterate over the weak references in the registry and their versions.
+    fn iter(&self) -> impl Iterator<Item = (&Version, &Weak<Extension>)> {
+        self.versions.iter()
     }
 
-    fn into_all(self) -> impl Iterator<Item = Weak<Extension>> {
-        self.versions.into_values()
+    /// Returns an iterator over the weak references in the registry and their versions.
+    fn into_iter(self) -> impl Iterator<Item = (Version, Weak<Extension>)> {
+        self.versions.into_iter()
     }
 }
 
 impl WeakExtensionRegistry {
     /// Create a new weak registry from a list of extensions and their ids.
-    pub fn new(extensions: impl IntoIterator<Item = (ExtensionId, Weak<Extension>)>) -> Self {
+    pub fn new(
+        extensions: impl IntoIterator<Item = (ExtensionId, Version, Weak<Extension>)>,
+    ) -> Self {
         let mut res = Self::default();
-        for (id, ext) in extensions {
-            res.register(id, ext);
+        for (id, version, ext) in extensions {
+            res.register(id, version, ext);
         }
         res
     }
 
     /// Gets the Extension with the given name
     #[must_use]
-    pub fn get(&self, name: &str) -> Option<&Weak<Extension>> {
+    pub fn get_latest(&self, name: &str) -> Option<(&Version, &Weak<Extension>)> {
         self.exts.get(name).map(WeakExtensionVersions::latest)
     }
 
-    /// Gets the Extension satisfying an optional serialized version requirement.
+    /// Gets the Extension satisfying an optional serialized version
+    /// requirement.
+    ///
+    /// If found a matching extension, returns a Weak reference to it along with
+    /// its version. If no matching extension is found, returns None.
     #[must_use]
-    pub fn get_req(&self, name: &str, version: Option<&Version>) -> Option<&Weak<Extension>> {
+    pub fn get_req(
+        &self,
+        name: &str,
+        version: Option<&Version>,
+    ) -> Option<(&Version, &Weak<Extension>)> {
         self.exts.get(name).and_then(|ext| ext.get_req(version))
     }
 
@@ -138,41 +179,55 @@ impl WeakExtensionRegistry {
     /// Register a new extension in the registry.
     ///
     /// Returns `true` if the extension was added, `false` if it was already present.
-    pub fn register(&mut self, id: ExtensionId, ext: impl Into<Weak<Extension>>) -> bool {
+    pub fn register(
+        &mut self,
+        id: ExtensionId,
+        version: Version,
+        ext: impl Into<Weak<Extension>>,
+    ) -> bool {
         let ext = ext.into();
         match self.exts.entry(id.clone()) {
             std::collections::btree_map::Entry::Occupied(mut occupied) => {
-                occupied.get_mut().register(ext)
+                occupied.get_mut().register(version, ext)
             }
             std::collections::btree_map::Entry::Vacant(vacant) => {
-                vacant.insert(WeakExtensionVersions::new(id, ext));
+                vacant.insert(WeakExtensionVersions::new(id, version, ext));
                 true
             }
         }
     }
 
     /// Returns an iterator over the weak references in the registry and their ids.
-    pub fn iter(&self) -> impl Iterator<Item = (&ExtensionId, &Weak<Extension>)> {
-        self.exts
-            .iter()
-            .map(|(id, versions)| (id, versions.latest()))
+    pub fn iter(&self) -> impl Iterator<Item = (&ExtensionId, &Version, &Weak<Extension>)> {
+        self.exts.iter().map(|(id, versions)| {
+            let (version, ext) = versions.latest();
+            (id, version, ext)
+        })
     }
 
     /// Returns an iterator over all retained weak references and their ids.
-    pub fn iter_all(&self) -> impl Iterator<Item = (&ExtensionId, &Weak<Extension>)> {
-        self.exts
-            .iter()
-            .flat_map(|(id, versions)| versions.iter().map(move |ext| (id, ext)))
+    pub fn iter_all(&self) -> impl Iterator<Item = (&ExtensionId, &Version, &Weak<Extension>)> {
+        self.exts.iter().flat_map(|(id, versions)| {
+            versions
+                .iter()
+                .map(move |(version, ext)| (id, version, ext))
+        })
     }
 
     /// Returns an iterator over the weak references in the registry.
-    pub fn extensions(&self) -> impl Iterator<Item = &Weak<Extension>> {
+    pub fn extensions(&self) -> impl Iterator<Item = (&Version, &Weak<Extension>)> {
         self.exts.values().map(WeakExtensionVersions::latest)
     }
 
-    /// Returns an iterator over all retained weak references.
-    pub fn all_extensions(&self) -> impl Iterator<Item = &Weak<Extension>> {
-        self.exts.values().flat_map(WeakExtensionVersions::iter)
+    /// Returns an iterator over all retained weak references, including their id and version.
+    pub fn all_extensions(
+        &self,
+    ) -> impl Iterator<Item = (&ExtensionId, &Version, &Weak<Extension>)> {
+        self.exts.values().flat_map(|versions| {
+            versions
+                .iter()
+                .map(move |(version, ext)| (&versions.id, version, ext))
+        })
     }
 
     /// Returns an iterator over the extension ids in the registry.
@@ -182,13 +237,17 @@ impl WeakExtensionRegistry {
 }
 
 impl IntoIterator for WeakExtensionRegistry {
-    type Item = Weak<Extension>;
-    type IntoIter = std::vec::IntoIter<Weak<Extension>>;
+    type Item = (ExtensionId, Version, Weak<Extension>);
+    type IntoIter = std::vec::IntoIter<(ExtensionId, Version, Weak<Extension>)>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.exts
-            .into_values()
-            .flat_map(WeakExtensionVersions::into_all)
+            .into_iter()
+            .flat_map(|(id, ext_versions)| {
+                ext_versions
+                    .into_iter()
+                    .map(move |(version, ext)| (id.clone(), version, ext))
+            })
             .collect_vec()
             .into_iter()
     }
@@ -200,7 +259,7 @@ impl<'a> TryFrom<&'a WeakExtensionRegistry> for ExtensionRegistry {
     fn try_from(weak: &'a WeakExtensionRegistry) -> Result<Self, Self::Error> {
         let exts: Vec<Arc<Extension>> = weak
             .all_extensions()
-            .map(|w| w.upgrade().ok_or(()))
+            .map(|(_, _, w)| w.upgrade().ok_or(()))
             .try_collect()?;
         Ok(ExtensionRegistry::new(exts))
     }
@@ -212,7 +271,7 @@ impl TryFrom<WeakExtensionRegistry> for ExtensionRegistry {
     fn try_from(weak: WeakExtensionRegistry) -> Result<Self, Self::Error> {
         let exts: Vec<Arc<Extension>> = weak
             .into_iter()
-            .map(|w| w.upgrade().ok_or(()))
+            .map(|(_, _, w)| w.upgrade().ok_or(()))
             .try_collect()?;
         Ok(ExtensionRegistry::new(exts))
     }
@@ -220,9 +279,12 @@ impl TryFrom<WeakExtensionRegistry> for ExtensionRegistry {
 
 impl<'a> From<&'a ExtensionRegistry> for WeakExtensionRegistry {
     fn from(reg: &'a ExtensionRegistry) -> Self {
-        Self::new(
-            reg.iter_all()
-                .map(|ext| (ext.name().clone(), Arc::downgrade(ext))),
-        )
+        Self::new(reg.iter_all().map(|ext| {
+            (
+                ext.name().clone(),
+                ext.version().clone(),
+                Arc::downgrade(ext),
+            )
+        }))
     }
 }

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -313,7 +313,7 @@ impl Hugr {
             let op = &mut self.op_types[pg_node];
 
             if let Some(extension) = resolve_op_extensions(node, op, extensions)? {
-                used_extensions.register_updated_ref(extension);
+                used_extensions.register(extension.clone());
             }
             used_extensions.extend(
                 resolve_op_types_extensions(Some(node), op, &weak_extensions)?.map(|weak| {
@@ -874,7 +874,7 @@ pub(crate) mod test {
         });
 
         let mut package = simple_package();
-        package.extensions.register(my_ext).unwrap();
+        package.extensions.register(my_ext);
         let mut hugr_str = Vec::new();
         package
             .store(&mut hugr_str, EnvelopeConfig::default())

--- a/hugr-core/src/hugr/hugrmut.rs
+++ b/hugr-core/src/hugr/hugrmut.rs
@@ -387,7 +387,7 @@ pub trait HugrMut: HugrMutInternals {
     ///
     /// These can be queried using [`HugrView::extensions`].
     ///
-    /// See [`ExtensionRegistry::register_updated`] for more information.
+    /// See [`ExtensionRegistry::register`] for more information.
     fn use_extension(&mut self, extension: impl Into<Arc<Extension>>);
 
     /// Extend the set of extensions used by the hugr with the extensions in the
@@ -398,7 +398,7 @@ pub trait HugrMut: HugrMutInternals {
     ///
     /// These can be queried using [`HugrView::extensions`].
     ///
-    /// See [`ExtensionRegistry::register_updated`] for more information.
+    /// See [`ExtensionRegistry::register`] for more information.
     fn use_extensions<Reg>(&mut self, registry: impl IntoIterator<Item = Reg>)
     where
         ExtensionRegistry: Extend<Reg>;
@@ -737,7 +737,7 @@ impl HugrMut for Hugr {
 
     #[inline]
     fn use_extension(&mut self, extension: impl Into<Arc<Extension>>) {
-        self.extensions_mut().register_updated(extension);
+        self.extensions_mut().register(extension);
     }
 
     #[inline]

--- a/hugr-core/src/hugr/patch/replace.rs
+++ b/hugr-core/src/hugr/patch/replace.rs
@@ -744,7 +744,7 @@ mod test {
         let bar = ext.instantiate_extension_op("bar", []).unwrap();
         let baz = ext.instantiate_extension_op("baz", []).unwrap();
         let mut registry = test_quantum_extension::REG.clone();
-        registry.register(ext).unwrap();
+        registry.register(ext);
 
         let mut h =
             DFGBuilder::new(Signature::new(vec![usize_t(), bool_t()], vec![usize_t()])).unwrap();

--- a/hugr-core/src/hugr/serialize/test.rs
+++ b/hugr-core/src/hugr/serialize/test.rs
@@ -642,7 +642,7 @@ fn roundtrip_optype(#[case] optype: impl Into<OpType> + std::fmt::Debug) {
 // test all standard extension serialisations are valid against scheme
 fn std_extensions_valid() {
     let std_reg = crate::std_extensions::std_reg();
-    for ext in std_reg {
+    for ext in std_reg.iter_all() {
         let val = serde_json::to_value(ext).unwrap();
         NamedSchema::check_schemas(&val, get_schemas(true)).unwrap();
         // check deserialises correctly, can't check equality because of custom binaries.

--- a/hugr-core/src/ops.rs
+++ b/hugr-core/src/ops.rs
@@ -504,7 +504,7 @@ impl OpType {
         let mut reg = collect_op_types_extensions(None, self)?;
         // And on the operation definition itself.
         if let Some(ext) = collect_op_extension(None, self)? {
-            reg.register_updated(ext);
+            reg.register(ext);
         }
         reg.extend_with_dependencies()?;
         Ok(reg)

--- a/hugr-core/src/types/custom.rs
+++ b/hugr-core/src/types/custom.rs
@@ -170,11 +170,9 @@ impl CustomType {
 
     /// Update the internal extension reference with a new weak pointer.
     pub fn update_extension(&mut self, extension_ref: Weak<Extension>) {
-        if self.extension_version.is_none() {
-            self.extension_version = extension_ref
-                .upgrade()
-                .map(|extension| extension.version().clone());
-        }
+        self.extension_version = extension_ref
+            .upgrade()
+            .map(|extension| extension.version().clone());
         self.extension_ref = extension_ref;
     }
 }

--- a/hugr-core/tests/model.rs
+++ b/hugr-core/tests/model.rs
@@ -123,7 +123,7 @@ fn import_package_with_extensions(#[case] format: EnvelopeFormat, simple_dfg_hug
         |_, _| {},
     );
     let mut package = Package::new([simple_dfg_hugr]);
-    package.extensions.register_updated(ext);
+    package.extensions.register(ext);
 
     let mut bytes: Vec<u8> = Vec::new();
     write_envelope(&mut bytes, &package, EnvelopeConfig::new(format)).unwrap();
@@ -132,7 +132,7 @@ fn import_package_with_extensions(#[case] format: EnvelopeFormat, simple_dfg_hug
     let (_, loaded_pkg) = read_envelope(buff, &std_reg()).unwrap();
 
     assert_eq!(loaded_pkg.extensions.len(), 1);
-    let read_ext = loaded_pkg.extensions.iter().next().unwrap();
+    let read_ext = loaded_pkg.extensions.iter_all().next().unwrap();
     assert_eq!(read_ext.name(), &"miniquantum".try_into().unwrap());
 
     assert_eq!(package, loaded_pkg);

--- a/hugr-llvm/src/emit/test.rs
+++ b/hugr-llvm/src/emit/test.rs
@@ -724,8 +724,8 @@ mod test_fns {
         let other_ty = int_ty.clone();
 
         let mut registry = PRELUDE_REGISTRY.clone();
-        registry.register(int_ops::EXTENSION.clone()).unwrap();
-        registry.register(int_types::EXTENSION.clone()).unwrap();
+        registry.register(int_ops::EXTENSION.clone());
+        registry.register(int_types::EXTENSION.clone());
 
         SimpleHugrConfig::new()
             .with_extensions(registry)

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -475,15 +475,40 @@ class ExtensionVersions:
         return frozenset(self._exts.keys())
 
     def add(self, extension: Extension) -> None:
-        """Add an extension to the set."""
+        """Add an extension to the set, coalescing compatible older versions."""
         if extension.name != self._id:
             msg = f"Extension {extension.name} has a different name than {self._id}"
             raise ValueError(msg)
+
+        compatible_versions = [
+            version
+            for version in self._exts
+            if _same_compatibility_group(version, extension.version)
+        ]
+        if compatible_versions:
+            latest_compatible = max(compatible_versions)
+            if latest_compatible > extension.version:
+                return
+            for version in compatible_versions:
+                del self._exts[version]
 
         self._exts[extension.version] = extension
 
         if extension.version > self._latest_version:
             self._latest_version = extension.version
+        else:
+            self._latest_version = max(self._exts)
+
+    def get_compatible(self, version: Version) -> Extension:
+        """Get the highest registered extension compatible with ``version``."""
+        compatible = [
+            extension
+            for ext_version, extension in self._exts.items()
+            if _semver_compatible(ext_version, version)
+        ]
+        if not compatible:
+            raise KeyError(version)
+        return max(compatible, key=lambda extension: extension.version)
 
     def __contains__(self, version: Version) -> bool:
         """Check if a version is in the set."""
@@ -575,11 +600,15 @@ class ExtensionRegistry:
             self.versioned_extensions[extension.name].add(extension)
         return self.versioned_extensions[extension.name][extension.version]
 
-    def get_extension(self, name: ExtensionId) -> Extension:
+    def get_extension(
+        self, name: ExtensionId, version: Version | None = None
+    ) -> Extension:
         """Retrieve an extension by name.
 
         Args:
             name: The name of the extension.
+            version: Optional serialized version requirement. If set, the
+                highest compatible registered version is returned.
 
         Returns:
             Extension in the registry.
@@ -588,7 +617,13 @@ class ExtensionRegistry:
             ExtensionNotFound: If the extension is not found in the registry.
         """
         try:
-            return self.versioned_extensions[name].latest
+            versions = self.versioned_extensions[name]
+        except KeyError as e:
+            raise self.ExtensionNotFound(name) from e
+        if version is None:
+            return versions.latest
+        try:
+            return versions.get_compatible(version)
         except KeyError as e:
             raise self.ExtensionNotFound(name) from e
 
@@ -673,3 +708,22 @@ class ExtensionResolutionResult:
                 if new_ext.name not in self.used_extensions:
                     self.used_extensions.register(new_ext)
                     queue.append(new_ext)
+
+
+def _semver_compatible(candidate: Version, requested: Version) -> bool:
+    """Return whether ``candidate`` can satisfy a request for ``requested``."""
+    # python-semver treats all 0.x releases as incompatible unless they are an
+    # exact match. For extension migration we follow caret-style semver
+    # compatibility, where 0.minor.patch releases may update the patch version.
+    if requested.major == 0 and requested.minor > 0:
+        return (
+            candidate >= requested
+            and candidate.major == requested.major
+            and candidate.minor == requested.minor
+        )
+    return requested.is_compatible(candidate)
+
+
+def _same_compatibility_group(left: Version, right: Version) -> bool:
+    """Return whether two versions are in the same semver-compatible group."""
+    return _semver_compatible(left, right) or _semver_compatible(right, left)

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -509,7 +509,9 @@ class Custom(DataflowOp):
 
         if registry is not None:
             try:
-                op_def = registry.get_extension(self.extension).get_op(self.op_name)
+                op_def = registry.get_extension(
+                    self.extension, self.extension_version
+                ).get_op(self.op_name)
             except (
                 Extension.OperationNotFound,
                 ExtensionRegistry.ExtensionNotFound,

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -1049,7 +1049,9 @@ class Opaque(Type):
 
         if registry is not None:
             try:
-                type_def = registry.get_extension(self.extension).get_type(self.id)
+                type_def = registry.get_extension(
+                    self.extension, self.extension_version
+                ).get_type(self.id)
             except (ExtensionRegistry.ExtensionNotFound, Extension.TypeNotFound):
                 pass
             else:

--- a/hugr-py/tests/test_custom.py
+++ b/hugr-py/tests/test_custom.py
@@ -179,3 +179,55 @@ def test_qualified_name():
 
     # Test OpDef with extension
     assert _STRINGLY_DEF.qualified_name() == "my_extension.StringlyOp"
+
+
+def _versioned_ext(version: ext.Version) -> ext.Extension:
+    """Helper function to create an extension with a given version for testing."""
+    extension = ext.Extension("versioned_ext", version)
+    extension.add_op_def(ext.OpDef("my_op", ext.OpDefSig(tys.FunctionType.endo([]))))
+    extension.add_type_def(
+        ext.TypeDef(
+            "MyType",
+            "A versioned type.",
+            [],
+            ext.ExplicitBound(tys.TypeBound.Copyable),
+        )
+    )
+    return extension
+
+
+def test_registry_version_resolution():
+    """Test that registry resolution picks the highest compatible version of an
+    extension."""
+
+    ext_0_2_5 = _versioned_ext(ext.Version(0, 2, 5))
+    ext_0_3_0 = _versioned_ext(ext.Version(0, 3, 0))
+    ext_1_3_0 = _versioned_ext(ext.Version(1, 3, 0))
+    reg = ext.ExtensionRegistry()
+    reg.register(ext_0_2_5)
+    reg.register(ext_0_3_0)
+    reg.register(ext_1_3_0)
+
+    assert reg.get_extension("versioned_ext", ext.Version(0, 2, 3)) is ext_0_2_5
+    assert reg.get_extension("versioned_ext", ext.Version(0, 3, 0)) is ext_0_3_0
+    assert reg.get_extension("versioned_ext", ext.Version(1, 2, 3)) is ext_1_3_0
+
+    custom = ops.Custom(
+        "my_op",
+        tys.FunctionType.endo([]),
+        "versioned_ext",
+        extension_version=ext.Version(0, 2, 3),
+    )
+    resolved = custom.resolve(reg)
+    assert isinstance(resolved, ops.ExtOp)
+    assert resolved.op_def().get_extension() is ext_0_2_5
+
+    opaque = tys.Opaque(
+        "MyType",
+        tys.TypeBound.Copyable,
+        extension="versioned_ext",
+        extension_version=ext.Version(0, 2, 3),
+    )
+    resolved_ty, _ = opaque._resolve_used_extensions(reg)
+    assert isinstance(resolved_ty, tys.ExtType)
+    assert resolved_ty.type_def.get_extension() is ext_0_2_5

--- a/hugr/benches/benchmarks/hugr/examples.rs
+++ b/hugr/benches/benchmarks/hugr/examples.rs
@@ -113,7 +113,7 @@ pub static QUANTUM_EXT: LazyLock<Arc<Extension>> = LazyLock::new(|| {
 
 pub static BENCH_EXTENSIONS: LazyLock<ExtensionRegistry> = LazyLock::new(|| {
     let mut reg = STD_REG.clone();
-    reg.register_updated(QUANTUM_EXT.clone());
+    reg.register(QUANTUM_EXT.clone());
     reg
 });
 

--- a/justfile
+++ b/justfile
@@ -79,7 +79,7 @@ update-pytest-snapshots:
 
 # Generate serialized declarations for the standard extensions and prelude.
 gen-extensions:
-    cargo run -p hugr-cli gen-extensions -o resources/std_extensions
+    cargo run -p hugr-cli gen-extensions -o resources/std_extensions --unversioned
     cp -r resources/std_extensions/* hugr-py/src/hugr/std/_json_defs/
 
 # Build the python documentation in hugr-py/docs.

--- a/uv.lock
+++ b/uv.lock
@@ -405,7 +405,7 @@ requires-dist = [
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0,<6" },
     { name = "pydantic", specifier = "~=2.8" },
     { name = "pydantic-extra-types", specifier = "~=2.9" },
-    { name = "pytket", marker = "extra == 'pytket'", specifier = ">=2.18.0" },
+    { name = "pytket", marker = "extra == 'pytket'", specifier = ">=1.34.0" },
     { name = "semver", specifier = "~=3.0" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.1.3,<10" },
     { name = "sphinx-favicon", marker = "extra == 'docs'", specifier = "~=1.1.0" },


### PR DESCRIPTION
Part of #2996. Closes #3000. Followup to #3063.

#3005 added support for multiple versions for the same extension in `ExtensionRegistry`. This PR implements the same for the rust side.

drive-by: Added missing extensions in `hugr-cli gen-extensions` test, and ensured the test won't get outdated again.

BREAKING CHANGE: `ExtensionRegistry::register` now returns an insertion result instead of failing on existing entries. Removed `ExtensionRegistry::register_updated` 
BREAKING CHANGE: `hugr-cli gen-extensions` now adds the extension version as suffix to the json files. Use `--unversioned` to get the old behaviour.

Added some python helper methods to rust the new ones in rust, but this is not a breaking change there.
BEGIN_COMMIT_OVERRIDE
feat: Keep multiple incompatible extension versions in ExtensionRegistry (#3064)
END_COMMIT_OVERRIDE