### PR TITLE
feat: Don't error out when validating a signature with a missing validation function

### DIFF
--- a/hugr-core/src/extension.rs
+++ b/hugr-core/src/extension.rs
@@ -771,6 +771,7 @@ pub enum SignatureError {
     /// Extension declaration specifies a binary compute signature function, but none
     /// was loaded.
     #[error("Binary validate signature function not loaded.")]
+    #[deprecated(note = "Missing validation functions are ignored.", since = "0.28.2")]
     MissingValidateFunc,
 }
 

--- a/hugr-core/src/extension/op_def.rs
+++ b/hugr-core/src/extension/op_def.rs
@@ -423,9 +423,9 @@ impl OpDef {
                 (&temp, other_args)
             }
             SignatureFunc::MissingComputeFunc => return Err(SignatureError::MissingComputeFunc),
-            SignatureFunc::MissingValidateFunc(_) => {
-                return Err(SignatureError::MissingValidateFunc);
-            }
+            // Validation functions cannot cross the serialization boundary.
+            // If they are missing, we ignore them and use the signature as-is.
+            SignatureFunc::MissingValidateFunc(ts) => (ts, args),
         };
         args.iter().try_for_each(|ta| ta.validate(var_decls))?;
         check_term_kinds(args, pf.params())?;


### PR DESCRIPTION
Extension ops may define a validation function for their signature.
This binary function cannot cross serialization boundaries, so it's represented with a `SignatureFunc::MissingValidateFunc(PolyFuncType)`.

If an extension gets defined in python, there is no way for the rust-based validator to run the function.
Previously this caused an error, but it should instead ignore the missing function.