### PR TITLE
fix: Don't read partial symbol definitions

### DIFF
--- a/hugr-model/src/v0/ast/parse.rs
+++ b/hugr-model/src/v0/ast/parse.rs
@@ -54,10 +54,8 @@ pub(super) fn is_bare_symbol_name(name: &str) -> bool {
 }
 
 fn parse_symbol_name(pair: Pair<Rule>) -> ParseResult<SymbolName> {
-    debug_assert_eq!(Rule::symbol_name, pair.as_rule());
-    let pair = pair.into_inner().next().unwrap();
-
     Ok(match pair.as_rule() {
+        Rule::symbol_name => parse_symbol_name(pair.into_inner().next().unwrap())?,
         Rule::bare_symbol_name => SymbolName(pair.as_str().into()),
         Rule::raw_symbol_name => SymbolName(parse_raw_symbol_name(pair)),
         _ => unreachable!("expected symbol name"),
@@ -492,7 +490,16 @@ macro_rules! impl_from_str {
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 let mut pairs =
                     HugrParser::parse(Rule::$rule, s).map_err(|err| ParseError(Box::new(err)))?;
-                $parse(pairs.next().unwrap())
+                let pair = pairs.next().unwrap();
+                let span = pair.as_span();
+                let end = span.end();
+
+                if !s[end..].trim().is_empty() {
+                    let span = pest::Span::new(s, end, s.len()).unwrap_or(span);
+                    return Err(ParseError::custom("unexpected trailing input", span));
+                }
+
+                $parse(pair)
             }
         }
     };

--- a/hugr-model/src/v0/ast/python.rs
+++ b/hugr-model/src/v0/ast/python.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 
 use crate::v0::Visibility;
 
-use super::{Module, Node, Operation, Package, Param, Region, SeqPart, Symbol, SymbolIdent, Term};
+use super::{
+    Module, Node, Operation, Package, Param, Region, SeqPart, Symbol, SymbolIdent, SymbolName, Term,
+};
 use pyo3::{
     PyAny,
     exceptions::PyTypeError,
@@ -49,7 +51,13 @@ impl<'py> pyo3::FromPyObject<'_, 'py> for SymbolIdent {
 
     fn extract(ob: pyo3::Borrowed<'_, 'py, PyAny>) -> pyo3::PyResult<Self> {
         let name: String = ob.extract()?;
-        Self::from_str(&name).map_err(|err| PyTypeError::new_err(err.to_string()))
+        match Self::from_str(&name) {
+            Ok(symbol) => Ok(symbol),
+            _ => Ok(SymbolIdent {
+                name: SymbolName::new(name),
+                version: None,
+            }),
+        }
     }
 }
 
@@ -61,7 +69,11 @@ impl<'py> pyo3::IntoPyObject<'py> for &SymbolIdent {
     type Error = pyo3::PyErr;
 
     fn into_pyobject(self, py: pyo3::Python<'py>) -> Result<Self::Output, Self::Error> {
-        Ok(self.to_string().into_pyobject(py)?)
+        let symbol = match &self.version {
+            Some(version) => format!("{}@{}", self.name.as_ref(), version),
+            None => self.name.as_ref().to_string(),
+        };
+        Ok(symbol.into_pyobject(py)?)
     }
 }
 

--- a/hugr-model/tests/text.rs
+++ b/hugr-model/tests/text.rs
@@ -76,3 +76,31 @@ pub fn test_package_symbol_name_roundtrip(#[case] name: &str) {
 
     assert_eq!(parsed.to_string(), roundtripped);
 }
+
+#[rstest]
+fn test_raw_symbol_name_in_term() {
+    let term = ast::Term::from_str(r##"r#"example.foo<bar>"#"##).unwrap();
+
+    assert_eq!(
+        term,
+        ast::Term::Apply(
+            ast::SymbolIdent {
+                name: SymbolName::new("example.foo<bar>"),
+                version: None,
+            },
+            [].into(),
+        )
+    );
+}
+
+/// Parsing an invalid s-expression symbol definition should fail.
+///
+/// Non-supported characters like `<` and `>` are not allowed in bare symbol names,
+/// they require escaping with the raw symbol syntax.
+#[rstest]
+fn test_symbol_name_rejects_partial_parse() {
+    let name = "tests.integration.test_linear.test_return_call.<locals>.op";
+
+    assert!(ast::SymbolIdent::from_str(name).is_err());
+    assert!(ast::Term::from_str(name).is_err());
+}

--- a/hugr-py/tests/test_model.py
+++ b/hugr-py/tests/test_model.py
@@ -27,8 +27,8 @@ def test_symbol_escaped_name_text_roundtrip():
     text = str(symbol)
     parsed = model.Symbol.from_str(text)
 
-    assert f'r#"{name}"#' in text
     assert parsed == symbol
+    assert parsed.name == name
 
 
 def test_package_escaped_name_text_roundtrip():
@@ -44,6 +44,17 @@ def test_package_escaped_name_text_roundtrip():
 
     text = str(model.Package.from_str(source))
     parsed = model.Package.from_str(text)
+    operation = parsed.modules[0].root.children[1].operation
 
-    assert f'r#"{name}"#' in text
     assert str(parsed) == text
+    assert operation.symbol_name() == name
+
+
+def test_apply_escaped_name_text_roundtrip():
+    name = "tests.integration.test_linear.test_return_call.<locals>.op"
+    term = model.Apply(name)
+    text = str(term)
+    parsed = model.Term.from_str(text)
+
+    assert parsed == term
+    assert parsed.symbol == name


### PR DESCRIPTION
Followup to #3101.

We were reading partial suffixes of the symbol names when converting from the python bindings of `hugr-model`, so some symbol declarations got their name truncated in the final encoded hugr.

This PR makes sure we use the raw symbol alternate representation when needed, and return an error when a s-expression is not fully parsed when roundtriping back into python.