### PR TITLE
ci: Fix outdated nightly version in WASM wheels build

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -34,7 +34,7 @@ env:
   UV_FROZEN: 1
   PYTHON_VERSION: "3.14"
   # Nightly version of rust used to build the wasm wheels
-  RUST_NIGHTLY_VERSION: "nightly-2026-01-29"
+  RUST_NIGHTLY_VERSION: "nightly-2026-05-28"
 
 jobs:
   # Check if the tag matches the package name,


### PR DESCRIPTION
https://github.com/Quantinuum/hugr/pull/3111 updated the `pyo3` dependency to a version using flags not supported by the pinned nightly rust version in the python wheels build action (required to build WASM wheels).

So the check has been failing since.

Test run: https://github.com/Quantinuum/hugr/actions/runs/28374805294 ✅