### PR TITLE
refactor: Use an enum instead of random bools in emit debug option

### DIFF
--- a/hugr-llvm/src/emit.rs
+++ b/hugr-llvm/src/emit.rs
@@ -282,6 +282,20 @@ where
     module_context: EmitModuleContext<'c, 'a, H>,
 }
 
+/// Policy for whether to emit debug info.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EmitDebugInfo {
+    /// Include debug info in the generated IR to the extent it is present in the HUGR.
+    ///
+    /// `ptr_bits` gives the number of bits in a pointer on target architecture - it is used only for generating debug info types.
+    Include {
+        /// The number of bits in a pointer on target architecture.
+        ptr_bits: u32,
+    },
+    /// Do not include any debug info in the generated IR, even if it is present in the HUGR.
+    Exclude,
+}
+
 impl<'c, 'a, H: HugrView<Node = Node>> EmitHugr<'c, 'a, H> {
     delegate! {
         to self.module_context {
@@ -355,18 +369,12 @@ impl<'c, 'a, H: HugrView<Node = Node>> EmitHugr<'c, 'a, H> {
     /// and [`hugr_core::ops::FuncDecl`] nodes are not emitted directly, but instead by
     /// emission of ops with static edges from them. So [`FuncDefn`] are the only
     /// interesting children.
-    ///
-    /// If `emit_debug` is true, debug info will be included in the generated IR to the
-    /// extent it is present in the HUGR. If `emit_debug` is false, any debug info on
-    /// the HUGR will be ignored. `ptr_bits` gives the number of bits in a pointer on
-    /// target architecture - it is used only for generating debug info types.
     pub fn emit_module(
         mut self,
         node: FatNode<'_, hugr_core::ops::Module, H>,
-        emit_debug: bool,
-        ptr_bits: u32,
+        emit_debug: EmitDebugInfo,
     ) -> Result<Self> {
-        if emit_debug {
+        if let EmitDebugInfo::Include { ptr_bits } = emit_debug {
             self.module_context.try_di_init(node, ptr_bits)?;
         }
         for c in node.children() {

--- a/hugr-llvm/src/emit/debug_info.rs
+++ b/hugr-llvm/src/emit/debug_info.rs
@@ -635,7 +635,8 @@ pub mod test {
     mod tests {
         use super::*;
         use crate::custom::CodegenExtsBuilder;
-        use crate::emit::test::{DFGW, Emission, SimpleHugrConfig};
+        use crate::emit::EmitDebugInfo;
+        use crate::emit::test::{DFGW, Emission, SimpleHugrConfig, TEST_EMIT_DEBUG};
         use crate::test::{TestContext, llvm_ctx};
         use crate::utils::fat::FatExt;
         use hugr_core::HugrView;
@@ -718,7 +719,8 @@ pub mod test {
             llvm_ctx.add_extensions(CodegenExtsBuilder::add_default_int_extensions);
             let hugr = build_hugr_with_all_debug_info();
             let root = hugr.fat_root().unwrap();
-            let emission = Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).unwrap();
+            let emission =
+                Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).unwrap();
             emission.verify().unwrap();
         }
 
@@ -729,7 +731,9 @@ pub mod test {
             llvm_ctx.add_extensions(CodegenExtsBuilder::add_default_int_extensions);
             let hugr = build_hugr_with_all_debug_info();
             let root = hugr.fat_root().unwrap();
-            let emission = Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), false).unwrap();
+            let emission =
+                Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), EmitDebugInfo::Exclude)
+                    .unwrap();
             emission.verify().unwrap();
         }
 
@@ -751,7 +755,7 @@ pub mod test {
                 },
             );
             let root = hugr.fat_root().unwrap();
-            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).is_err());
+            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).is_err());
         }
 
         /// Test that compilation fails when a wrong debug info record type is attached
@@ -775,7 +779,7 @@ pub mod test {
                 },
             );
             let root = hugr.fat_root().unwrap();
-            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).is_err());
+            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).is_err());
         }
 
         /// Test that compilation fails when a wrong debug info record type is attached
@@ -799,7 +803,7 @@ pub mod test {
                 },
             );
             let root = hugr.fat_root().unwrap();
-            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).is_err());
+            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).is_err());
         }
 
         /// Test that compilation fails when invalid JSON (not matching CompileUnitRecord's
@@ -815,7 +819,7 @@ pub mod test {
                 serde_json::json!({"not_a_valid_field": true}),
             );
             let root = hugr.fat_root().unwrap();
-            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).is_err());
+            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).is_err());
         }
 
         /// Test that compilation fails when a CompileUnitRecord has an out-of-range
@@ -835,7 +839,7 @@ pub mod test {
                 },
             );
             let root = hugr.fat_root().unwrap();
-            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).is_err());
+            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).is_err());
         }
 
         /// Test that compilation fails when invalid JSON (not matching SubprogramRecord's
@@ -855,7 +859,7 @@ pub mod test {
                 serde_json::json!({"not_a_valid_field": true}),
             );
             let root = hugr.fat_root().unwrap();
-            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).is_err());
+            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).is_err());
         }
 
         /// Test that compilation fails when a SubprogramRecord has an out-of-range file
@@ -879,7 +883,7 @@ pub mod test {
                 },
             );
             let root = hugr.fat_root().unwrap();
-            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).is_err());
+            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).is_err());
         }
 
         /// Test that `unmangle_hugr_func_name` correctly strips the prefix and suffix
@@ -933,7 +937,7 @@ pub mod test {
                 serde_json::json!({"not_a_valid_field": true}),
             );
             let root = hugr.fat_root().unwrap();
-            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), true).is_err());
+            assert!(Emission::emit_hugr(root, llvm_ctx.get_emit_hugr(), TEST_EMIT_DEBUG).is_err());
         }
     }
 }

--- a/hugr-llvm/src/emit/test.rs
+++ b/hugr-llvm/src/emit/test.rs
@@ -1,7 +1,7 @@
 use inkwell::execution_engine::ExecutionEngine;
 use std::ffi::CStr;
 
-use crate::emit::EmitFuncContext;
+use crate::emit::{EmitDebugInfo, EmitFuncContext};
 use crate::extension::PreludeCodegen;
 use crate::types::HugrFuncType;
 use crate::utils::fat::FatNode;
@@ -22,7 +22,7 @@ mod panic_runtime;
 
 // currently all our targets have the same pointer size.
 // used for debug info.
-const TEST_PTR_SIZE: u32 = 64;
+pub const TEST_EMIT_DEBUG: EmitDebugInfo = EmitDebugInfo::Include { ptr_bits: 64 };
 
 #[allow(clippy::upper_case_acronyms)]
 pub type DFGW = DFGWrapper<Hugr, BuildHandle<FuncID<true>>>;
@@ -43,9 +43,9 @@ impl<'c> Emission<'c> {
     pub fn emit_hugr<'a: 'c, H: HugrView<Node = Node>>(
         hugr: FatNode<'c, hugr_core::ops::Module, H>,
         eh: EmitHugr<'c, 'a, H>,
-        emit_debug: bool,
+        emit_debug: EmitDebugInfo,
     ) -> Result<Self> where {
-        let (module, maybe_di_ctx) = eh.emit_module(hugr, emit_debug, TEST_PTR_SIZE)?.finish();
+        let (module, maybe_di_ctx) = eh.emit_module(hugr, emit_debug)?.finish();
         if let Some(di_ctx) = maybe_di_ctx {
             di_ctx.finish();
         }
@@ -328,8 +328,12 @@ macro_rules! check_emission {
         // We add random debug info to all test HUGRs for coverage.
         $crate::emit::debug_info::test::add_random_debug_info(&mut $hugr);
         let root = $crate::utils::fat::FatExt::fat_root(&$hugr).unwrap();
-        let emission =
-            $crate::emit::test::Emission::emit_hugr(root, $test_ctx.get_emit_hugr(), true).unwrap();
+        let emission = $crate::emit::test::Emission::emit_hugr(
+            root,
+            $test_ctx.get_emit_hugr(),
+            $crate::emit::test::TEST_EMIT_DEBUG,
+        )
+        .unwrap();
 
         let mut settings = $crate::emit::test::insta::Settings::clone_current();
         let new_suffix = settings

--- a/hugr-llvm/src/test.rs
+++ b/hugr-llvm/src/test.rs
@@ -13,6 +13,7 @@ use inkwell::{
 use itertools::Itertools as _;
 use rstest::fixture;
 
+use crate::emit::test::TEST_EMIT_DEBUG;
 use crate::{
     custom::{CodegenExtsBuilder, CodegenExtsMap},
     emit::{
@@ -174,8 +175,12 @@ impl TestContext {
     pub fn exec_hugr<T>(&self, mut hugr: THugrView, entry_point: impl AsRef<str>) -> T {
         // We add random debug info to all test HUGRs for coverage.
         add_random_debug_info(&mut hugr);
-        let emission =
-            Emission::emit_hugr(hugr.fat_root().unwrap(), self.get_emit_hugr(), true).unwrap();
+        let emission = Emission::emit_hugr(
+            hugr.fat_root().unwrap(),
+            self.get_emit_hugr(),
+            TEST_EMIT_DEBUG,
+        )
+        .unwrap();
         emission.verify().unwrap();
 
         emission.jit_exec::<T>(entry_point).unwrap()
@@ -234,8 +239,12 @@ impl TestContext {
     pub fn exec_hugr_panicking(&self, mut hugr: THugrView, entry_point: impl AsRef<str>) -> String {
         // We add random debug info to all test HUGRs for coverage.
         add_random_debug_info(&mut hugr);
-        let emission =
-            Emission::emit_hugr(hugr.fat_root().unwrap(), self.get_emit_hugr(), true).unwrap();
+        let emission = Emission::emit_hugr(
+            hugr.fat_root().unwrap(),
+            self.get_emit_hugr(),
+            TEST_EMIT_DEBUG,
+        )
+        .unwrap();
         emission.verify().unwrap();
 
         emission.exec_panicking(entry_point).unwrap()


### PR DESCRIPTION
This unreleased API used a bare `bool` argument, plus an option that was only valid when the bool was `true`.

We replace it with a `EmitDebugInfo` enum instead. That should make the call sites easier to read.

The unpublished PR that added these arguments is already marked as breaking, so I'm not marking this one.