### PR TITLE
ci: Disable failing cargo-dist target

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -11,11 +11,13 @@ ci = "github"
 targets = [
     "aarch64-apple-darwin",
     "aarch64-unknown-linux-gnu",
-    "aarch64-pc-windows-msvc",
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "x86_64-pc-windows-msvc",
+    # The runner provided by cargo-dist 0.32.0 for this target uses rust 1.89,
+    # which is not compatible with the project's MSRV
+    #"aarch64-pc-windows-msvc",
 ]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"


### PR DESCRIPTION
Looks like the `cargo-dist` update from #3100 didn't fix the problem; the generated CI tries to build `hugr-cli` for `aarch64-pc-windows-msvc` targets (and only that target) with an older `rustc 1.89`, which does not work for our MSRV.

Let's just disable the target to get things working. We can re-enable it in the future when cargo-dist updates it.

Failed CI: https://github.com/Quantinuum/hugr/actions/runs/27288776636/job/80603349675#step:9:19