### PR TITLE
feat!: Remove metadata object from python Nodes

### DIFF
--- a/hugr-py/src/hugr/build/base.py
+++ b/hugr-py/src/hugr/build/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import (
+    TYPE_CHECKING,
     Protocol,
     cast,
 )
@@ -12,6 +13,9 @@ from hugr.hugr.node_port import (
     Node,
     ToNode,
 )
+
+if TYPE_CHECKING:
+    from hugr.metadata import NodeMetadata
 
 
 class ParentBuilder(ToNode, Protocol[OpVar]):
@@ -24,6 +28,11 @@ class ParentBuilder(ToNode, Protocol[OpVar]):
 
     def to_node(self) -> Node:
         return self.parent_node
+
+    @property
+    def metadata(self) -> NodeMetadata:
+        """Metadata associated with this builder's parent node."""
+        return self.hugr[self.parent_node].metadata
 
     @property
     def parent_op(self) -> OpVar:

--- a/hugr-py/src/hugr/build/dfg.py
+++ b/hugr-py/src/hugr/build/dfg.py
@@ -46,6 +46,11 @@ class DefinitionBuilder(Generic[OpVar]):
 
     hugr: Hugr[OpVar]
 
+    @property
+    def metadata(self) -> NodeMetadata:
+        """Metadata associated with this builder's root node."""
+        return self.hugr[self.hugr.entrypoint].metadata
+
     def module_root_builder(self) -> Module:
         """Allows access to the `Module` at the root of the Hugr
         (outside the scope of this builder, perhaps outside the entrypoint).

--- a/hugr-py/src/hugr/build/function.py
+++ b/hugr-py/src/hugr/build/function.py
@@ -11,7 +11,6 @@ from hugr.hugr import Hugr
 
 if TYPE_CHECKING:
     from hugr.hugr.node_port import Node
-    from hugr.metadata import NodeMetadata
     from hugr.tys import PolyFuncType, Type, TypeBound, TypeParam, TypeRow, Visibility
 
 __all__ = ["Function", "Module"]
@@ -98,8 +97,3 @@ class Module(DefinitionBuilder[ops.Module]):
     def add_alias_decl(self, name: str, bound: TypeBound) -> Node:
         """Add a type alias declaration."""
         return self.hugr.add_node(ops.AliasDecl(name, bound), self.hugr.module_root)
-
-    @property
-    def metadata(self) -> NodeMetadata:
-        """Metadata associated with this module."""
-        return self.hugr.entrypoint.metadata

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -211,11 +211,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         return n
 
     def __iter__(self) -> Iterator[Node]:
-        return (
-            self._node_handle(idx, data.metadata)
-            for idx, data in enumerate(self._nodes)
-            if data is not None
-        )
+        return (Node(idx) for idx, data in enumerate(self._nodes) if data is not None)
 
     def __len__(self) -> int:
         return self.num_nodes()
@@ -356,24 +352,14 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         if self._free_nodes:
             node = self._free_nodes.pop()
             self._nodes[node.idx] = node_data
-            node._bind_hugr(self)
         else:
-            node = self._node_handle(len(self._nodes), node_data.metadata)
+            node = Node(len(self._nodes))
             self._nodes.append(node_data)
         node._num_out_ports = num_outs
-        node._metadata = node_data.metadata
         if parent:
             self[parent].children.append(node)
 
         self._update_node_outs(node, num_outs)
-        return node
-
-    def _node_handle(
-        self, idx: NodeIdx, metadata: NodeMetadata, num_outs: int | None = None
-    ) -> Node:
-        """Create a node handle bound to this HUGR's canonical node table."""
-        node = Node(idx, metadata, num_outs)
-        node._bind_hugr(self)
         return node
 
     def _update_node_outs(self, node: Node, num_outs: int | None) -> Node:
@@ -485,9 +471,6 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             self._links.delete_left(_SubPort(out))
 
         weight, self._nodes[node.idx] = self._nodes[node.idx], None
-
-        # Free up the metadata dictionary
-        node._metadata = NodeMetadata()
 
         self._free_nodes.append(node)
         return weight
@@ -977,7 +960,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             serial_idx = len(nodes)
 
             # non contiguous indices will be erased
-            nodes.append(data._to_serial(Node(serial_idx, NodeMetadata())))
+            nodes.append(data._to_serial(Node(serial_idx)))
             metadata.append(data.metadata.as_dict() if data.metadata else None)
             if self.entrypoint == node:
                 entrypoint = serial_idx
@@ -1049,9 +1032,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
                 continue
 
             node_meta = get_meta(idx)
-            parent: Node | None = hugr._node_handle(
-                serial_node.root.parent, get_meta(serial_node.root.parent)
-            )
+            parent: Node | None = Node(serial_node.root.parent)
 
             serial_node.root.parent = -1
             op = serial_node.root.deserialize()
@@ -1064,8 +1045,8 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
                 hugr.entrypoint = n
 
         for (src_node, src_offset), (dst_node, dst_offset) in serial.edges:
-            src = hugr._node_handle(src_node, get_meta(src_node))
-            dst = hugr._node_handle(dst_node, get_meta(dst_node))
+            src = Node(src_node)
+            dst = Node(dst_node)
             if src_offset is None or dst_offset is None:
                 src_op = hugr[src].op
                 if isinstance(src_op, DataflowBlock | ExitBlock):

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -212,7 +212,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
 
     def __iter__(self) -> Iterator[Node]:
         return (
-            Node(idx, data.metadata)
+            self._node_handle(idx, data.metadata)
             for idx, data in enumerate(self._nodes)
             if data is not None
         )
@@ -356,8 +356,9 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         if self._free_nodes:
             node = self._free_nodes.pop()
             self._nodes[node.idx] = node_data
+            node._bind_hugr(self)
         else:
-            node = Node(len(self._nodes), NodeMetadata())
+            node = self._node_handle(len(self._nodes), node_data.metadata)
             self._nodes.append(node_data)
         node._num_out_ports = num_outs
         node._metadata = node_data.metadata
@@ -365,6 +366,14 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             self[parent].children.append(node)
 
         self._update_node_outs(node, num_outs)
+        return node
+
+    def _node_handle(
+        self, idx: NodeIdx, metadata: NodeMetadata, num_outs: int | None = None
+    ) -> Node:
+        """Create a node handle bound to this HUGR's canonical node table."""
+        node = Node(idx, metadata, num_outs)
+        node._bind_hugr(self)
         return node
 
     def _update_node_outs(self, node: Node, num_outs: int | None) -> Node:
@@ -1040,7 +1049,9 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
                 continue
 
             node_meta = get_meta(idx)
-            parent: Node | None = Node(serial_node.root.parent)
+            parent: Node | None = hugr._node_handle(
+                serial_node.root.parent, get_meta(serial_node.root.parent)
+            )
 
             serial_node.root.parent = -1
             op = serial_node.root.deserialize()
@@ -1053,8 +1064,8 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
                 hugr.entrypoint = n
 
         for (src_node, src_offset), (dst_node, dst_offset) in serial.edges:
-            src = Node(src_node, _metadata=get_meta(src_node))
-            dst = Node(dst_node, _metadata=get_meta(dst_node))
+            src = hugr._node_handle(src_node, get_meta(src_node))
+            dst = hugr._node_handle(dst_node, get_meta(dst_node))
             if src_offset is None or dst_offset is None:
                 src_op = hugr[src].op
                 if isinstance(src_op, DataflowBlock | ExitBlock):

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -157,11 +157,17 @@ class Node(ToNode):
     with globally unique index.
     """
 
+    # The ID of the node.
     idx: NodeIdx
+    # If the node is not linked to a Hugr, the metadata information.
+    #
+    # This gets overriden by the Hugr's node info if `self._hugr` is alive.
     _metadata: NodeMetadata = field(
         repr=False, compare=False, default_factory=NodeMetadata
     )
+    # Number of output ports for this node, or None if the number is not fixed.
     _num_out_ports: int | None = field(default=None, compare=False, repr=False)
+    # The Hugr that owns this node, if any.
     _hugr: weakref.ReferenceType[Any] | None = field(
         default=None, compare=False, repr=False
     )

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import weakref
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
+    Any,
     ClassVar,
     Generic,
     Protocol,
@@ -146,7 +148,7 @@ class ToNode(Wire, Protocol):
     @property
     def metadata(self) -> NodeMetadata:
         """Metadata associated with this node."""
-        return self.to_node()._metadata
+        return self.to_node().metadata
 
 
 @dataclass(eq=True, order=True)
@@ -160,6 +162,30 @@ class Node(ToNode):
         repr=False, compare=False, default_factory=NodeMetadata
     )
     _num_out_ports: int | None = field(default=None, compare=False, repr=False)
+    _hugr: weakref.ReferenceType[Any] | None = field(
+        default=None, compare=False, repr=False
+    )
+
+    def _bind_hugr(self, hugr: Any) -> None:
+        """Bind this node handle to the HUGR that owns its node data."""
+        self._hugr = weakref.ref(hugr)
+
+    @property
+    def metadata(self) -> NodeMetadata:
+        """Metadata associated with this node.
+
+        HUGR-owned node handles fetch metadata from their graph's canonical node
+        table. Standalone ``Node`` values keep using their local metadata, so
+        they remain useful as lightweight index tokens.
+        """
+        if self._hugr is not None:
+            hugr = self._hugr()
+            if hugr is not None:
+                try:
+                    return hugr[self].metadata
+                except KeyError:
+                    pass
+        return self._metadata
 
     def _index(
         self, index: PortOffset | slice | tuple[PortOffset, ...]

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import weakref
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
-    Any,
     ClassVar,
     Generic,
     Protocol,
@@ -16,8 +14,6 @@ from typing import (
 )
 
 from typing_extensions import Self
-
-from hugr.metadata import NodeMetadata
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -145,11 +141,6 @@ class ToNode(Wire, Protocol):
         else:
             return self.out(offset)
 
-    @property
-    def metadata(self) -> NodeMetadata:
-        """Metadata associated with this node."""
-        return self.to_node().metadata
-
 
 @dataclass(eq=True, order=True)
 class Node(ToNode):
@@ -159,39 +150,10 @@ class Node(ToNode):
 
     # The ID of the node.
     idx: NodeIdx
-    # If the node is not linked to a Hugr, the metadata information.
-    #
-    # This gets overriden by the Hugr's node info if `self._hugr` is alive.
-    _metadata: NodeMetadata = field(
-        repr=False, compare=False, default_factory=NodeMetadata
-    )
     # Number of output ports for this node, or None if the number is not fixed.
-    _num_out_ports: int | None = field(default=None, compare=False, repr=False)
-    # The Hugr that owns this node, if any.
-    _hugr: weakref.ReferenceType[Any] | None = field(
-        default=None, compare=False, repr=False
+    _num_out_ports: int | None = field(
+        default=None, compare=False, repr=False, kw_only=True
     )
-
-    def _bind_hugr(self, hugr: Any) -> None:
-        """Bind this node handle to the HUGR that owns its node data."""
-        self._hugr = weakref.ref(hugr)
-
-    @property
-    def metadata(self) -> NodeMetadata:
-        """Metadata associated with this node.
-
-        HUGR-owned node handles fetch metadata from their graph's canonical node
-        table. Standalone ``Node`` values keep using their local metadata, so
-        they remain useful as lightweight index tokens.
-        """
-        if self._hugr is not None:
-            hugr = self._hugr()
-            if hugr is not None:
-                try:
-                    return hugr[self].metadata
-                except KeyError:
-                    pass
-        return self._metadata
 
     def _index(
         self, index: PortOffset | slice | tuple[PortOffset, ...]

--- a/hugr-py/tests/test_metadata.py
+++ b/hugr-py/tests/test_metadata.py
@@ -78,16 +78,10 @@ def test_metadata_roundtrip() -> None:
     loaded = Hugr.from_bytes(data)
     node = loaded[loaded.module_root]
 
-    # The module root handle should expose the same metadata as the node table.
-    assert loaded.module_root.metadata is node.metadata
-    assert loaded.module_root.metadata.as_dict() == node.metadata.as_dict()
-
     # Typed readback
     assert node.metadata[HugrGenerator] == gen
-    assert loaded.module_root.metadata[HugrGenerator] == gen
     assert node.metadata.get(HugrGenerator) == gen
     assert node.metadata[HugrUsedExtensions] == exts
-    assert loaded.module_root.metadata[HugrUsedExtensions] == exts
     assert node.metadata.get(HugrUsedExtensions) == exts
     assert node.metadata[CustomMetadata] == custom_payload
     assert node.metadata[CustomMetadata.KEY] == custom_payload

--- a/hugr-py/tests/test_metadata.py
+++ b/hugr-py/tests/test_metadata.py
@@ -78,10 +78,16 @@ def test_metadata_roundtrip() -> None:
     loaded = Hugr.from_bytes(data)
     node = loaded[loaded.module_root]
 
+    # The module root handle should expose the same metadata as the node table.
+    assert loaded.module_root.metadata is node.metadata
+    assert loaded.module_root.metadata.as_dict() == node.metadata.as_dict()
+
     # Typed readback
     assert node.metadata[HugrGenerator] == gen
+    assert loaded.module_root.metadata[HugrGenerator] == gen
     assert node.metadata.get(HugrGenerator) == gen
     assert node.metadata[HugrUsedExtensions] == exts
+    assert loaded.module_root.metadata[HugrUsedExtensions] == exts
     assert node.metadata.get(HugrUsedExtensions) == exts
     assert node.metadata[CustomMetadata] == custom_payload
     assert node.metadata[CustomMetadata.KEY] == custom_payload


### PR DESCRIPTION
Fixes https://github.com/Quantinuum/tket2/issues/1757

Python `Node`s kept a `NodeMetadata` object internally to record info about the node.

When a node got added / linked to a `Hugr`, the metadata object was replaced with a reference to the one inside the corresponding `NodeData` in `Hugr._nodes`.

The problem with this is that if someone does
```
hugr[some_node].metadata = new_metadata_object
```
then the object references get out of sync.

This was the case with `hugr.entrypoint` and `hugr.module_root` that didn't get updated after decoding a hugr, but could have shown in user code too.

The simplest solution here, to avoid users accidentally breaking the sync, is to remove the metadata object from `Node`, and fetch it from the appropriate Hugr instead.

BREAKING CHANGE: Removed `ToNode.metadata` method. Use `Hugr[node].metadata` instead.