### PR TITLE
feat: Overrride `__repr__` for `RegionKind`

### DIFF
--- a/hugr-py/src/hugr/model/__init__.py
+++ b/hugr-py/src/hugr/model/__init__.py
@@ -300,6 +300,9 @@ class RegionKind(Enum):
     CONTROL_FLOW = 1
     MODULE = 2
 
+    def __repr__(self) -> str:
+        return str(self)
+
 
 @dataclass
 class Region:


### PR DESCRIPTION
With this change, `repr(RegionKind.DATA_FLOW) == "RegionKind.DATA_FLOW"`, rather than `"<RegionKind.DATA_FLOW: 0>"`. This helps with debugging involving `Model` objects as it means one can paste their string representations directly into Python scripts.