### PR TITLE
chore: Fix lint warnings in rust 1.97

### DIFF
--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -560,7 +560,7 @@ impl PartialEq<dyn CustomConst> for ConstExternalSymbol {
 #[typetag::serde]
 impl CustomConst for ConstExternalSymbol {
     fn name(&self) -> ValueName {
-        format!("@{}", &self.symbol).into()
+        format!("@{}", self.symbol).into()
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
@@ -689,10 +689,10 @@ impl MakeExtensionOp for MakeTuple {
     {
         let def = TupleOpDef::from_def(ext_op.def())?;
         if def != TupleOpDef::MakeTuple {
-            return Err(OpLoadError::NotMember(ext_op.unqualified_id().to_string()))?;
+            return Err(OpLoadError::NotMember(ext_op.unqualified_id().to_string()));
         }
         let [TypeArg::List(elems)] = ext_op.args() else {
-            return Err(SignatureError::InvalidTypeArgs)?;
+            return Err(SignatureError::InvalidTypeArgs.into());
         };
         Ok(Self(elems.clone().try_into()?))
     }
@@ -737,10 +737,10 @@ impl MakeExtensionOp for UnpackTuple {
     {
         let def = TupleOpDef::from_def(ext_op.def())?;
         if def != TupleOpDef::UnpackTuple {
-            return Err(OpLoadError::NotMember(ext_op.unqualified_id().to_string()))?;
+            return Err(OpLoadError::NotMember(ext_op.unqualified_id().to_string()));
         }
         let [Term::List(elems)] = ext_op.args() else {
-            return Err(SignatureError::InvalidTypeArgs)?;
+            return Err(SignatureError::InvalidTypeArgs.into());
         };
         Ok(Self(elems.clone().try_into()?))
     }


### PR DESCRIPTION
Rust 1.97 is coming out today.

This PR fixes some new lints before they cause problems in our CI.

I was also getting some inkwell-related ICEs when running on `beta`, we'll see if it's a build fluke, or they still appear on the stable release.

<details>

<summary>
Rust error log
</summary>

```
thread 'rustc' (13663732) panicked at /rustc-dev/6b3fa26749ab40e159b2dd5cf577acaaf5902772/compiler/rustc_metadata/src/rmeta/decoder.rs:1404:17:
assertion `left == right` failed
  left: TypeNs("llvm_sys")
 right: Ctor
stack backtrace:
   0:        0x10b922d3c - <<std[a3189482ba289ff4]::sys::backtrace::BacktraceLock>::print::DisplayBacktrace as core[8ba6287cc279b2b5]::fmt::Display>::fmt
   1:        0x108befe94 - core[8ba6287cc279b2b5]::fmt::write
   2:        0x10b939aa8 - <std[a3189482ba289ff4]::sys::stdio::unix::Stderr as std[a3189482ba289ff4]::io::Write>::write_fmt
   3:        0x10b8f76c4 - std[a3189482ba289ff4]::panicking::default_hook::{closure#0}
   4:        0x10b9141e0 - std[a3189482ba289ff4]::panicking::default_hook
   5:        0x1097e2b30 - std[a3189482ba289ff4]::panicking::update_hook::<alloc[9fac1223c623ba44]::boxed::Box<rustc_driver_impl[21c3becc454883de]::install_ice_hook::{closure#1}>>::{closure#0}
   6:        0x10b9147ac - std[a3189482ba289ff4]::panicking::panic_with_hook
   7:        0x10b8f7748 - std[a3189482ba289ff4]::panicking::panic_handler::{closure#0}
   8:        0x10b8ee070 - std[a3189482ba289ff4]::sys::backtrace::__rust_end_short_backtrace::<std[a3189482ba289ff4]::panicking::panic_handler::{closure#0}, !>
   9:        0x10b8f8c70 - __rustc[a7b7b02e776dd976]::rust_begin_unwind
  10:        0x10b9dea40 - core[8ba6287cc279b2b5]::panicking::panic_fmt
  11:        0x10b9de940 - core[8ba6287cc279b2b5]::panicking::assert_failed_inner
  12:        0x10baa42e0 - core[8ba6287cc279b2b5]::panicking::assert_failed::<rustc_hir[b4c00c16b30efa0e]::definitions::DefPathData, rustc_hir[b4c00c16b30efa0e]::definitions::DefPathData>
  13:        0x10a2d31f4 - <rustc_metadata[d7c238da3e9a48ae]::rmeta::decoder::CrateMetadata>::get_item_attrs
  14:        0x10a2e97ec - rustc_metadata[d7c238da3e9a48ae]::rmeta::decoder::cstore_impl::provide_extern::attrs_for_def
  15:        0x10aed8fb0 - rustc_query_impl[b38cd939b6df8be5]::query_impl::attrs_for_def::invoke_provider_fn::__rust_begin_short_backtrace
  16:        0x10ad1b9f0 - rustc_query_impl[b38cd939b6df8be5]::execution::try_execute_query::<rustc_middle[fb1cc90ecdcae56f]::query::caches::DefIdCache<rustc_middle[fb1cc90ecdcae56f]::query::erase::ErasedData<[u8; 16usize]>>, false>
  17:        0x10aed90a8 - rustc_query_impl[b38cd939b6df8be5]::query_impl::attrs_for_def::execute_query_non_incr::__rust_end_short_backtrace
  18:        0x102fffbc4 - <rustc_middle[fb1cc90ecdcae56f]::ty::context::TyCtxt>::get_all_attrs::<rustc_span[9c644fff229d6cbe]::def_id::DefId>
  19:        0x103207644 - rustdoc[893abef7f982f8d7]::clean::inline::build_module_items
  20:        0x10320650c - rustdoc[893abef7f982f8d7]::clean::inline::build_module
  21:        0x103204984 - rustdoc[893abef7f982f8d7]::clean::inline::try_inline
  22:        0x103207374 - rustdoc[893abef7f982f8d7]::clean::inline::build_module_items
  23:        0x10320650c - rustdoc[893abef7f982f8d7]::clean::inline::build_module
  24:        0x103204984 - rustdoc[893abef7f982f8d7]::clean::inline::try_inline
  25:        0x103207374 - rustdoc[893abef7f982f8d7]::clean::inline::build_module_items
  26:        0x10320650c - rustdoc[893abef7f982f8d7]::clean::inline::build_module
  27:        0x103204984 - rustdoc[893abef7f982f8d7]::clean::inline::try_inline
  28:        0x103207374 - rustdoc[893abef7f982f8d7]::clean::inline::build_module_items
  29:        0x10320650c - rustdoc[893abef7f982f8d7]::clean::inline::build_module
  30:        0x103204984 - rustdoc[893abef7f982f8d7]::clean::inline::try_inline
  31:        0x1031d6014 - rustdoc[893abef7f982f8d7]::clean::clean_use_statement_inner
  32:        0x1031cd5dc - rustdoc[893abef7f982f8d7]::clean::clean_doc_module
  33:        0x1031c20f0 - rustdoc[893abef7f982f8d7]::core::run_global_ctxt
  34:        0x103128140 - rustdoc[893abef7f982f8d7]::main_args::{closure#2}::{closure#0}
  35:        0x103120a9c - rustc_interface[2fbe9bdc42826fba]::interface::run_compiler::<(), rustdoc[893abef7f982f8d7]::main_args::{closure#2}>::{closure#1}
  36:        0x103094380 - std[a3189482ba289ff4]::sys::backtrace::__rust_begin_short_backtrace::<rustc_interface[2fbe9bdc42826fba]::util::run_in_thread_with_globals<rustc_interface[2fbe9bdc42826fba]::util::run_in_thread_pool_with_globals<rustc_interface[2fbe9bdc42826fba]::interface::run_compiler<(), rustdoc[893abef7f982f8d7]::main_args::{closure#2}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>
  37:        0x103152a00 - <std[a3189482ba289ff4]::thread::lifecycle::spawn_unchecked<rustc_interface[2fbe9bdc42826fba]::util::run_in_thread_with_globals<rustc_interface[2fbe9bdc42826fba]::util::run_in_thread_pool_with_globals<rustc_interface[2fbe9bdc42826fba]::interface::run_compiler<(), rustdoc[893abef7f982f8d7]::main_args::{closure#2}>::{closure#1}, ()>::{closure#0}, ()>::{closure#0}::{closure#0}, ()>::{closure#1} as core[8ba6287cc279b2b5]::ops::function::FnOnce<()>>::call_once::{shim:vtable#0}
  38:        0x10b91f90c - <std[a3189482ba289ff4]::sys::thread::unix::Thread>::new::thread_start
  39:        0x1864e5c58 - __pthread_cond_wait

error: the compiler unexpectedly panicked. This is a bug

note: we would appreciate a bug report: https://github.com/rust-lang/rust/issues/new?labels=C-bug%2C+I-ICE%2C+T-rustdoc&template=ice.md

note: rustc 1.98.0-beta.1 (6b3fa2674 2026-07-06) running on aarch64-apple-darwin

note: compiler flags: --crate-type lib

note: some of the compiler flags provided by cargo are hidden

query stack during panic:
#0 [attrs_for_def] collecting attributes of `inkwell::llvm_sys`
end of query stack
```

</details>