### PR TITLE
fix: Publish parametrisation check for types

### DIFF
--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -454,7 +454,7 @@ impl Term {
     }
 
     /// Checks whether the term is parametric, i.e. it (recursively) contains variables.
-    pub(crate) fn is_parametrized(&self) -> bool {
+    pub fn is_parametrized(&self) -> bool {
         match self {
             Term::SumType(SumType::General { rows }) => {
                 rows.iter().any(|row| row.is_parametrized())


### PR DESCRIPTION
It seems that in #3056, I forgot to make this function public, and I need it to be public for work in https://github.com/Quantinuum/tket2/pull/1609.