### PR TITLE
feat: Prefer local extension Arcs when loading a package

### DIFF
--- a/hugr-core/src/envelope/reader.rs
+++ b/hugr-core/src/envelope/reader.rs
@@ -93,8 +93,14 @@ impl<R: BufRead> EnvelopeReader<R> {
         &self.description.header
     }
 
+    /// Add any extensions that were bundled in the package definition to the
+    /// local registry.
     fn register_packaged(&mut self, extensions: &ExtensionRegistry) {
-        self.registry.extend(extensions);
+        for versions in extensions {
+            for ext in versions.iter() {
+                self.registry.register_if_new(ext.clone());
+            }
+        }
     }
 
     /// Handle extension resolution errors by recording missing extensions in the description.

--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -250,32 +250,53 @@ impl ExtensionVersions {
     ///
     /// Panics if the extension id does not match the collection's id.
     pub fn register(&mut self, extension: Arc<Extension>) -> ExtensionRegisterResult {
+        self.register_internal(extension, true)
+    }
+
+    /// Register an extension version and report what happened.
+    ///
+    /// If we already have a compatible version, the extension with the higher
+    /// version is kept. If versions match exactly, the old extension is kept.
+    ///
+    /// Panics if the extension id does not match the collection's id.
+    pub fn register_if_new(&mut self, extension: Arc<Extension>) -> ExtensionRegisterResult {
+        self.register_internal(extension, false)
+    }
+
+    /// Register an extension version and report what happened.
+    fn register_internal(
+        &mut self,
+        extension: Arc<Extension>,
+        replace_exact_match: bool,
+    ) -> ExtensionRegisterResult {
         assert_eq!(
             extension.name(),
             &self.id,
             "extension id does not match ExtensionVersions id"
         );
 
-        let version = extension.version().clone();
-        let compatible_version = self.compatible_registered_version(&version);
+        let new_version = extension.version().clone();
+        let current_version = self.compatible_registered_version(&new_version);
 
-        let Some(compatible_version) = compatible_version else {
-            self.versions.insert(version, extension);
+        let Some(current_version) = current_version else {
+            self.versions.insert(new_version, extension);
             return ExtensionRegisterResult::Inserted;
         };
 
-        if compatible_version > version {
+        if (current_version > new_version)
+            || (current_version == new_version && !replace_exact_match)
+        {
             return ExtensionRegisterResult::KeptExisting {
-                version: compatible_version,
+                version: current_version,
             };
         }
 
-        self.versions.remove(&compatible_version);
-        let replaced = compatible_version < version;
-        self.versions.insert(version, extension);
+        self.versions.remove(&current_version);
+        let replaced = current_version < new_version;
+        self.versions.insert(new_version, extension);
         if replaced {
             ExtensionRegisterResult::Replaced {
-                version: compatible_version,
+                version: current_version,
             }
         } else {
             ExtensionRegisterResult::ReplacedExact
@@ -438,10 +459,33 @@ impl ExtensionRegistry {
     /// the existing entry.
     ///
     pub fn register(&mut self, extension: impl Into<Arc<Extension>>) -> ExtensionRegisterResult {
+        self.register_internal(extension.into(), true)
+    }
+
+    /// Registers a new extension to the registry, and report what happened.
+    ///
+    /// If we already have a compatible version, the extension with the higher
+    /// version is kept. If versions match exactly, the old extension is kept.
+    ///
+    pub fn register_if_new(
+        &mut self,
+        extension: impl Into<Arc<Extension>>,
+    ) -> ExtensionRegisterResult {
+        self.register_internal(extension.into(), false)
+    }
+
+    /// Registers a new extension to the registry, and report what happened.
+    fn register_internal(
+        &mut self,
+        extension: impl Into<Arc<Extension>>,
+        replace_exact_match: bool,
+    ) -> ExtensionRegisterResult {
         use btree_map::Entry::*;
         let extension = extension.into();
         let result = match self.exts.entry(extension.name().clone()) {
-            Occupied(mut prev) => prev.get_mut().register(extension),
+            Occupied(mut prev) => prev
+                .get_mut()
+                .register_internal(extension, replace_exact_match),
             Vacant(ve) => {
                 ve.insert(ExtensionVersions::new(extension));
                 ExtensionRegisterResult::Inserted

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -195,7 +195,7 @@ impl<N: HugrNode> ExtensionResolutionError<N> {
 pub enum ExtensionCollectionError<N: HugrNode = Node> {
     /// An operation requires an extension that is not in the given registry.
     #[display(
-        "{op}{} contains custom types for which have lost the reference to their defining extensions. Dropped extensions: {}",
+        "{op}{} contains custom types which have lost the reference to their defining extensions. Dropped extensions: {}",
         if let Some(node) = node { format!(" ({node})") } else { String::new() },
         missing_extensions.join(", ")
     )]
@@ -209,7 +209,7 @@ pub enum ExtensionCollectionError<N: HugrNode = Node> {
     },
     /// A signature requires an extension that is not in the given registry.
     #[display(
-        "Signature {signature} contains custom types for which have lost the reference to their defining extensions. Dropped extensions: {}",
+        "Signature {signature} contains custom types which have lost the reference to their defining extensions. Dropped extensions: {}",
         missing_extensions.join(", ")
     )]
     DroppedSignatureExtensions {


### PR DESCRIPTION
When loading a package with bundled extensions, don't replace the locally defined ones if the package extension have the exact same extension. This helps with avoiding dropped Arcs when manipulating the Hugr later on.

Adds `register_if_new` methods to `ExtensionRegistry` and `ExtensionVersions` that act like normal `register` but, in the case of the exact existing version already being registered, avoids replacing the existing value.

This change is required for https://github.com/Quantinuum/tket2/pull/1580, but it's only a partial fix.
We still need to analyze and improve the Arc handling when we insert new operations to a Hugr which use different instantiations of existing extensions, but I'll open a separate issue for that.

drive-by: Fix the wording in a couple error messages.