### PR TITLE
fix: Re-link opdefs when doing extension resolution

### DIFF
--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -7,11 +7,13 @@
 
 use std::sync::Arc;
 
+use semver::Version;
+
 use super::{Extension, ExtensionCollectionError, ExtensionResolutionError};
 use crate::Node;
-use crate::extension::{ExtensionId, ExtensionRegistry};
+use crate::extension::{ExtensionId, ExtensionRegistry, OpDef};
 use crate::ops::custom::OpaqueOpError;
-use crate::ops::{DataflowOpTrait, ExtensionOp, NamedOp, OpType};
+use crate::ops::{DataflowOpTrait, ExtensionOp, NamedOp, OpNameRef, OpType};
 
 /// Returns the extension in the registry required by the operation.
 ///
@@ -64,35 +66,52 @@ pub(crate) fn resolve_op_extensions<'e>(
     op: &mut OpType,
     extensions: &'e ExtensionRegistry,
 ) -> Result<Option<&'e Arc<Extension>>, ExtensionResolutionError> {
-    let ext_not_found_error =
-        |ext_id: &ExtensionId, op_id| ExtensionResolutionError::MissingOpExtension {
-            node: Some(node),
-            op: op_id,
-            missing_extension: ext_id.clone(),
-            available_extensions: extensions.ids().cloned().collect(),
+    /// Returns the OpDef and Extension for the given operation, or an error if either is not found.
+    fn op_and_ext<'a, 'e>(
+        extensions: &'e ExtensionRegistry,
+        node: Node,
+        ext_id: &'a ExtensionId,
+        ext_version: Option<&'a Version>,
+        qualified_id: impl AsRef<OpNameRef>,
+        unqualified_id: impl AsRef<OpNameRef>,
+    ) -> Result<(&'e Arc<OpDef>, &'e Arc<Extension>), ExtensionResolutionError> {
+        let Some(extension) = extensions.get_req(ext_id, ext_version) else {
+            return Err(ExtensionResolutionError::MissingOpExtension {
+                node: Some(node),
+                op: qualified_id.as_ref().into(),
+                missing_extension: ext_id.clone(),
+                available_extensions: extensions.ids().cloned().collect(),
+            });
         };
-    let op_not_found_error =
-        |extension: &Arc<Extension>, op_id| OpaqueOpError::OpNotFoundInExtension {
-            node,
-            op: op_id,
-            extension: extension.name().clone(),
-            available_ops: extension
-                .operations()
-                .map(|(name, _)| name.clone())
-                .collect(),
+        let Some(op_def) = extension.get_op(unqualified_id.as_ref()) else {
+            return Err(OpaqueOpError::OpNotFoundInExtension {
+                node,
+                op: qualified_id.as_ref().into(),
+                extension: ext_id.clone(),
+                available_ops: extension
+                    .operations()
+                    .map(|(name, _)| name.clone())
+                    .collect(),
+            }
+            .into());
         };
+
+        Ok((op_def, extension))
+    }
 
     match op {
         OpType::ExtensionOp(ext_op) => {
             let ext_id = ext_op.extension_id();
             let ext_version = ext_op.extension_version();
 
-            let extension = extensions
-                .get_req(ext_id, Some(&ext_version))
-                .ok_or_else(|| ext_not_found_error(ext_id, ext_op.qualified_id()))?;
-            let op_def = extension
-                .get_op(ext_op.unqualified_id())
-                .ok_or_else(|| op_not_found_error(extension, ext_op.qualified_id()))?;
+            let (op_def, extension) = op_and_ext(
+                extensions,
+                node,
+                ext_id,
+                Some(&ext_version),
+                ext_op.qualified_id(),
+                ext_op.unqualified_id(),
+            )?;
 
             // Relink the extension operation to an OpDef from the registry.
             //
@@ -112,12 +131,14 @@ pub(crate) fn resolve_op_extensions<'e>(
             let ext_id = opaque.extension();
             let ext_version = opaque.extension_version();
 
-            let extension = extensions
-                .get_req(ext_id, ext_version)
-                .ok_or_else(|| ext_not_found_error(ext_id, opaque.qualified_id()))?;
-            let op_def = extension
-                .get_op(opaque.unqualified_id())
-                .ok_or_else(|| op_not_found_error(extension, opaque.qualified_id()))?;
+            let (op_def, extension) = op_and_ext(
+                extensions,
+                node,
+                ext_id,
+                ext_version,
+                opaque.qualified_id(),
+                opaque.unqualified_id(),
+            )?;
 
             let ext_op =
                 ExtensionOp::new_with_cached(op_def.clone(), opaque.args().to_vec(), opaque)

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use super::{Extension, ExtensionCollectionError, ExtensionResolutionError};
 use crate::Node;
-use crate::extension::ExtensionRegistry;
+use crate::extension::{ExtensionId, ExtensionRegistry};
 use crate::ops::custom::OpaqueOpError;
 use crate::ops::{DataflowOpTrait, ExtensionOp, NamedOp, OpType};
 
@@ -49,8 +49,8 @@ pub(crate) fn collect_op_extension(
 /// Compute the required extension for an operation.
 ///
 /// If the op is a [`OpType::OpaqueOp`], replace it with a resolved
-/// [`OpType::ExtensionOp`] by looking searching for the operation in the
-/// extension registries.
+/// [`OpType::ExtensionOp`] by searching for the operation in the extension
+/// registries.
 ///
 /// If `op` was an opaque or extension operation, the result contains the
 /// extension reference that should be added to the hugr's extension registry.
@@ -64,78 +64,85 @@ pub(crate) fn resolve_op_extensions<'e>(
     op: &mut OpType,
     extensions: &'e ExtensionRegistry,
 ) -> Result<Option<&'e Arc<Extension>>, ExtensionResolutionError> {
-    let extension = operation_extension(node, op, extensions)?;
-
-    let OpType::OpaqueOp(opaque) = op else {
-        return Ok(extension);
-    };
-
-    // Fail if the Extension is not in the registry, or if the Extension was
-    // found but did not have the expected operation.
-    let extension = extension.expect("OpaqueOp should have an extension");
-    let Some(def) = extension.get_op(opaque.unqualified_id()) else {
-        return Err(OpaqueOpError::OpNotFoundInExtension {
+    let ext_not_found_error =
+        |ext_id: &ExtensionId, op_id| ExtensionResolutionError::MissingOpExtension {
+            node: Some(node),
+            op: op_id,
+            missing_extension: ext_id.clone(),
+            available_extensions: extensions.ids().cloned().collect(),
+        };
+    let op_not_found_error =
+        |extension: &Arc<Extension>, op_id| OpaqueOpError::OpNotFoundInExtension {
             node,
-            op: opaque.name().clone(),
+            op: op_id,
             extension: extension.name().clone(),
             available_ops: extension
                 .operations()
                 .map(|(name, _)| name.clone())
                 .collect(),
-        }
-        .into());
-    };
+        };
 
-    let ext_op = ExtensionOp::new_with_cached(def.clone(), opaque.args().to_vec(), opaque)
-        .map_err(|e| OpaqueOpError::SignatureError {
-            node,
-            name: opaque.name().clone(),
-            cause: e,
-        })?;
-
-    if opaque.signature().io() != ext_op.signature().io() {
-        return Err(OpaqueOpError::SignatureMismatch {
-            node,
-            extension: opaque.extension().clone(),
-            op: def.name().clone(),
-            computed: Box::new(ext_op.signature().into_owned()),
-            stored: Box::new(opaque.signature().into_owned()),
-        }
-        .into());
-    }
-
-    // Replace the opaque operation with the resolved extension operation.
-    *op = ext_op.into();
-
-    Ok(Some(extension))
-}
-
-/// Returns the extension in the registry required by the operation.
-///
-/// If the operation does not require an extension, returns `None`.
-fn operation_extension<'e>(
-    node: Node,
-    op: &OpType,
-    extensions: &'e ExtensionRegistry,
-) -> Result<Option<&'e Arc<Extension>>, ExtensionResolutionError> {
-    let Some(ext_id) = op.extension_id() else {
-        return Ok(None);
-    };
-    let extension = match op {
-        OpType::OpaqueOp(opaque) => extensions.get_req(ext_id, opaque.extension_version()),
+    match op {
         OpType::ExtensionOp(ext_op) => {
-            let version = ext_op.extension_version();
-            extensions.get_exact(ext_id, &version)
+            let ext_id = ext_op.extension_id();
+            let ext_version = ext_op.extension_version();
+
+            let extension = extensions
+                .get_req(ext_id, Some(&ext_version))
+                .ok_or_else(|| ext_not_found_error(ext_id, ext_op.qualified_id()))?;
+            let op_def = extension
+                .get_op(ext_op.unqualified_id())
+                .ok_or_else(|| op_not_found_error(extension, ext_op.qualified_id()))?;
+
+            // Relink the extension operation to an OpDef from the registry.
+            //
+            // This ensures we don't keep around stale OpDefs that may have
+            // their Weak extension reference dropped.
+            ext_op
+                .relink_def(op_def.clone())
+                .map_err(|e| OpaqueOpError::SignatureError {
+                    node,
+                    name: ext_op.qualified_id(),
+                    cause: e,
+                })?;
+
+            Ok(Some(extension))
         }
-        _ => extensions.get(ext_id),
-    };
-    match extension {
-        Some(e) => Ok(Some(e)),
-        None => Err(ExtensionResolutionError::missing_op_extension(
-            Some(node),
-            op,
-            ext_id,
-            extensions,
-        )),
+        OpType::OpaqueOp(opaque) => {
+            let ext_id = opaque.extension();
+            let ext_version = opaque.extension_version();
+
+            let extension = extensions
+                .get_req(ext_id, ext_version)
+                .ok_or_else(|| ext_not_found_error(ext_id, opaque.qualified_id()))?;
+            let op_def = extension
+                .get_op(opaque.unqualified_id())
+                .ok_or_else(|| op_not_found_error(extension, opaque.qualified_id()))?;
+
+            let ext_op =
+                ExtensionOp::new_with_cached(op_def.clone(), opaque.args().to_vec(), opaque)
+                    .map_err(|e| OpaqueOpError::SignatureError {
+                        node,
+                        name: opaque.name().clone(),
+                        cause: e,
+                    })?;
+
+            if opaque.signature().io() != ext_op.signature().io() {
+                return Err(OpaqueOpError::SignatureMismatch {
+                    node,
+                    extension: opaque.extension().clone(),
+                    op: op_def.name().clone(),
+                    computed: Box::new(ext_op.signature().into_owned()),
+                    stored: Box::new(opaque.signature().into_owned()),
+                }
+                .into());
+            }
+
+            // Replace the opaque operation with the resolved extension operation.
+            *op = ext_op.into();
+
+            Ok(Some(extension))
+        }
+        _ => Ok(None),
     }
 }

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -191,6 +191,81 @@ fn make_extension_self_referencing(name: &str, op_name: &str, type_name: &str) -
     })
 }
 
+/// Create two extensions where one operation's signature uses the other's type.
+fn make_dependent_extensions() -> (Arc<Extension>, Arc<Extension>) {
+    let dep_ext =
+        Extension::new_test_arc(ExtensionId::new_unchecked("dummy.dep"), |ext, ext_ref| {
+            ext.add_type(
+                "dep_type".into(),
+                vec![],
+                String::new(),
+                TypeDefBound::copyable(),
+                ext_ref,
+            )
+            .unwrap();
+        });
+    let dep_ty = dep_ext
+        .get_type("dep_type")
+        .unwrap()
+        .instantiate([])
+        .unwrap();
+    let op_ext = Extension::new_test_arc(ExtensionId::new_unchecked("dummy.op"), |ext, ext_ref| {
+        ext.add_op(
+            "uses_dep".into(),
+            String::new(),
+            Signature::new(vec![dep_ty.into()], vec![]),
+            ext_ref,
+        )
+        .unwrap();
+    });
+    (dep_ext, op_ext)
+}
+
+/// Check that resolved extension operations are relinked to OpDefs from the
+/// registry when doing resolution, and that the resolved extensions are correct
+/// even when there are multiple compatible versions in the registry.
+#[test]
+fn ext_resolution_relinks_opdefs() {
+    let (original_dep, original_op_ext) = make_dependent_extensions();
+    let dep_ty = original_dep
+        .get_type("dep_type")
+        .unwrap()
+        .instantiate([])
+        .unwrap();
+    let op = original_op_ext
+        .instantiate_extension_op("uses_dep", [])
+        .unwrap();
+
+    let mut build = DFGBuilder::new(Signature::new(vec![dep_ty.into()], vec![])).unwrap();
+    let [input] = build.input_wires_arr();
+    build.add_dataflow_op(op, [input]).unwrap();
+    let mut hugr = build.finish_hugr_with_outputs([]).unwrap();
+
+    let (canonical_dep, canonical_op_ext) = make_dependent_extensions();
+    let resolution_extensions =
+        ExtensionRegistry::new([canonical_dep.clone(), canonical_op_ext.clone()]);
+
+    // After dropping the extensions here and running extension resolution (so the hugr's internal register also drops the old references),
+    // the old OpDefs in the ExtensionOp should lose its reference.
+    drop(original_dep);
+    drop(original_op_ext);
+    hugr.resolve_extension_defs(&resolution_extensions).unwrap();
+
+    // Check that the ExtensionOp was relinked to the new OpDef from the registry.
+    let op = hugr
+        .nodes()
+        .map(|node| hugr.get_optype(node))
+        .find_map(OpType::as_extension_op)
+        .unwrap();
+    let canonical_def = canonical_op_ext.get_op("uses_dep").unwrap();
+    assert!(Arc::ptr_eq(op.def_arc(), canonical_def));
+
+    let rebuilt_op = ExtensionOp::new(op.def_arc().clone(), []).unwrap();
+    let rebuilt_op: OpType = rebuilt_op.into();
+    let rebuilt_extensions = rebuilt_op.used_extensions().unwrap();
+    assert!(rebuilt_extensions.contains(canonical_dep.name()));
+}
+
 /// Check that the extensions added during building coincide with read-only collected extensions
 /// and that they survive a serialization roundtrip.
 fn check_extension_resolution(mut hugr: Hugr) {

--- a/hugr-core/src/hugr/validate.rs
+++ b/hugr-core/src/hugr/validate.rs
@@ -7,6 +7,7 @@ use std::iter;
 use itertools::Itertools;
 use petgraph::algo::dominators::{self, Dominators};
 use petgraph::visit::{Topo, Walker};
+use semver::Version;
 use thiserror::Error;
 
 use crate::core::HugrNode;
@@ -200,6 +201,16 @@ impl<'a, H: HugrView> ValidationContext<'a, H> {
         // TODO Maybe we should delegate these checks to the OpTypes themselves.
         if let OpType::Const(c) = op_type {
             c.validate()?;
+        }
+        if let OpType::ExtensionOp(ext_op) = op_type {
+            // Ensure the extension reference has not been dropped and the signature is still valid.
+            ext_op.def().extension().upgrade().ok_or_else(|| {
+                ValidationError::ExtensionReferenceDropped {
+                    node,
+                    extension: ext_op.extension_id().to_string(),
+                    version: Some(ext_op.extension_version()),
+                }
+            })?;
         }
 
         Ok(())
@@ -764,6 +775,19 @@ pub enum ValidationError<N: HugrNode> {
     /// The HUGR entrypoint must be a region container.
     #[error("The HUGR entrypoint ({node}) must be a region container, but '{}' does not accept children.", optype.name())]
     EntrypointNotContainer { node: N, optype: Box<OpType> },
+    /// An extension reference has been dropped.
+    #[error(
+        "Extension '{extension}{ver}' reference in {node} has been dropped.",
+        ver = version.as_ref().map(|v| format!("@{v}")).unwrap_or_default()
+    )]
+    ExtensionReferenceDropped {
+        /// The node with the dropped reference.
+        node: N,
+        /// The name of the extension that was not resolved.
+        extension: String,
+        /// The version of the extension that was not resolved, if available.
+        version: Option<Version>,
+    },
 }
 
 /// Errors related to the inter-graph edge validations.

--- a/hugr-core/src/ops/custom.rs
+++ b/hugr-core/src/ops/custom.rs
@@ -77,6 +77,23 @@ impl ExtensionOp {
         })
     }
 
+    /// Replace this operation's definition with the matching definition from
+    /// another registry.
+    ///
+    /// This is used while resolving HUGRs to make sure already-resolved
+    /// operations keep their cached definition in the same registry as the
+    /// HUGR's retained extensions.
+    pub(crate) fn relink_def(&mut self, def: Arc<OpDef>) -> Result<(), SignatureError> {
+        let signature = match def.compute_signature(&self.args) {
+            Ok(sig) => sig,
+            Err(SignatureError::MissingComputeFunc) => self.signature.clone(),
+            Err(e) => return Err(e),
+        };
+        self.def = def;
+        self.signature = signature;
+        Ok(())
+    }
+
     /// Return the argument values for this operation.
     #[must_use]
     pub fn args(&self) -> &[TypeArg] {


### PR DESCRIPTION
When doing extension resolution on `ExtensionOp`s, ensure we update the `OpDef` reference to the one in the resolution extension registry.

Previously, when an `ExtensionOp` was defined with a different extension and we then ran extension resolution with a different Extension for the same ID, we didn't update the `Weak<Extension>` reference.

After doing resolution, replacing the extension registry inside the hugr may cause the op's Weak extension pointer to be dropped, causing errors down the line.