### PR TITLE
refactor: simplify InlineDFG, extend tests

### DIFF
--- a/hugr-core/src/hugr/patch/inline_dfg.rs
+++ b/hugr-core/src/hugr/patch/inline_dfg.rs
@@ -412,11 +412,8 @@ mod test {
         let ext_order_succs = HashSet::from_iter(once(h_a2.node()).chain(o4.then_some(cx.node())));
 
         // Order predecessors of DFG get edges to both Input any-successor and DFG Order-successors
-        let ext_order_tgts = HashSet::from_iter(
-            inp_succs
-                .into_iter()
-                .chain(ext_order_succs.clone()),
-        );
+        let ext_order_tgts =
+            HashSet::from_iter(inp_succs.into_iter().chain(ext_order_succs.clone()));
         assert_eq!(
             order_neighbours(h_a.node(), Direction::Outgoing),
             ext_order_tgts

--- a/hugr-core/src/hugr/patch/inline_dfg.rs
+++ b/hugr-core/src/hugr/patch/inline_dfg.rs
@@ -89,7 +89,7 @@ impl<N: HugrNode> PatchHugrMut for InlineDFG<N> {
             // after inlining, connect all such pairs A and B directly. This is not strictly necessary
             // in all cases (specifically if there are Order paths from the DFG's Input to Output),
             // but the redundant edges shouldn't cause any issues and can potentially be removed by
-            // a later pass.
+            // a later pass, if we care.
             for tgt_n in h
                 .linked_inputs(n, oth_out)
                 .map(|(n, _)| n)
@@ -328,14 +328,14 @@ mod test {
          *           |.    /         NB. Order edge H_a to nested DFG
          *           | .  |
          *           |  /-|--------\
-         *           |  | | .  Cst | NB. Order edge Input to LCst
+         *           |  | |  . Cst | NB. Order edge Input to LCst
          *           |  | |  . |   |
          *           |  | |   LCst |
-         *           |  |  \ /  .  |
-         *           |  |  RZ   .  |
-         *           |  |  |    .  |  Order edge LCst to if
-         *           |  |  meas .  |
-         *           |  |  | \  .  |
+         *           |  |  \ /     |
+         *           |  |  RZ      |
+         *           |  |  |       |
+         *           |  |  meas    |
+         *           |  |  | \     |
          *           |  |  |  if   |
          *           |  |  |  .    | NB. Order edge if to Output
          *           |  \--|-------/
@@ -364,7 +364,6 @@ mod test {
         if_n.case_builder(0)?.finish_with_outputs([])?;
         if_n.case_builder(1)?.finish_with_outputs([])?;
         let if_n = if_n.finish_sub_container()?;
-        inner.add_other_wire(f.node(), if_n.node());
         inner.add_other_wire(if_n.node(), inner.output().node());
         let inner = inner.finish_with_outputs([m])?;
         outer.add_other_wire(h_a.node(), inner.node());

--- a/hugr-core/src/hugr/patch/inline_dfg.rs
+++ b/hugr-core/src/hugr/patch/inline_dfg.rs
@@ -161,6 +161,7 @@ impl<N: HugrNode> PatchHugrMut for InlineDFG<N> {
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;
+    use std::iter::once;
 
     use rstest::rstest;
 
@@ -320,32 +321,36 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn order_edges() -> Result<(), Box<dyn std::error::Error>> {
+    #[rstest]
+    fn order_edges(
+        #[values(false, true)] o1: bool,
+        #[values(false, true)] o2: bool,
+        #[values(false, true)] o3: bool,
+        #[values(false, true)] o4: bool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
         /*      -----|-----|-----
          *           |     |
          *          H_a   H_b
-         *           |.    /         NB. Order edge H_a to nested DFG
-         *           | .  |
+         *           |.   |?         NB. Order edge H_a to nested DFG
+         *           | .  |?         NB. Optional(o1) Order edge from H_b to nested DFG
          *           |  /-|--------\
-         *           |  | |  . Cst | NB. Order edge Input to LCst
-         *           |  | |  . |   |
-         *           |  | |   LCst |
-         *           |  |  \ /     |
+         *           |  | |? . Cst | NB. Order edge Input to LCst
+         *           |  | |? . |   | NB. Optional(o2) Order edge from Input to RZ
+         *           |  | |?  LCst |
+         *           |  | \? /     |
          *           |  |  RZ      |
          *           |  |  |       |
          *           |  |  meas    |
-         *           |  |  | \     |
-         *           |  |  |  if   |
-         *           |  |  |  .    | NB. Order edge if to Output
+         *           |  |  |? \    |
+         *           |  |  |? if   | NB. Optional(o3) Order edge from meas to Output
+         *           |  |  |? .    | NB. Order edge if to Output
          *           |  \--|-------/
-         *           |  .  |
-         *           | .   |         NB. Order edge nested DFG to H_a2
-         *           H_a2  /
-         *             \  /
-         *              CX
+         *           |  . ?|         NB. Optional(o4) Order edge from nested DFG to CX
+         *           | .  ?|         NB. Order edge nested DFG to H_a2
+         *           H_a2 ?|
+         *              \ ?/
+         *               CX
          */
-
         let mut outer = DFGBuilder::new(endo_sig(vec![qb_t(), qb_t()]))?;
         let [a, b] = outer.input_wires_arr();
         let h_a = outer.add_dataflow_op(test_quantum_extension::h_gate(), [a])?;
@@ -355,6 +360,9 @@ mod test {
         let f = inner.add_load_value(float_types::ConstF64::new(1.0));
         inner.add_other_wire(inner.input().node(), f.node());
         let r = inner.add_dataflow_op(test_quantum_extension::rz_f64(), [i, f])?;
+        if o2 {
+            inner.add_other_wire(inner.input().node(), r.node());
+        }
         let [m, b] = inner
             .add_dataflow_op(test_quantum_extension::measure(), r.outputs())?
             .outputs_arr();
@@ -365,14 +373,23 @@ mod test {
         if_n.case_builder(1)?.finish_with_outputs([])?;
         let if_n = if_n.finish_sub_container()?;
         inner.add_other_wire(if_n.node(), inner.output().node());
+        if o3 {
+            inner.add_other_wire(m.node(), inner.output().node());
+        }
         let inner = inner.finish_with_outputs([m])?;
         outer.add_other_wire(h_a.node(), inner.node());
+        if o1 {
+            outer.add_other_wire(h_b.node(), inner.node());
+        }
         let h_a2 = outer.add_dataflow_op(test_quantum_extension::h_gate(), h_a.outputs())?;
         outer.add_other_wire(inner.node(), h_a2.node());
         let cx = outer.add_dataflow_op(
             test_quantum_extension::cx_gate(),
             h_a2.outputs().chain(inner.outputs()),
         )?;
+        if o4 {
+            outer.add_other_wire(inner.node(), cx.node());
+        }
         let mut outer = outer.finish_hugr_with_outputs(cx.outputs())?;
 
         outer.apply_patch(InlineDFG(*inner.handle()))?;
@@ -384,25 +401,67 @@ mod test {
                 .map(|(n, _)| n)
                 .collect::<HashSet<_>>()
         };
-        // h_a should have Order edges added to Rz, the F64 load_const and H_a2 (the DFG's Order successor)
+        // h_a should have Order edge(s) to the F64 load_const and the Rz,
+        // and the DFG's Order successors (h_a2, and optionally CX)
+        let input_ord_tgts = HashSet::from_iter(
+            [f.node(), r.node(), h_a2.node()]
+                .into_iter()
+                .chain(o4.then_some(cx.node())),
+        );
         assert_eq!(
             order_neighbours(h_a.node(), Direction::Outgoing),
-            HashSet::from([r.node(), f.node(), h_a2.node()])
+            input_ord_tgts
         );
-        // The load_const should have Order edges from the inputs to the inner DFG, i.e. h_a and h_b
+        //if h_b had an Order edge to the DFG, then it should have Order edges to the same nodes as h_a,
+        // otherwise, only to the Order-successors of the Input node
+        assert_eq!(
+            order_neighbours(h_b.node(), Direction::Outgoing),
+            if o1 {
+                input_ord_tgts
+            } else {
+                HashSet::from_iter([f.node()].into_iter().chain(o2.then_some(r.node())))
+            }
+        );
+        // The F64 LoadConstant (with an Order edge from Input) has edges from all DFG predecessors
         assert_eq!(
             order_neighbours(f.node(), Direction::Incoming),
-            HashSet::from([h_a.node(), h_b.node()])
+            HashSet::from_iter([h_a.node(), h_b.node()])
         );
-        // h_a2 should have Order edges from the measure, if, and H_a (the DFG's Order predecessor)
+        // The RZ has an Order edge from h_a, and from h_b if EITHER h_b -> DFG or Input -> RZ were Order edges
         assert_eq!(
-            order_neighbours(h_a2.node(), Direction::Incoming),
-            HashSet::from([h_a.node(), m.node(), if_n.node()])
+            order_neighbours(r.node(), Direction::Incoming),
+            HashSet::from_iter(once(h_a.node()).chain((o1 || o2).then_some(h_b.node())))
         );
-        // the if should have Order edges to the CX and h_a2
+
+        // The `if` had an Order edge to Output, so now has Order edges to both h_a2 and CX
         assert_eq!(
             order_neighbours(if_n.node(), Direction::Outgoing),
-            HashSet::from([h_a2.node(), cx.node()])
+            HashSet::from_iter([h_a2.node(), cx.node()])
+        );
+        // `meas` has Order edge to h_a2 (DFG Order-successor), and to CX if EITHER meas->Output or DFG->CX were Order edges
+        assert_eq!(
+            order_neighbours(m.node(), Direction::Outgoing),
+            HashSet::from_iter(once(h_a2.node()).chain((o3 || o4).then_some(cx.node())))
+        );
+
+        // h_a2 should have Order edges from `meas` and `if`, and the DFG's Order-precedessors (h_a, and optionally h_b),
+        let output_ord_srcs = HashSet::from_iter(
+            [h_a.node(), m.node(), if_n.node()]
+                .into_iter()
+                .chain(o1.then_some(h_b.node())),
+        );
+        assert_eq!(
+            order_neighbours(h_a2.node(), Direction::Incoming),
+            output_ord_srcs
+        );
+        // if CX had an Order edge from the DFG, then same, otherwise only from `if` and maybe `meas`
+        assert_eq!(
+            order_neighbours(cx.node(), Direction::Incoming),
+            if o4 {
+                output_ord_srcs
+            } else {
+                HashSet::from_iter(once(if_n.node()).chain(o3.then_some(m.node())))
+            }
         );
         Ok(())
     }

--- a/hugr-core/src/hugr/patch/inline_dfg.rs
+++ b/hugr-core/src/hugr/patch/inline_dfg.rs
@@ -2,8 +2,6 @@
 //! of the DFG except Input+Output into the DFG's parent,
 //! and deleting the DFG along with its Input + Output
 
-use std::collections::HashSet;
-
 use super::{PatchHugrMut, PatchVerification};
 use crate::core::HugrNode;
 use crate::ops::handle::{DfgID, NodeHandle};
@@ -78,7 +76,7 @@ impl<N: HugrNode> PatchHugrMut for InlineDFG<N> {
         for ch in h.children(n).skip(2).collect::<Vec<_>>() {
             h.set_parent(ch, parent);
         }
-        let internal_order_path = is_order_reachable(h, input, output);
+
         // DFG Inputs. Deal with Order inputs first
         for (src_n, src_p) in h.linked_outputs(n, oth_in).collect::<Vec<_>>() {
             // Order edge from src_n to DFG => add order edge to each successor of Input node
@@ -86,16 +84,18 @@ impl<N: HugrNode> PatchHugrMut for InlineDFG<N> {
             for tgt_n in h.output_neighbours(input).collect::<Vec<_>>() {
                 h.add_other_edge(src_n, tgt_n);
             }
-            if !internal_order_path {
-                // Ensure the order chain continues from the DFG's order-predecessors to its order-successors,
-                // even if e.g. the interior of the DFG is disconnected. (Check could be more precise.)
-                for tgt_n in h
-                    .linked_inputs(n, oth_out)
-                    .map(|(n, _)| n)
-                    .collect::<Vec<_>>()
-                {
-                    h.add_other_edge(src_n, tgt_n);
-                }
+
+            // In order to ensure that any nodes A, B with Order edges A->DFG->B are still ordered
+            // after inlining, connect all such pairs A and B directly. This is not strictly necessary
+            // in all cases (specifically if there are Order paths from the DFG's Input to Output),
+            // but the redundant edges shouldn't cause any issues and can potentially be removed by
+            // a later pass.
+            for tgt_n in h
+                .linked_inputs(n, oth_out)
+                .map(|(n, _)| n)
+                .collect::<Vec<_>>()
+            {
+                h.add_other_edge(src_n, tgt_n);
             }
         }
         // And remaining (Value) inputs
@@ -158,24 +158,6 @@ impl<N: HugrNode> PatchHugrMut for InlineDFG<N> {
     }
 }
 
-/// Determines whether there is a path along [Order] edges only from `src` to `tgt`.
-///
-/// [Order]: crate::types::EdgeKind::StateOrder
-fn is_order_reachable<H: HugrView>(h: &H, src: H::Node, tgt: H::Node) -> bool {
-    let mut visited = HashSet::new();
-    let mut to_visit = vec![src];
-    while let Some(n) = to_visit.pop() {
-        if visited.insert(n) {
-            if n == tgt {
-                return true;
-            }
-            let order_outport = h.get_optype(n).other_output_port().unwrap();
-            to_visit.extend(h.linked_inputs(n, order_outport).map(|(n, _)| n));
-        }
-    }
-    false
-}
-
 #[cfg(test)]
 mod test {
     use std::collections::HashSet;
@@ -195,10 +177,9 @@ mod test {
     use crate::std_extensions::arithmetic::int_types::{self, ConstInt};
     use crate::types::Signature;
     use crate::utils::test_quantum_extension;
-    use crate::{Direction, HugrView, Port, type_row};
-    use crate::{Hugr, Wire};
+    use crate::{Direction, Hugr, HugrView, Port, Wire, type_row};
 
-    use super::{InlineDFG, is_order_reachable};
+    use super::InlineDFG;
 
     fn find_dfgs<H: HugrView>(h: &H) -> Vec<H::Node> {
         h.entry_descendants()
@@ -364,7 +345,7 @@ mod test {
          *             \  /
          *              CX
          */
-        // Extension inference here relies on quantum ops not requiring their own test_quantum_extension
+
         let mut outer = DFGBuilder::new(endo_sig(vec![qb_t(), qb_t()]))?;
         let [a, b] = outer.input_wires_arr();
         let h_a = outer.add_dataflow_op(test_quantum_extension::h_gate(), [a])?;
@@ -404,20 +385,20 @@ mod test {
                 .map(|(n, _)| n)
                 .collect::<HashSet<_>>()
         };
-        // h_a should have Order edges added to Rz and the F64 load_const
+        // h_a should have Order edges added to Rz, the F64 load_const and H_a2 (the DFG's Order successor)
         assert_eq!(
             order_neighbours(h_a.node(), Direction::Outgoing),
-            HashSet::from([r.node(), f.node()])
+            HashSet::from([r.node(), f.node(), h_a2.node()])
         );
-        // Likewise the load_const should have Order edges from the inputs to the inner DFG, i.e. h_a and h_b
+        // The load_const should have Order edges from the inputs to the inner DFG, i.e. h_a and h_b
         assert_eq!(
             order_neighbours(f.node(), Direction::Incoming),
             HashSet::from([h_a.node(), h_b.node()])
         );
-        // h_a2 should have Order edges from the measure and if
+        // h_a2 should have Order edges from the measure, if, and H_a (the DFG's Order predecessor)
         assert_eq!(
             order_neighbours(h_a2.node(), Direction::Incoming),
-            HashSet::from([m.node(), if_n.node()])
+            HashSet::from([h_a.node(), m.node(), if_n.node()])
         );
         // the if should have Order edges to the CX and h_a2
         assert_eq!(
@@ -427,7 +408,10 @@ mod test {
         Ok(())
     }
 
-    fn check_reachable<H: HugrView>(h: &H, src: H::Node, tgt: H::Node) {
+    /// Determines whether there is a path along [Order] edges only from `src` to `tgt`.
+    ///
+    /// [Order]: crate::types::EdgeKind::StateOrder
+    fn check_order_reachable<H: HugrView>(h: &H, src: H::Node, tgt: H::Node) {
         let mut visited = HashSet::new();
         let mut to_visit = vec![src];
         while let Some(n) = to_visit.pop() {
@@ -435,7 +419,8 @@ mod test {
                 if n == tgt {
                     return;
                 }
-                to_visit.extend(h.output_neighbours(n));
+                let order_outport = h.get_optype(n).other_output_port().unwrap();
+                to_visit.extend(h.linked_inputs(n, order_outport).map(|(n, _)| n));
             }
         }
         panic!("Node {tgt:?} not reachable from {src:?}");
@@ -465,12 +450,11 @@ mod test {
         h.add_other_wire(qfree.node(), inner.node());
         h.add_other_wire(inner.node(), qalloc.node());
         let mut h = h.finish_hugr_with_outputs([q2]).unwrap();
-        assert!(is_order_reachable(&h, qfree.node(), qalloc.node()));
+        check_order_reachable(&h, qfree.node(), qalloc.node());
 
         h.apply_patch(InlineDFG(*inner.handle())).unwrap();
         h.validate().unwrap();
-        // These were both failing prior to https://github.com/Quantinuum/hugr/pull/3072
-        check_reachable(&h, qfree.node(), qalloc.node());
-        assert!(is_order_reachable(&h, qfree.node(), qalloc.node()));
+        // This was failing prior to https://github.com/Quantinuum/hugr/pull/3072
+        check_order_reachable(&h, qfree.node(), qalloc.node());
     }
 }

--- a/hugr-core/src/hugr/patch/inline_dfg.rs
+++ b/hugr-core/src/hugr/patch/inline_dfg.rs
@@ -401,67 +401,57 @@ mod test {
                 .map(|(n, _)| n)
                 .collect::<HashSet<_>>()
         };
-        // h_a should have Order edge(s) to the F64 load_const and the Rz,
-        // and the DFG's Order successors (h_a2, and optionally CX)
-        let input_ord_tgts = HashSet::from_iter(
-            [f.node(), r.node(), h_a2.node()]
+        let ext_preds = HashSet::from([h_a.node(), h_b.node()]);
+        let ext_order_preds = HashSet::from_iter(once(h_a.node()).chain(o1.then_some(h_b.node())));
+        let inp_succs = HashSet::from([f.node(), r.node()]);
+        let inp_order_succs = HashSet::from_iter(once(f.node()).chain(o2.then_some(r.node())));
+
+        let out_preds = [m.node(), if_n.node()];
+        let out_order_preds = HashSet::from_iter(once(if_n.node()).chain(o3.then_some(m.node())));
+        let ext_succs = HashSet::from([h_a2.node(), cx.node()]);
+        let ext_order_succs = HashSet::from_iter(once(h_a2.node()).chain(o4.then_some(cx.node())));
+
+        // Order predecessors of DFG get edges to both Input any-successor and DFG Order-successors
+        let ext_order_tgts = HashSet::from_iter(
+            inp_succs
                 .into_iter()
-                .chain(o4.then_some(cx.node())),
+                .chain(ext_order_succs.clone()),
         );
         assert_eq!(
             order_neighbours(h_a.node(), Direction::Outgoing),
-            input_ord_tgts
+            ext_order_tgts
         );
-        //if h_b had an Order edge to the DFG, then it should have Order edges to the same nodes as h_a,
-        // otherwise, only to the Order-successors of the Input node
         assert_eq!(
             order_neighbours(h_b.node(), Direction::Outgoing),
-            if o1 {
-                input_ord_tgts
-            } else {
-                HashSet::from_iter([f.node()].into_iter().chain(o2.then_some(r.node())))
-            }
+            if o1 { ext_order_tgts } else { inp_order_succs }
         );
-        // The F64 LoadConstant (with an Order edge from Input) has edges from all DFG predecessors
-        assert_eq!(
-            order_neighbours(f.node(), Direction::Incoming),
-            HashSet::from_iter([h_a.node(), h_b.node()])
-        );
-        // The RZ has an Order edge from h_a, and from h_b if EITHER h_b -> DFG or Input -> RZ were Order edges
+        assert_eq!(order_neighbours(f.node(), Direction::Incoming), ext_preds);
         assert_eq!(
             order_neighbours(r.node(), Direction::Incoming),
-            HashSet::from_iter(once(h_a.node()).chain((o1 || o2).then_some(h_b.node())))
+            if o2 {
+                ext_preds.clone()
+            } else {
+                ext_order_preds.clone()
+            }
         );
 
-        // The `if` had an Order edge to Output, so now has Order edges to both h_a2 and CX
         assert_eq!(
             order_neighbours(if_n.node(), Direction::Outgoing),
-            HashSet::from_iter([h_a2.node(), cx.node()])
+            ext_succs
         );
-        // `meas` has Order edge to h_a2 (DFG Order-successor), and to CX if EITHER meas->Output or DFG->CX were Order edges
         assert_eq!(
             order_neighbours(m.node(), Direction::Outgoing),
-            HashSet::from_iter(once(h_a2.node()).chain((o3 || o4).then_some(cx.node())))
+            if o3 { ext_succs } else { ext_order_succs }
         );
-
-        // h_a2 should have Order edges from `meas` and `if`, and the DFG's Order-precedessors (h_a, and optionally h_b),
-        let output_ord_srcs = HashSet::from_iter(
-            [h_a.node(), m.node(), if_n.node()]
-                .into_iter()
-                .chain(o1.then_some(h_b.node())),
-        );
+        // Order successors of DFG get edges from both Output any-predecessors and DFG Order-predecessors
+        let ext_order_srcs = HashSet::from_iter(out_preds.into_iter().chain(ext_order_preds));
         assert_eq!(
             order_neighbours(h_a2.node(), Direction::Incoming),
-            output_ord_srcs
+            ext_order_srcs
         );
-        // if CX had an Order edge from the DFG, then same, otherwise only from `if` and maybe `meas`
         assert_eq!(
             order_neighbours(cx.node(), Direction::Incoming),
-            if o4 {
-                output_ord_srcs
-            } else {
-                HashSet::from_iter(once(if_n.node()).chain(o3.then_some(m.node())))
-            }
+            if o4 { ext_order_srcs } else { out_order_preds }
         );
         Ok(())
     }


### PR DESCRIPTION
#3072 added extra order edges from the DFG's Order-predecessors to its Order-successors only if there was no path from the DFG's Input to the DFG's Output.

However, it's fairly harmless to add them anyway - the extra ones would be totally redundant in such case and should be removed by tket2's RemoveRedundantOrderEdgesPass - moreover the extra edges are from (nodes that already have other outgoing Order edges) and to (nodes that already have incoming Order edges), and do not place any extra restrictions on ordering, so should not inhibit optimization at all.

While about it, also extend the test (and remove the extra order edge added "in the middle" in #3072)