### PR TITLE
docs: Cleanup the python README

### DIFF
--- a/hugr-py/README.md
+++ b/hugr-py/README.md
@@ -26,22 +26,8 @@ The HUGR specification is [here](https://quantinuum.github.io/hugr/specification
 
 The package name is `hugr`. It can be installed from PyPI:
 ```bash
-pip install hugr
+uv pip install hugr
 ```
-
-The current releases are in alpha stage, and the API is subject to change.
-
-## Usage
-
-TODO
-
-## Recent Changes
-
-TODO
-
-## Development
-
-TODO
 
 ## License
 


### PR DESCRIPTION
Removes the empty `TODO` sections from the README rendered by pypi.

See https://pypi.org/project/hugr/0.16.0/

drive-by: Nudge people to use `uv`