### PR TITLE
fix: Don't override extensions unnecessarily on Extend

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -640,7 +640,7 @@ impl<'a> IntoIterator for &'a ExtensionRegistry {
 impl<'a> Extend<&'a Arc<Extension>> for ExtensionRegistry {
     fn extend<T: IntoIterator<Item = &'a Arc<Extension>>>(&mut self, iter: T) {
         for ext in iter {
-            self.register(ext.clone());
+            self.register_if_new(ext.clone());
         }
     }
 }
@@ -648,7 +648,7 @@ impl<'a> Extend<&'a Arc<Extension>> for ExtensionRegistry {
 impl Extend<Arc<Extension>> for ExtensionRegistry {
     fn extend<T: IntoIterator<Item = Arc<Extension>>>(&mut self, iter: T) {
         for ext in iter {
-            self.register(ext);
+            self.register_if_new(ext);
         }
     }
 }


### PR DESCRIPTION
The final cleanup I did for #3094 removed part of the fix necessary to get https://github.com/Quantinuum/tket2/pull/1580 working.
We do actually need to have the `register_if_new` logic in the Extend implementations too.

This is a quick (but sound) measure to get the hugr update in tket working.
We'll have to do a more careful analysis of how the pointers interact later on (I'll open an issue).