### PR TITLE
fix: Display source error for errors during payload reads

### DIFF
--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -101,7 +101,7 @@ pub enum ReadError {
     #[error(transparent)]
     EnvelopeHeader(#[from] Box<HeaderError>),
     /// Error reading the package payload.
-    #[error("Error reading package payload in envelope.")]
+    #[error("Error reading package payload in envelope: {source}")]
     Payload {
         /// The source error.
         source: Box<PayloadError>,


### PR DESCRIPTION
This has been a major annoyance, since to find out the source error if given through `hugr-py`, one would need to add this line and locally compile `hugr-py`. Let's persist that for now.