### PR TITLE
feat!: Remove deprecated pure json HUGR APIs

### DIFF
--- a/hugr-cli/src/hugr_io.rs
+++ b/hugr-cli/src/hugr_io.rs
@@ -1,12 +1,12 @@
 //! Input/output arguments for the HUGR CLI.
 
 use clio::Input;
+use hugr::Extension;
 use hugr::envelope::description::PackageDesc;
 use hugr::envelope::read_envelope;
 use hugr::extension::ExtensionRegistry;
 use hugr::extension::resolution::WeakExtensionRegistry;
 use hugr::package::Package;
-use hugr::{Extension, Hugr};
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
 
@@ -69,40 +69,6 @@ impl HugrInputArgs {
                 Ok(read_envelope(buffer, &extensions)?)
             }
         }
-    }
-
-    /// Read a hugr JSON file from an optional reader.
-    ///
-    /// If `reader` is `None`, reads from the input specified in the args.
-    /// This is a legacy option for reading old HUGR JSON files.
-    #[deprecated(since = "0.27.0")]
-    pub(crate) fn get_hugr_with_reader<R: Read>(
-        &mut self,
-        reader: Option<R>,
-    ) -> Result<Hugr, CliError> {
-        let extensions = self.load_extensions()?;
-
-        /// Wraps the hugr JSON so that it defines a valid envelope.
-        const PREPEND: &str = r#"HUGRiHJv?@{"modules": ["#;
-        const APPEND: &str = r#"],"extensions": []}"#;
-
-        let mut envelope = PREPEND.to_string();
-
-        match reader {
-            Some(r) => {
-                let mut buffer = BufReader::new(r);
-                buffer.read_to_string(&mut envelope)?;
-            }
-            None => {
-                let mut buffer = BufReader::new(&mut self.input);
-                buffer.read_to_string(&mut envelope)?;
-            }
-        }
-
-        envelope.push_str(APPEND);
-
-        let hugr = Hugr::load_str(envelope, Some(&extensions))?;
-        Ok(hugr)
     }
 
     /// Return a register with the selected extensions.

--- a/hugr-cli/src/lib.rs
+++ b/hugr-cli/src/lib.rs
@@ -90,11 +90,6 @@ pub enum CliError {
     #[error("Error validating HUGR.")]
     /// Errors produced by the `validate` subcommand.
     Validate(#[from] PackageValidationError),
-    /// Pretty error when the user passes a non-envelope file.
-    #[error(
-        "Input file is not a HUGR envelope. Invalid magic number.\n\nUse `--hugr-json` to read a raw HUGR JSON file instead."
-    )]
-    NotAnEnvelope,
     /// Invalid format string for conversion.
     #[error(
         "Invalid format: '{_0}'. Valid formats are: json, model, model-exts, s-expression, s-expression-exts"

--- a/hugr-cli/src/mermaid.rs
+++ b/hugr-cli/src/mermaid.rs
@@ -9,7 +9,6 @@ use clio::Output;
 use hugr::HugrView;
 use hugr::hugr::views::render::NodeLabel;
 use hugr::metadata::DEBUGINFO_META_KEY;
-use hugr::package::PackageValidationError;
 
 /// Dump the standard extensions.
 #[derive(Parser, Debug)]
@@ -94,28 +93,6 @@ impl MermaidArgs {
         Ok(())
     }
 
-    /// Write the mermaid diagram for a legacy HUGR json with optional I/O overrides.
-    #[expect(deprecated)]
-    fn run_print_hugr_with_io<R: Read, W: Write>(
-        &mut self,
-        input_override: Option<R>,
-        mut output_override: Option<W>,
-    ) -> Result<()> {
-        let hugr = self.input_args.get_hugr_with_reader(input_override)?;
-
-        if self.validate {
-            hugr.validate()
-                .map_err(PackageValidationError::Validation)?;
-        }
-
-        if let Some(ref mut writer) = output_override {
-            writeln!(writer, "{}", hugr.mermaid_string())?;
-        } else {
-            writeln!(self.output, "{}", hugr.mermaid_string())?;
-        }
-        Ok(())
-    }
-
     /// Write the mermaid diagram to the output.
     pub fn run_print(&mut self) -> Result<()> {
         self.run_print_with_io(None::<&[u8]>, None::<Vec<u8>>)
@@ -124,11 +101,5 @@ impl MermaidArgs {
     /// Write the mermaid diagram for a HUGR envelope.
     pub fn run_print_envelope(&mut self) -> Result<()> {
         self.run_print_envelope_with_io(None::<&[u8]>, None::<Vec<u8>>)
-    }
-
-    /// Write the mermaid diagram for a legacy HUGR json.
-    #[deprecated(since = "0.27.0")]
-    pub fn run_print_hugr(&mut self) -> Result<()> {
-        self.run_print_hugr_with_io(None::<&[u8]>, None::<Vec<u8>>)
     }
 }

--- a/hugr-py/src/hugr/_serialization/serial_hugr.py
+++ b/hugr-py/src/hugr/_serialization/serial_hugr.py
@@ -37,18 +37,6 @@ class SerialHugr(ConfiguredBaseModel):
     )
     entrypoint: NodeIdx | None = None
 
-    def to_json(self) -> str:
-        """Return a JSON representation of the Hugr."""
-        from hugr import __version__ as hugr_version
-
-        self.encoder = f"hugr-py v{hugr_version}"
-        return self.model_dump_json()
-
-    @classmethod
-    def load_json(cls, json: dict[Any, Any]) -> "SerialHugr":
-        """Decode a JSON-encoded Hugr."""
-        return cls(**json)
-
     @classmethod
     def get_version(cls) -> str:
         """Return the version of the schema."""

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import copy
-import json
 from collections.abc import Iterable, Iterator, Mapping
 from dataclasses import dataclass, field
 from queue import Queue
@@ -15,8 +14,6 @@ from typing import (
     cast,
     overload,
 )
-
-from typing_extensions import deprecated
 
 import hugr.model as model
 import hugr.ops as ops
@@ -1172,15 +1169,6 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         config = config or EnvelopeConfig.TEXT
         return _make_envelope_str(self.to_package(include_extensions), config)
 
-    @deprecated("Use HUGR envelopes instead. See the `to_bytes` and `to_str` methods.")
-    def to_json(self) -> str:
-        """Serialize the HUGR to a JSON string.
-
-        For most use cases, it is recommended to store a HUGR package instead.
-        See :meth:`hugr.package.Package.to_bytes`.
-        """
-        return self._to_serial().to_json()
-
     def to_model(self) -> model.Module:
         """Export this module into the hugr model format."""
         from hugr.model.export import ModelExport
@@ -1210,18 +1198,6 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             ext for ext in include_extensions.all_extensions if ext.name not in std
         ]
         return Package(modules=[self], extensions=extensions)
-
-    @classmethod
-    @deprecated("Use HUGR envelopes instead. See the `to_bytes` and `to_str` methods.")
-    def load_json(cls, json_str: str) -> Hugr:
-        """Deserialize a JSON string into a HUGR.
-
-        For most use cases, it is recommended to use package serialization instead.
-        See :meth:`hugr.package.Package.from_bytes`.
-        """
-        json_dict = json.loads(json_str)
-        serial = SerialHugr.load_json(json_dict)
-        return cls._from_serial(serial)
 
     def render_dot(
         self, config: RenderConfig | None = None, root: Node | None = None

--- a/hugr-py/src/hugr/package.py
+++ b/hugr-py/src/hugr/package.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
-from typing_extensions import deprecated
-
 import hugr._serialization.extension as ext_s
 import hugr.model as model
 from hugr import ext
@@ -163,26 +161,6 @@ class Package:
         """
         config = config or EnvelopeConfig.TEXT
         return _make_envelope_str(self, config)
-
-    @deprecated("Use HUGR envelopes instead. See the `to_bytes` and `to_str` methods.")
-    def to_json(self) -> str:
-        """Serialize the package to a printable HUGR envelope string."""
-        return self._to_serial().model_dump_json()
-
-    @classmethod
-    @deprecated(
-        "Use HUGR envelopes instead. See the `from_bytes` and `from_str` methods."
-    )
-    def from_json(cls, json_str: str) -> Package:
-        """Deserialize a JSON string to a Package object.
-
-        Args:
-            json_str: The JSON string representing a Package.
-
-        Returns:
-            The deserialized Package object.
-        """
-        return ext_s.Package.model_validate_json(json_str).deserialize()
 
     def to_model(self) -> model.Package:
         """Export the package as its hugr model representation.


### PR DESCRIPTION
Removes the deprecated public APIs for writing and loading raw json hugrs.

Closes #3075.

This does not yet remove the `Json` envelope format, only the pure jsons with no envelope header.
While that component is still included, old json hugrs may be migrated to envelopes by prepending and appending the following strings:
```rs
PREPEND = r#"HUGRiHJv?@{"modules": ["#;
APPEND = r#"],"extensions": []}"#;
```

The removal of envelope json support is tracked in #3007.

BREAKING CHANGE: Removed pure HUGR JSON store/decode APIs 