### PR TITLE
perf: Register used extensions through a special resolver and lazy coalesce versions

### DIFF
--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -478,30 +478,49 @@ class ExtensionVersions:
         """Get all versions of the extension."""
         return frozenset(self._exts.keys())
 
+    def _coalesce_single(self, resolve_on: Version) -> None:
+        compatible_versions = [
+            version
+            for version in self._exts
+            if _same_compatibility_group(version, resolve_on)
+        ]
+        if len(compatible_versions) > 0:
+            latest_compatible = max(compatible_versions)
+            for version in compatible_versions:
+                if version != latest_compatible:
+                    del self._exts[version]
+
+    def coalesce(self) -> None:
+        """Ensures the latest version is up to date and any semver compatible versions
+        are coalesced, with only the latest of that group retained.
+
+        This is done automatically by `add`, but not by `add_lazy`.
+        """
+        self._latest_version = max(self._exts)
+
+        for version in list(self._exts.keys()):
+            # body mutates the dictionary, so check whether the version is still present
+            if version in self._exts:
+                self._coalesce_single(version)
+
     def add(self, extension: Extension) -> None:
         """Add an extension to the set, coalescing compatible older versions."""
         if extension.name != self._id:
             msg = f"Extension {extension.name} has a different name than {self._id}"
             raise ValueError(msg)
 
-        compatible_versions = [
-            version
-            for version in self._exts
-            if _same_compatibility_group(version, extension.version)
-        ]
-        if compatible_versions:
-            latest_compatible = max(compatible_versions)
-            if latest_compatible > extension.version:
-                return
-            for version in compatible_versions:
-                del self._exts[version]
+        self.add_lazy(extension)
+        self._latest_version = max(self._exts)
+        self._coalesce_single(extension.version)
 
+    def add_lazy(self, extension: Extension) -> None:
+        """Add an extension to the set, NOT coalescing compatible older versions.
+        Use `coalesce` to subsequently coalesce all compatible versions.
+        """
+        if extension.name != self._id:
+            msg = f"Extension {extension.name} has a different name than {self._id}"
+            raise ValueError(msg)
         self._exts[extension.version] = extension
-
-        if extension.version > self._latest_version:
-            self._latest_version = extension.version
-        else:
-            self._latest_version = max(self._exts)
 
     def get_compatible(self, version: Version) -> Extension:
         """Get the highest registered extension compatible with ``version``."""
@@ -656,7 +675,7 @@ class UsedExtensionResolver:
     certain extensions are present and unresolved operations are added efficiently.
     """
 
-    _used_extensions: ExtensionRegistry = field(default_factory=ExtensionRegistry)
+    _used_extensions: dict[ExtensionId, ExtensionVersions] = field(default_factory=dict)
     _unresolved_extensions: set[ExtensionId] = field(default_factory=set)
     _unresolved_ops: dict[tuple[tys.ExtensionId, str], ops.Custom] = field(
         default_factory=dict
@@ -666,7 +685,10 @@ class UsedExtensionResolver:
     )
 
     def register(self, extension: Extension) -> None:
-        self._used_extensions.register(extension)
+        if extension.name not in self._used_extensions:
+            self._used_extensions[extension.name] = ExtensionVersions(extension)
+        else:
+            self._used_extensions[extension.name].add_lazy(extension)
 
     def ensure_unresolved(self, ext_id: ExtensionId) -> None:
         self._unresolved_extensions.add(ext_id)
@@ -689,14 +711,17 @@ class UsedExtensionResolver:
         Args:
             result: The result of resolving extensions to add.
         """
-        self._used_extensions.extend(result.used_extensions)
+        for ext in result.used_extensions.all_extensions:
+            self.register(ext)
         self._unresolved_extensions.update(result.unresolved_extensions)
         self._unresolved_ops.update(result.unresolved_ops)
         self._unresolved_types.update(result.unresolved_types)
 
     def result(self) -> ExtensionResolutionResult:
+        for versions in self._used_extensions.values():
+            versions.coalesce()
         return ExtensionResolutionResult(
-            self._used_extensions,
+            ExtensionRegistry(self._used_extensions),
             self._unresolved_extensions,
             self._unresolved_ops,
             self._unresolved_types,

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -21,6 +21,9 @@ __all__ = [
     "OpDef",
     "Extension",
     "Version",
+    "ExtensionRegistry",
+    "ExtensionResolutionResult",
+    "UsedExtensionResolver",
 ]
 
 if TYPE_CHECKING:
@@ -264,9 +267,6 @@ class OpDef(ExtensionObject):
         return ops.ExtOp(self, concrete_signature, list(args or []))
 
 
-T = TypeVar("T", bound=ops.RegisteredOp)
-
-
 @dataclass
 class Extension:
     """HUGR extension declaration."""
@@ -343,17 +343,19 @@ class Extension:
         if registry is not None and self.name not in registry:
             registry.register(self)
 
+        resolver = UsedExtensionResolver()
         result = ExtensionResolutionResult()
         for op_def in self.operations.values():
             poly_func = op_def.signature.poly_func
             if poly_func is None:
                 continue
-            _, sig_result = poly_func._resolve_used_extensions(registry)
-            result.extend(sig_result)
+            poly_func._resolve_used_extensions(resolver, registry)
 
             for lower_func in op_def.lower_funcs:
                 lower_result = lower_func.hugr.used_extensions(registry)
                 result.extend(lower_result)
+
+        result.extend(resolver.result())
 
         return result
 
@@ -424,6 +426,8 @@ class Extension:
         if not isinstance(signature, OpDefSig):
             binary = signature is None
             signature = OpDefSig(signature, binary)
+
+        T = TypeVar("T", bound=ops.RegisteredOp)
 
         def _inner(cls: type[T]) -> type[T]:
             new_description = cls.__doc__ if description is None and cls.__doc__ else ""
@@ -644,6 +648,59 @@ class ExtensionRegistry:
 
     def __contains__(self, name: ExtensionId) -> bool:
         return name in self.versioned_extensions
+
+
+@dataclass
+class UsedExtensionResolver:
+    """A stateful helper class for resolving used extensions, enabling to ensure that
+    certain extensions are present and unresolved operations are added efficiently.
+    """
+
+    _used_extensions: ExtensionRegistry = field(default_factory=ExtensionRegistry)
+    _unresolved_extensions: set[ExtensionId] = field(default_factory=set)
+    _unresolved_ops: dict[tuple[tys.ExtensionId, str], ops.Custom] = field(
+        default_factory=dict
+    )
+    _unresolved_types: dict[tuple[tys.ExtensionId, str], tys.Opaque] = field(
+        default_factory=dict
+    )
+
+    def register(self, extension: Extension) -> None:
+        self._used_extensions.register(extension)
+
+    def ensure_unresolved(self, ext_id: ExtensionId) -> None:
+        self._unresolved_extensions.add(ext_id)
+
+    def ensure_unresolved_op(
+        self, ext_id: ExtensionId, type_id: str, op: ops.Custom
+    ) -> None:
+        if (ext_id, type_id) not in self._unresolved_ops:
+            self._unresolved_ops[(ext_id, type_id)] = op
+
+    def ensure_unresolved_type(
+        self, ext_id: ExtensionId, type_id: str, opaque_type: tys.Opaque
+    ) -> None:
+        if (ext_id, type_id) not in self._unresolved_types:
+            self._unresolved_types[(ext_id, type_id)] = opaque_type
+
+    def extend_with_result(self, result: ExtensionResolutionResult) -> None:
+        """Add the values from another result to this resolver.
+
+        Args:
+            result: The result of resolving extensions to add.
+        """
+        self._used_extensions.extend(result.used_extensions)
+        self._unresolved_extensions.update(result.unresolved_extensions)
+        self._unresolved_ops.update(result.unresolved_ops)
+        self._unresolved_types.update(result.unresolved_types)
+
+    def result(self) -> ExtensionResolutionResult:
+        return ExtensionResolutionResult(
+            self._used_extensions,
+            self._unresolved_extensions,
+            self._unresolved_ops,
+            self._unresolved_types,
+        )
 
 
 @dataclass

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -44,7 +44,6 @@ from hugr.ops import (
 )
 from hugr.tys import Kind, OrderKind, Type, ValueKind
 from hugr.utils import BiMap
-from hugr.val import Value
 
 from .node_port import (
     Direction,
@@ -1258,21 +1257,19 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             >>> Dfg(tys.Qubit).hugr.used_extensions().ids()
             {'prelude'}
         """
-        from hugr.ext import ExtensionResolutionResult
+        from hugr.ext import UsedExtensionResolver
         from hugr.std import _std_extensions
 
         if resolve_from is not None:
             resolve_from.extend(_std_extensions())
 
-        result = ExtensionResolutionResult()
+        resolver = UsedExtensionResolver()
 
         for node in self:
             op = self[node].op
-            # _resolve_used_extensions returns the resolved op and the extensions
-            resolved_op, op_result = op._resolve_used_extensions(resolve_from)
-            self[node].op = resolved_op
-            result.extend(op_result)
+            self[node].op = op._resolve_used_extensions(resolver, resolve_from)
 
+        result = resolver.result()
         result._extend_with_transitive_ops(resolve_from)
 
         return result

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -29,7 +29,11 @@ if TYPE_CHECKING:
 
     from hugr import ext
     from hugr._serialization.ops import BaseOp
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult, UsedExtensionResolver
+    from hugr.ext import (
+        ExtensionRegistry,
+        ExtensionResolutionResult,
+        UsedExtensionResolver,
+    )
     from hugr.tys import Visibility
 
 

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -19,6 +19,7 @@ from typing_extensions import Self
 import hugr._serialization.ops as sops
 import hugr._serialization.tys as stys
 from hugr import tys, val
+from hugr.ext import UsedExtensionResolver
 from hugr.hugr.node_port import Direction, InPort, Node, OutPort, PortOffset, Wire
 from hugr.utils import comma_sep_repr, comma_sep_str, ser_it
 
@@ -84,14 +85,15 @@ class Op(Protocol):
         return str(self)
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
         """Resolve the extensions required to define this operation.
 
         Does not include transitive dependencies required by the returned
         extension definitions, to avoid infinite recursion.
 
         Args:
+            resolver: The resolver to report used extensions to.
             registry: A registry to resolve unresolved extensions from.
 
         Returns:
@@ -99,9 +101,7 @@ class Op(Protocol):
             - A result type with both resolved and unresolved extensions
               referenced by the operation.
         """
-        from hugr.ext import ExtensionResolutionResult
-
-        return (self, ExtensionResolutionResult())
+        return self
 
     def used_extensions(
         self, resolve_from: ExtensionRegistry | None = None
@@ -119,7 +119,9 @@ class Op(Protocol):
         Returns:
             The result containing used and unresolved extensions.
         """
-        _, result = self._resolve_used_extensions(resolve_from)
+        resolver = UsedExtensionResolver()
+        _ = self._resolve_used_extensions(resolver, resolve_from)
+        result = resolver.result()
         result._extend_with_transitive_ops(resolve_from)
         return result
 
@@ -302,10 +304,10 @@ class Input(DataflowOp):
         return "Input"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        result = tys._resolve_typerow_exts_inplace(self.types, registry)
-        return (self, result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        tys._resolve_typerow_exts_inplace(self.types, resolver, registry)
+        return self
 
 
 @dataclass()
@@ -346,15 +348,12 @@ class Output(DataflowOp, _PartialOp):
         return "Output"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
         if self._types is None:
-            return (self, ExtensionResolutionResult())
-
-        result = tys._resolve_typerow_exts_inplace(self._types, registry)
-        return (self, result)
+            return self
+        tys._resolve_typerow_exts_inplace(self._types, resolver, registry)
+        return self
 
 
 @runtime_checkable
@@ -453,10 +452,10 @@ class AsExtOp(DataflowOp, Protocol):
         return f"{name}<{comma_sep_str(self.type_args())}>"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        _, result = self.ext_op._resolve_used_extensions(registry)
-        return (self, result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        _ = self.ext_op._resolve_used_extensions(resolver, registry)
+        return self
 
 
 @dataclass(frozen=True, eq=False)
@@ -498,14 +497,14 @@ class Custom(DataflowOp):
 
         If extension or operation is not found, returns itself.
         """
-        op, _ = self._resolve_used_extensions(registry)
+        op = self._resolve_used_extensions(UsedExtensionResolver(), registry)
         assert isinstance(op, ExtOp | Custom)
         return op
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        from hugr.ext import Extension, ExtensionRegistry, ExtensionResolutionResult
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        from hugr.ext import Extension, ExtensionRegistry
 
         if registry is not None:
             try:
@@ -519,21 +518,14 @@ class Custom(DataflowOp):
                 pass
             else:
                 op = ExtOp(op_def, self.signature, self.args)
-                return op._resolve_used_extensions(registry)
+                return op._resolve_used_extensions(resolver, registry)
 
         # Could not resolve to an ExtOp - return self with unresolved extension
-        result = ExtensionResolutionResult()
-
-        signature, sig_result = self.signature._resolve_used_extensions(registry)
+        signature = self.signature._resolve_used_extensions(resolver, registry)
         assert isinstance(signature, tys.FunctionType)
-        result.extend(sig_result)
-
-        new_args: list[tys.TypeArg] = []
-        for arg in self.args:
-            resolved_arg, arg_result = arg._resolve_used_extensions(registry)
-            new_args.append(resolved_arg)
-            result.extend(arg_result)
-
+        new_args = [
+            arg._resolve_used_extensions(resolver, registry) for arg in self.args
+        ]
         new_op = Custom(
             self.op_name,
             signature,
@@ -542,11 +534,10 @@ class Custom(DataflowOp):
             self.extension_version,
         )
 
-        result.unresolved_extensions.add(self.extension)
-        if (self.extension, self.op_name) not in result.unresolved_ops:
-            result.unresolved_ops[(self.extension, self.op_name)] = new_op
+        resolver.ensure_unresolved(self.extension)
+        resolver.ensure_unresolved_op(self.extension, self.op_name, new_op)
 
-        return (new_op, result)
+        return new_op
 
     def name(self) -> str:
         return f"Custom({self.op_name})"
@@ -610,35 +601,28 @@ class ExtOp(AsExtOp):
         return poly_func.body
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        result.used_extensions.register(self._op_def.get_extension())
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        resolver.register(self._op_def.get_extension())
 
         # Signature
         new_signature: tys.FunctionType | None = self.signature
         if self.signature is not None:
-            resolved_sig, sig_result = self.signature._resolve_used_extensions(registry)
+            resolved_sig = self.signature._resolve_used_extensions(resolver, registry)
             assert isinstance(
                 resolved_sig, tys.FunctionType
             ), "HUGR internal error, expected resolved signature to be function type."
             new_signature = resolved_sig
-            result.extend(sig_result)
         else:
             # Get extensions from the default signature in the OpDef
-            _, sig_result = self.outer_signature()._resolve_used_extensions(registry)
-            result.extend(sig_result)
+            _ = self.outer_signature()._resolve_used_extensions(resolver, registry)
 
         # Args
-        new_args: list[tys.TypeArg] = []
-        for arg in self.args:
-            resolved_arg, arg_result = arg._resolve_used_extensions(registry)
-            new_args.append(resolved_arg)
-            result.extend(arg_result)
+        new_args = [
+            arg._resolve_used_extensions(resolver, registry) for arg in self.args
+        ]
 
-        return (ExtOp(self._op_def, new_signature, new_args), result)
+        return ExtOp(self._op_def, new_signature, new_args)
 
 
 class RegisteredOp(AsExtOp):
@@ -701,17 +685,15 @@ class MakeTuple(AsExtOp, _PartialOp):
         return "MakeTuple"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
         from hugr import std
-        from hugr.ext import ExtensionResolutionResult
 
-        result = ExtensionResolutionResult()
-        result.used_extensions.register(std.PRELUDE)
+        resolver.register(std.PRELUDE)
         if self._types is not None:
-            result.extend(tys._resolve_typerow_exts_inplace(self._types, registry))
+            tys._resolve_typerow_exts_inplace(self._types, resolver, registry)
 
-        return (self, result)
+        return self
 
 
 @dataclass()
@@ -769,17 +751,15 @@ class UnpackTuple(AsExtOp, _PartialOp):
         return "UnpackTuple"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
         from hugr import std
-        from hugr.ext import ExtensionResolutionResult
 
-        result = ExtensionResolutionResult()
-        result.used_extensions.register(std.PRELUDE)
+        resolver.register(std.PRELUDE)
         if self._types is not None:
-            result.extend(tys._resolve_typerow_exts_inplace(self._types, registry))
+            tys._resolve_typerow_exts_inplace(self._types, resolver, registry)
 
-        return (self, result)
+        return self
 
 
 @dataclass(frozen=True)
@@ -810,11 +790,11 @@ class Tag(DataflowOp):
         )
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        sum_ty, result = self.sum_ty._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        sum_ty = self.sum_ty._resolve_used_extensions(resolver, registry)
         assert isinstance(sum_ty, tys.Sum)
-        return (Tag(self.tag, sum_ty), result)
+        return Tag(self.tag, sum_ty)
 
     def __repr__(self) -> str:
         if len(self.sum_ty.variant_rows) == 2:
@@ -970,12 +950,12 @@ class DFG(DfParentOp, DataflowOp):
         return "DFG"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        result = tys._resolve_typerow_exts_inplace(self.inputs, registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        tys._resolve_typerow_exts_inplace(self.inputs, resolver, registry)
         if self._outputs is not None:
-            result.extend(tys._resolve_typerow_exts_inplace(self._outputs, registry))
-        return (self, result)
+            tys._resolve_typerow_exts_inplace(self._outputs, resolver, registry)
+        return self
 
 
 @dataclass()
@@ -1024,12 +1004,12 @@ class CFG(DataflowOp):
         return self.inputs
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        result = tys._resolve_typerow_exts_inplace(self.inputs, registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        tys._resolve_typerow_exts_inplace(self.inputs, resolver, registry)
         if self._outputs is not None:
-            result.extend(tys._resolve_typerow_exts_inplace(self._outputs, registry))
-        return (self, result)
+            tys._resolve_typerow_exts_inplace(self._outputs, resolver, registry)
+        return self
 
 
 @dataclass
@@ -1100,20 +1080,19 @@ class DataflowBlock(DfParentOp):
         return "DataflowBlock"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        result = tys._resolve_typerow_exts_inplace(self.inputs, registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        tys._resolve_typerow_exts_inplace(self.inputs, resolver, registry)
         if self._sum is not None:
-            resolved_sum, sum_result = self._sum._resolve_used_extensions(registry)
+            resolved_sum = self._sum._resolve_used_extensions(resolver, registry)
             assert isinstance(
                 resolved_sum, tys.Sum
             ), "HUGR internal error, expected resolved type to be sum."
             self._sum = resolved_sum
-            result.extend(sum_result)
         if self._other_outputs is not None:
             other_out = self._other_outputs
-            result.extend(tys._resolve_typerow_exts_inplace(other_out, registry))
-        return (self, result)
+            tys._resolve_typerow_exts_inplace(other_out, resolver, registry)
+        return self
 
 
 @dataclass
@@ -1145,16 +1124,11 @@ class ExitBlock(Op):
         return "ExitBlock"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
         if self._cfg_outputs is not None:
-            result.extend(
-                tys._resolve_typerow_exts_inplace(self._cfg_outputs, registry)
-            )
-        return (self, result)
+            tys._resolve_typerow_exts_inplace(self._cfg_outputs, resolver, registry)
+        return self
 
 
 @dataclass
@@ -1183,10 +1157,10 @@ class Const(Op):
         return f"Const({self.val})"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        result = self.val._resolve_used_extensions_inplace(registry)
-        return (self, result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        self.val._resolve_used_extensions_inplace(resolver, registry)
+        return self
 
 
 @dataclass
@@ -1231,16 +1205,11 @@ class LoadConst(DataflowOp):
         return "LoadConst"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        typ: tys.Type | None = None
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
         if self._typ is not None:
-            typ, result = self._typ._resolve_used_extensions(registry)
-            self._typ = typ
-        return (self, result)
+            self._typ = self._typ._resolve_used_extensions(resolver, registry)
+        return self
 
 
 @dataclass()
@@ -1302,18 +1271,18 @@ class Conditional(DataflowOp):
         return [self.sum_ty, *self.other_inputs]
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        resolved_sum, result = self.sum_ty._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        resolved_sum = self.sum_ty._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_sum, tys.Sum
         ), "HUGR internal error, expected resolved type to be sum."
         self.sum_ty = resolved_sum
 
-        result.extend(tys._resolve_typerow_exts_inplace(self.other_inputs, registry))
+        tys._resolve_typerow_exts_inplace(self.other_inputs, resolver, registry)
         if self._outputs is not None:
-            result.extend(tys._resolve_typerow_exts_inplace(self._outputs, registry))
-        return (self, result)
+            tys._resolve_typerow_exts_inplace(self._outputs, resolver, registry)
+        return self
 
 
 @dataclass
@@ -1355,12 +1324,12 @@ class Case(DfParentOp):
         return "Case"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        result = tys._resolve_typerow_exts_inplace(self.inputs, registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        tys._resolve_typerow_exts_inplace(self.inputs, resolver, registry)
         if self._outputs is not None:
-            result.extend(tys._resolve_typerow_exts_inplace(self._outputs, registry))
-        return (self, result)
+            tys._resolve_typerow_exts_inplace(self._outputs, resolver, registry)
+        return self
 
 
 @dataclass
@@ -1419,17 +1388,13 @@ class TailLoop(DfParentOp, DataflowOp):
         return "TailLoop"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        result.extend(tys._resolve_typerow_exts_inplace(self.just_inputs, registry))
-        result.extend(tys._resolve_typerow_exts_inplace(self.rest, registry))
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        tys._resolve_typerow_exts_inplace(self.just_inputs, resolver, registry)
+        tys._resolve_typerow_exts_inplace(self.rest, resolver, registry)
         if self._just_outputs is not None:
-            out_result = tys._resolve_typerow_exts_inplace(self._just_outputs, registry)
-            result.extend(out_result)
-        return (self, result)
+            tys._resolve_typerow_exts_inplace(self._just_outputs, resolver, registry)
+        return self
 
 
 @dataclass
@@ -1497,15 +1462,14 @@ class FuncDefn(DfParentOp):
         return f"FuncDefn({self.f_name})"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        result = tys._resolve_typerow_exts_inplace(self.inputs, registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        tys._resolve_typerow_exts_inplace(self.inputs, resolver, registry)
         for i, param in enumerate(self.params):
-            self.params[i], param_result = param._resolve_used_extensions(registry)
-            result.extend(param_result)
+            self.params[i] = param._resolve_used_extensions(resolver, registry)
         if self._outputs is not None:
-            result.extend(tys._resolve_typerow_exts_inplace(self._outputs, registry))
-        return (self, result)
+            tys._resolve_typerow_exts_inplace(self._outputs, resolver, registry)
+        return self
 
 
 @dataclass
@@ -1539,14 +1503,14 @@ class FuncDecl(Op):
         return f"FuncDecl({self.f_name})"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        resolved_sig, result = self.signature._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        resolved_sig = self.signature._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_sig, tys.PolyFuncType
         ), "HUGR internal error, expected resolved signature to be poly function type."
         self.signature = resolved_sig
-        return (self, result)
+        return self
 
 
 @dataclass
@@ -1604,28 +1568,23 @@ class _CallOrLoad:
             self.type_args = list(type_args)
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Self, ExtensionResolutionResult]:
-        resolved_sig, result = self.signature._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Self:
+        resolved_sig = self.signature._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_sig, tys.PolyFuncType
         ), "HUGR internal error, expected resolved signature to be poly function type."
         self.signature = resolved_sig  # type: ignore[attr-defined]
 
-        resolved_inst, inst_result = self.instantiation._resolve_used_extensions(
-            registry
-        )
+        resolved_inst = self.instantiation._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_inst, tys.FunctionType
         ), "HUGR internal error, expected resolved instantiation to be function type."
         self.instantiation = resolved_inst
-        result.extend(inst_result)
 
         for i, arg in enumerate(self.type_args):
-            resolved_arg, arg_result = arg._resolve_used_extensions(registry)
-            self.type_args[i] = resolved_arg
-            result.extend(arg_result)
-        return (self, result)
+            self.type_args[i] = arg._resolve_used_extensions(resolver, registry)
+        return self
 
 
 class Call(_CallOrLoad, DataflowOp):
@@ -1724,18 +1683,16 @@ class CallIndirect(DataflowOp, _PartialOp):
         return "CallIndirect"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
         if self._signature is None:
-            return (self, ExtensionResolutionResult())
-        resolved_sig, result = self._signature._resolve_used_extensions(registry)
+            return self
+        resolved_sig = self._signature._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_sig, tys.FunctionType
         ), "HUGR internal error, expected resolved signature to be function type."
         self._signature = resolved_sig
-        return (self, result)
+        return self
 
 
 class LoadFunc(_CallOrLoad, DataflowOp):
@@ -1870,7 +1827,7 @@ class AliasDefn(Op):
         return f"AliasDefn({self.alias})"
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Op, ExtensionResolutionResult]:
-        self.definition, result = self.definition._resolve_used_extensions(registry)
-        return (self, result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Op:
+        self.definition = self.definition._resolve_used_extensions(resolver, registry)
+        return self

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -19,7 +19,6 @@ from typing_extensions import Self
 import hugr._serialization.ops as sops
 import hugr._serialization.tys as stys
 from hugr import tys, val
-from hugr.ext import UsedExtensionResolver
 from hugr.hugr.node_port import Direction, InPort, Node, OutPort, PortOffset, Wire
 from hugr.utils import comma_sep_repr, comma_sep_str, ser_it
 
@@ -30,7 +29,7 @@ if TYPE_CHECKING:
 
     from hugr import ext
     from hugr._serialization.ops import BaseOp
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
+    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult, UsedExtensionResolver
     from hugr.tys import Visibility
 
 
@@ -119,6 +118,8 @@ class Op(Protocol):
         Returns:
             The result containing used and unresolved extensions.
         """
+        from hugr.ext import UsedExtensionResolver
+
         resolver = UsedExtensionResolver()
         _ = self._resolve_used_extensions(resolver, resolve_from)
         result = resolver.result()
@@ -497,6 +498,8 @@ class Custom(DataflowOp):
 
         If extension or operation is not found, returns itself.
         """
+        from hugr.ext import UsedExtensionResolver
+
         op = self._resolve_used_extensions(UsedExtensionResolver(), registry)
         assert isinstance(op, ExtOp | Custom)
         return op

--- a/hugr-py/src/hugr/ops.py
+++ b/hugr-py/src/hugr/ops.py
@@ -101,8 +101,6 @@ class Op(Protocol):
 
         Returns:
             - The resolved operation
-            - A result type with both resolved and unresolved extensions
-              referenced by the operation.
         """
         return self
 

--- a/hugr-py/src/hugr/std/collections/array.py
+++ b/hugr-py/src/hugr/std/collections/array.py
@@ -11,7 +11,7 @@ from hugr.std._util import _load_extension
 from hugr.utils import comma_sep_str
 
 if TYPE_CHECKING:
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
+    from hugr.ext import ExtensionRegistry, UsedExtensionResolver
 
 EXTENSION = _load_extension("collections.array")
 
@@ -60,9 +60,9 @@ class Array(tys.ExtType):
         return tys.TypeBound.Linear
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Array, ExtensionResolutionResult]:
-        ext_type, result = super()._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Array:
+        ext_type = super()._resolve_used_extensions(resolver, registry)
 
         assert isinstance(
             ext_type, tys.ExtType
@@ -73,7 +73,7 @@ class Array(tys.ExtType):
 
         array = Array(tys.Unit, 0)
         array.args = ext_type.args
-        return array, result
+        return array
 
 
 @dataclass
@@ -110,9 +110,9 @@ class ArrayVal(val.ExtensionValue):
         )
 
     def _resolve_used_extensions_inplace(
-        self, registry: ExtensionRegistry | None = None
-    ) -> ExtensionResolutionResult:
-        resolved_ty, result = self.ty._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
+        resolved_ty = self.ty._resolve_used_extensions(resolver, registry)
 
         assert isinstance(
             resolved_ty, Array
@@ -120,5 +120,4 @@ class ArrayVal(val.ExtensionValue):
 
         self.ty = resolved_ty
         for value in self.v:
-            result.extend(value._resolve_used_extensions_inplace(registry))
-        return result
+            value._resolve_used_extensions_inplace(resolver, registry)

--- a/hugr-py/src/hugr/std/collections/borrow_array.py
+++ b/hugr-py/src/hugr/std/collections/borrow_array.py
@@ -11,7 +11,7 @@ from hugr.std._util import _load_extension
 from hugr.utils import comma_sep_str
 
 if TYPE_CHECKING:
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
+    from hugr.ext import ExtensionRegistry, UsedExtensionResolver
 
 EXTENSION = _load_extension("collections.borrow_arr")
 
@@ -62,9 +62,9 @@ class BorrowArray(tys.ExtType):
         return tys.TypeBound.Linear
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[BorrowArray, ExtensionResolutionResult]:
-        ext_type, result = super()._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> BorrowArray:
+        ext_type = super()._resolve_used_extensions(resolver, registry)
 
         assert isinstance(
             ext_type, tys.ExtType
@@ -75,7 +75,7 @@ class BorrowArray(tys.ExtType):
 
         borrow_array = BorrowArray(tys.Unit, 0)
         borrow_array.args = ext_type.args
-        return borrow_array, result
+        return borrow_array
 
 
 # Note that only borrow array values with no elements borrowed should be emitted.
@@ -113,13 +113,12 @@ class BorrowArrayVal(val.ExtensionValue):
         )
 
     def _resolve_used_extensions_inplace(
-        self, registry: ExtensionRegistry | None = None
-    ) -> ExtensionResolutionResult:
-        resolved_ty, result = self.ty._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
+        resolved_ty = self.ty._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_ty, BorrowArray
         ), "HUGR internal error, expected resolved type to be borrow array."
         self.ty = resolved_ty
         for value in self.v:
-            result.extend(value._resolve_used_extensions_inplace(registry))
-        return result
+            value._resolve_used_extensions_inplace(resolver, registry)

--- a/hugr-py/src/hugr/std/collections/list.py
+++ b/hugr-py/src/hugr/std/collections/list.py
@@ -11,7 +11,7 @@ from hugr.std._util import _load_extension
 from hugr.utils import comma_sep_str
 
 if TYPE_CHECKING:
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
+    from hugr.ext import ExtensionRegistry, UsedExtensionResolver
 
 EXTENSION = _load_extension("collections.list")
 
@@ -38,9 +38,9 @@ class List(tys.ExtType):
         return self.ty.type_bound()
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[List, ExtensionResolutionResult]:
-        ext_type, result = super()._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> List:
+        ext_type = super()._resolve_used_extensions(resolver, registry)
 
         assert isinstance(
             ext_type, tys.ExtType
@@ -51,7 +51,7 @@ class List(tys.ExtType):
 
         list = List(tys.Unit)
         list.args = ext_type.args
-        return list, result
+        return list
 
 
 @dataclass
@@ -78,13 +78,12 @@ class ListVal(val.ExtensionValue):
         return f"[{comma_sep_str(self.v)}]"
 
     def _resolve_used_extensions_inplace(
-        self, registry: ExtensionRegistry | None = None
-    ) -> ExtensionResolutionResult:
-        resolved_ty, result = self.ty._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
+        resolved_ty = self.ty._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_ty, List
         ), "HUGR internal error, expected resolved type to be list."
         self.ty = resolved_ty
         for value in self.v:
-            result.extend(value._resolve_used_extensions_inplace(registry))
-        return result
+            value._resolve_used_extensions_inplace(resolver, registry)

--- a/hugr-py/src/hugr/std/collections/static_array.py
+++ b/hugr-py/src/hugr/std/collections/static_array.py
@@ -10,7 +10,7 @@ from hugr.std._util import _load_extension
 from hugr.utils import comma_sep_str
 
 if TYPE_CHECKING:
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
+    from hugr.ext import ExtensionRegistry, UsedExtensionResolver
 
 EXTENSION = _load_extension("collections.static_array")
 
@@ -40,9 +40,9 @@ class StaticArray(tys.ExtType):
         return self.ty.type_bound()
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[StaticArray, ExtensionResolutionResult]:
-        ext_type, result = super()._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> StaticArray:
+        ext_type = super()._resolve_used_extensions(resolver, registry)
 
         assert isinstance(
             ext_type, tys.ExtType
@@ -53,7 +53,7 @@ class StaticArray(tys.ExtType):
 
         static_array = StaticArray(tys.Unit)
         static_array.args = ext_type.args
-        return static_array, result
+        return static_array
 
 
 @dataclass
@@ -86,13 +86,12 @@ class StaticArrayVal(val.ExtensionValue):
         return f"static_array({comma_sep_str(self.v)})"
 
     def _resolve_used_extensions_inplace(
-        self, registry: ExtensionRegistry | None = None
-    ) -> ExtensionResolutionResult:
-        resolved_ty, result = self.ty._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
+        resolved_ty = self.ty._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_ty, StaticArray
         ), "HUGR internal error, expected resolved type to be static array."
         self.ty = resolved_ty
         for value in self.v:
-            result.extend(value._resolve_used_extensions_inplace(registry))
-        return result
+            value._resolve_used_extensions_inplace(resolver, registry)

--- a/hugr-py/src/hugr/std/float.py
+++ b/hugr-py/src/hugr/std/float.py
@@ -31,11 +31,11 @@ class FloatVal(val.ExtensionValue):
         return f"{self.v}"
 
     def _resolve_used_extensions_inplace(
-        self, registry: ext.ExtensionRegistry | None = None
-    ) -> ext.ExtensionResolutionResult:
-        result = ext.ExtensionResolutionResult()
-        result.used_extensions.register(FLOAT_TYPES_EXTENSION)
-        return result
+        self,
+        resolver: ext.UsedExtensionResolver,
+        registry: ext.ExtensionRegistry | None = None,
+    ) -> None:
+        resolver.register(FLOAT_TYPES_EXTENSION)
 
     def to_model(self) -> model.Term:
         return model.Apply("arithmetic.float.const_f64", [model.Literal(self.v)])

--- a/hugr-py/src/hugr/std/int.py
+++ b/hugr-py/src/hugr/std/int.py
@@ -13,6 +13,7 @@ from hugr.ops import AsExtOp, DataflowOp, ExtOp, RegisteredOp
 from hugr.std._util import _load_extension
 
 if TYPE_CHECKING:
+    from hugr.ext import UsedExtensionResolver
     from hugr.ops import Command, ComWire
 
 CONVERSIONS_EXTENSION = _load_extension("arithmetic.conversions")
@@ -95,11 +96,11 @@ class IntVal(val.ExtensionValue):
         return f"{self.v}"
 
     def _resolve_used_extensions_inplace(
-        self, registry: ext.ExtensionRegistry | None = None
-    ) -> ext.ExtensionResolutionResult:
-        result = ext.ExtensionResolutionResult()
-        result.used_extensions.register(INT_TYPES_EXTENSION)
-        return result
+        self,
+        resolver: UsedExtensionResolver,
+        registry: ext.ExtensionRegistry | None = None,
+    ) -> None:
+        resolver.register(INT_TYPES_EXTENSION)
 
     def to_model(self) -> model.Term:
         unsigned = _to_unsigned(self.v, 1 << self.width)

--- a/hugr-py/src/hugr/std/ptr.py
+++ b/hugr-py/src/hugr/std/ptr.py
@@ -9,7 +9,7 @@ from hugr import tys
 from hugr.std._util import _load_extension
 
 if TYPE_CHECKING:
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
+    from hugr.ext import ExtensionRegistry, UsedExtensionResolver
 
 EXTENSION = _load_extension("ptr")
 
@@ -35,9 +35,9 @@ class Ptr(tys.ExtType):
         return self.args[0].ty
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Ptr, ExtensionResolutionResult]:
-        ext_type, result = super()._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Ptr:
+        ext_type = super()._resolve_used_extensions(resolver, registry)
 
         assert isinstance(
             ext_type, tys.ExtType
@@ -48,4 +48,4 @@ class Ptr(tys.ExtType):
 
         ptr = Ptr(tys.Unit)
         ptr.args = ext_type.args
-        return ptr, result
+        return ptr

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -182,6 +182,7 @@ def _resolve_typerow_exts_inplace(
             If None, opaque types will not be resolved.
 
     Example:
+        >>> from hugr.ext import UsedExtensionResolver
         >>> _resolver = UsedExtensionResolver()
         >>> _resolve_typerow_exts_inplace([Qubit, USize()], _resolver)
         >>> _resolver.result().ids()

--- a/hugr-py/src/hugr/tys.py
+++ b/hugr-py/src/hugr/tys.py
@@ -24,8 +24,7 @@ if TYPE_CHECKING:
     from semver import Version
 
     from hugr import ext
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
-
+    from hugr.ext import ExtensionRegistry, UsedExtensionResolver
 
 ExtensionId = stys.ExtensionId
 ExtensionSet = stys.ExtensionSet
@@ -49,20 +48,19 @@ class TypeParam(Protocol):
         raise NotImplementedError(self)
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeParam, ExtensionResolutionResult]:
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeParam:
         """Resolve the extensions required to define this type parameter.
 
         Args:
+            resolver: The resolver to track used and unresolved extensions.
             registry: A registry to resolve unresolved extensions from.
                 If None, opaque types will not be resolved.
 
         Returns:
-            A tuple of the resolved type parameter and the resolution result.
+            The resolved type parameter.
         """
-        from hugr.ext import ExtensionResolutionResult
-
-        return (self, ExtensionResolutionResult())
+        return self
 
 
 @runtime_checkable
@@ -79,28 +77,28 @@ class TypeArg(Protocol):
     @deprecated("Call `used_extensions` on the hugr instead.")
     def resolve(self, registry: ext.ExtensionRegistry) -> TypeArg:
         """Resolve types in the argument using the given registry."""
-        resolved, _ = self._resolve_used_extensions(registry)
-        return resolved
+        from hugr.ext import UsedExtensionResolver
+
+        return self._resolve_used_extensions(UsedExtensionResolver(), registry)
 
     def to_model(self) -> model.Term | model.Splice:
         """Convert the type argument to a model Term."""
         raise NotImplementedError(self)
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeArg, ExtensionResolutionResult]:
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeArg:
         """Resolve the extensions required to define this type argument.
 
         Args:
+            resolver: The resolver to track used and unresolved extensions.
             registry: A registry to resolve unresolved extensions from.
                 If None, opaque types will not be resolved.
 
         Returns:
-            A tuple of the resolved type argument and the resolution result.
+            The resolved type argument.
         """
-        from hugr.ext import ExtensionResolutionResult
-
-        return (self, ExtensionResolutionResult())
+        return self
 
 
 @runtime_checkable
@@ -137,31 +135,31 @@ class Type(Protocol):
     @deprecated("Call `used_extensions` on the hugr instead.")
     def resolve(self, registry: ext.ExtensionRegistry) -> Type:
         """Resolve types in the type using the given registry."""
-        resolved, _ = self._resolve_used_extensions(registry)
-        return resolved
+        from hugr.ext import UsedExtensionResolver
+
+        return self._resolve_used_extensions(UsedExtensionResolver(), registry)
 
     def to_model(self) -> model.Term | model.Splice:
         """Convert the type to a model Term."""
         raise NotImplementedError(self)
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Type, ExtensionResolutionResult]:
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Type:
         """Resolve the extensions required to define this type.
 
         Does not include transitive dependencies required by the returned
         extension definitions, to avoid infinite recursion.
 
         Args:
+            resolver: The resolver to track used and unresolved extensions.
             registry: A registry to resolve unresolved extensions from.
                 If None, opaque types will not be resolved.
 
         Returns:
-            A tuple of the resolved type and the resolution result.
+            The resolved type.
         """
-        from hugr.ext import ExtensionResolutionResult
-
-        return (self, ExtensionResolutionResult())
+        return self
 
 
 #: Row of types.
@@ -169,29 +167,28 @@ TypeRow = list[Type]
 
 
 def _resolve_typerow_exts_inplace(
-    row: TypeRow, registry: ExtensionRegistry | None = None
-) -> ExtensionResolutionResult:
+    row: TypeRow,
+    resolver: UsedExtensionResolver,
+    registry: ExtensionRegistry | None = None,
+) -> None:
     """Resolve the extensions required to define a row of types.
 
     Modifies the row in-place to resolve opaque types.
 
     Args:
         row: The row of types.
+        resolver: The resolver to track used and unresolved extensions.
         registry: A registry to resolve unresolved extensions from.
             If None, opaque types will not be resolved.
 
     Example:
-        >>> _resolve_typerow_exts_inplace([Qubit, USize()]).ids()
+        >>> _resolver = UsedExtensionResolver()
+        >>> _resolve_typerow_exts_inplace([Qubit, USize()], _resolver)
+        >>> _resolver.result().ids()
         {'prelude'}
     """
-    from hugr.ext import ExtensionResolutionResult
-
-    result = ExtensionResolutionResult()
     for i, ty in enumerate(row):
-        resolved_ty, ty_result = ty._resolve_used_extensions(registry)
-        row[i] = resolved_ty
-        result.extend(ty_result)
-    return result
+        row[i] = ty._resolve_used_extensions(resolver, registry)
 
 
 # --------------------------------------------
@@ -294,10 +291,9 @@ class ListParam(TypeParam):
         return model.Apply("core.list", [item_type])
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeParam, ExtensionResolutionResult]:
-        resolved_param, result = self.param._resolve_used_extensions(registry)
-        return (ListParam(resolved_param), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeParam:
+        return ListParam(self.param._resolve_used_extensions(resolver, registry))
 
 
 @dataclass(frozen=True)
@@ -317,17 +313,14 @@ class TupleParam(TypeParam):
         return model.Apply("core.tuple", [item_types])
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeParam, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        new_params = []
-        for param in self.params:
-            resolved_param, param_result = param._resolve_used_extensions(registry)
-            new_params.append(resolved_param)
-            result.extend(param_result)
-        return (TupleParam(new_params), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeParam:
+        return TupleParam(
+            [
+                param._resolve_used_extensions(resolver, registry)
+                for param in self.params
+            ]
+        )
 
 
 @dataclass(frozen=True)
@@ -347,10 +340,9 @@ class ConstParam(TypeParam):
         return model.Apply("core.const", [ty])
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeParam, ExtensionResolutionResult]:
-        resolved_ty, result = self.ty._resolve_used_extensions(registry)
-        return (ConstParam(resolved_ty), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeParam:
+        return ConstParam(self.ty._resolve_used_extensions(resolver, registry))
 
 
 # ------------------------------------------
@@ -374,10 +366,10 @@ class TypeTypeArg(TypeArg):
         return self.ty.to_model()
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeArg, ExtensionResolutionResult]:
-        resolved_ty, result = self.ty._resolve_used_extensions(registry)
-        return (TypeTypeArg(resolved_ty), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeArg:
+        resolved_ty = self.ty._resolve_used_extensions(resolver, registry)
+        return TypeTypeArg(resolved_ty)
 
 
 @dataclass(frozen=True)
@@ -461,17 +453,11 @@ class ListArg(TypeArg):
         return model.List([elem.to_model() for elem in self.elems])
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeArg, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        new_elems = []
-        for elem in self.elems:
-            resolved_elem, elem_result = elem._resolve_used_extensions(registry)
-            new_elems.append(resolved_elem)
-            result.extend(elem_result)
-        return (ListArg(new_elems), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeArg:
+        return ListArg(
+            [elem._resolve_used_extensions(resolver, registry) for elem in self.elems]
+        )
 
 
 @dataclass(frozen=True)
@@ -502,17 +488,11 @@ class ListConcatArg(TypeArg):
                 return self
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeArg, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        new_lists = []
-        for elem in self.lists:
-            resolved_elem, elem_result = elem._resolve_used_extensions(registry)
-            new_lists.append(resolved_elem)
-            result.extend(elem_result)
-        return (ListConcatArg(new_lists), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeArg:
+        return ListConcatArg(
+            [elem._resolve_used_extensions(resolver, registry) for elem in self.lists]
+        )
 
 
 @dataclass(frozen=True)
@@ -531,17 +511,11 @@ class TupleArg(TypeArg):
         return model.Tuple([elem.to_model() for elem in self.elems])
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeArg, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        new_elems = []
-        for elem in self.elems:
-            resolved_elem, elem_result = elem._resolve_used_extensions(registry)
-            new_elems.append(resolved_elem)
-            result.extend(elem_result)
-        return (TupleArg(new_elems), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeArg:
+        return TupleArg(
+            [elem._resolve_used_extensions(resolver, registry) for elem in self.elems]
+        )
 
 
 @dataclass(frozen=True)
@@ -572,17 +546,11 @@ class TupleConcatArg(TypeArg):
                 return self
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeArg, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        new_tuples = []
-        for tup in self.tuples:
-            resolved_tup, tup_result = tup._resolve_used_extensions(registry)
-            new_tuples.append(resolved_tup)
-            result.extend(tup_result)
-        return (TupleConcatArg(new_tuples), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeArg:
+        return TupleConcatArg(
+            [tup._resolve_used_extensions(resolver, registry) for tup in self.tuples]
+        )
 
 
 @dataclass(frozen=True)
@@ -602,10 +570,10 @@ class VariableArg(TypeArg):
         return model.Var(f"_{self.idx}")
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[TypeArg, ExtensionResolutionResult]:
-        resolved_param, result = self.param._resolve_used_extensions(registry)
-        return (VariableArg(self.idx, resolved_param), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> TypeArg:
+        resolved_param = self.param._resolve_used_extensions(resolver, registry)
+        return VariableArg(self.idx, resolved_param)
 
 
 # ----------------------------------------------
@@ -678,14 +646,11 @@ class Sum(Type):
         return model.Apply("core.adt", [variants])
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Type, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Type:
         for row in self.variant_rows:
-            result.extend(_resolve_typerow_exts_inplace(row, registry))
-        return (self, result)
+            _resolve_typerow_exts_inplace(row, resolver, registry)
+        return self
 
 
 @dataclass(eq=False, repr=False)
@@ -801,14 +766,13 @@ class USize(Type):
         return model.Apply("prelude.usize")
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Type, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Type:
         from hugr.std.prelude import PRELUDE_EXTENSION
 
-        result = ExtensionResolutionResult()
-        result.used_extensions.register(PRELUDE_EXTENSION)
-        return (self, result)
+        resolver.register(PRELUDE_EXTENSION)
+
+        return self
 
 
 @dataclass(frozen=True)
@@ -890,12 +854,11 @@ class FunctionType(Type):
         return model.Apply("core.fn", [inputs, outputs])
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Type, ExtensionResolutionResult]:
-        in_result = _resolve_typerow_exts_inplace(self.input, registry)
-        out_result = _resolve_typerow_exts_inplace(self.output, registry)
-        in_result.extend(out_result)
-        return (self, in_result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Type:
+        _resolve_typerow_exts_inplace(self.input, resolver, registry)
+        _resolve_typerow_exts_inplace(self.output, resolver, registry)
+        return self
 
 
 @dataclass(frozen=True)
@@ -935,16 +898,15 @@ class PolyFuncType(Type):
         raise TypeError(error)
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Type, ExtensionResolutionResult]:
-        resolved_body, result = self.body._resolve_used_extensions(registry)
-        new_params = []
-        for param in self.params:
-            resolved_param, param_result = param._resolve_used_extensions(registry)
-            new_params.append(resolved_param)
-            result.extend(param_result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Type:
+        resolved_body = self.body._resolve_used_extensions(resolver, registry)
         assert type(resolved_body) is FunctionType
-        return (PolyFuncType(new_params, resolved_body), result)
+        new_params = [
+            param._resolve_used_extensions(resolver, registry) for param in self.params
+        ]
+
+        return PolyFuncType(new_params, resolved_body)
 
 
 @dataclass
@@ -995,19 +957,13 @@ class ExtType(Type):
         return self._to_opaque().to_model()
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Type, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
-
-        result = ExtensionResolutionResult()
-        result.used_extensions.register(self.type_def.get_extension())
-
-        new_args = []
-        for arg in self.args:
-            resolved_arg, arg_result = arg._resolve_used_extensions(registry)
-            new_args.append(resolved_arg)
-            result.extend(arg_result)
-        return (ExtType(self.type_def, new_args), result)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Type:
+        resolver.register(self.type_def.get_extension())
+        new_args = [
+            arg._resolve_used_extensions(resolver, registry) for arg in self.args
+        ]
+        return ExtType(self.type_def, new_args)
 
 
 @dataclass
@@ -1048,9 +1004,9 @@ class Opaque(Type):
         return model.Apply(name, args)
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Type, ExtensionResolutionResult]:
-        from hugr.ext import Extension, ExtensionRegistry, ExtensionResolutionResult
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Type:
+        from hugr.ext import Extension, ExtensionRegistry
 
         if registry is not None:
             try:
@@ -1061,17 +1017,14 @@ class Opaque(Type):
                 pass
             else:
                 # Successfully got the type_def - resolve to ExtType
-                return ExtType(type_def, self.args)._resolve_used_extensions(registry)
+                return ExtType(type_def, self.args)._resolve_used_extensions(
+                    resolver, registry
+                )
 
-        # Could not resolve to an ExtType - return self with unresolved extension
-        result = ExtensionResolutionResult()
-
-        new_args = []
-        for arg in self.args:
-            resolved_arg, arg_result = arg._resolve_used_extensions(registry)
-            new_args.append(resolved_arg)
-            result.extend(arg_result)
-
+        # Could not resolve to an ExtType - add to unresolved types
+        new_args = [
+            arg._resolve_used_extensions(resolver, registry) for arg in self.args
+        ]
         new_type = Opaque(
             self.id,
             self.bound,
@@ -1080,11 +1033,10 @@ class Opaque(Type):
             self.extension_version,
         )
 
-        result.unresolved_extensions.add(self.extension)
-        if (self.extension, self.id) not in result.unresolved_types:
-            result.unresolved_types[(self.extension, self.id)] = new_type
+        resolver.ensure_unresolved(self.extension)
+        resolver.ensure_unresolved_type(self.extension, self.id, new_type)
 
-        return (new_type, result)
+        return new_type
 
 
 @dataclass
@@ -1102,14 +1054,12 @@ class _QubitDef(Type):
         return model.Apply("prelude.qubit", [])
 
     def _resolve_used_extensions(
-        self, registry: ExtensionRegistry | None = None
-    ) -> tuple[Type, ExtensionResolutionResult]:
-        from hugr.ext import ExtensionResolutionResult
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> Type:
         from hugr.std.prelude import PRELUDE_EXTENSION
 
-        result = ExtensionResolutionResult()
-        result.used_extensions.register(PRELUDE_EXTENSION)
-        return (self, result)
+        resolver.register(PRELUDE_EXTENSION)
+        return self
 
 
 #: Qubit type.

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -16,7 +16,7 @@ from hugr.utils import comma_sep_repr, comma_sep_str, ser_it
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    from hugr.ext import ExtensionRegistry, ExtensionResolutionResult
+    from hugr.ext import ExtensionRegistry, UsedExtensionResolver
     from hugr.hugr import Hugr
 
 
@@ -43,13 +43,14 @@ class Value(Protocol):
     def to_model(self) -> model.Term: ...
 
     def _resolve_used_extensions_inplace(
-        self, registry: ExtensionRegistry | None = None
-    ) -> ExtensionResolutionResult:
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
         """Resolve the extensions required to define this value.
 
         The value is modified in-place.
 
         Args:
+            resolver: The resolved to report used extensions to.
             registry: A registry to resolve unresolved extensions from.
                 If None, opaque operations and types will not be resolved.
 
@@ -57,9 +58,6 @@ class Value(Protocol):
             The resolution result containing used and unresolved extensions.
         """
         ...
-        from hugr.ext import ExtensionResolutionResult
-
-        return ExtensionResolutionResult()
 
 
 @dataclass
@@ -175,17 +173,16 @@ class Sum(Value):
         )
 
     def _resolve_used_extensions_inplace(
-        self, registry: ExtensionRegistry | None = None
-    ) -> ExtensionResolutionResult:
-        resolved_typ, result = self.typ._resolve_used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
+        resolved_typ = self.typ._resolve_used_extensions(resolver, registry)
         assert isinstance(
             resolved_typ, tys.Sum
         ), "HUGR internal error, expected resolved type to be sum."
         self.typ = resolved_typ
 
         for val in self.vals:
-            result.extend(val._resolve_used_extensions_inplace(registry))
-        return result
+            val._resolve_used_extensions_inplace(resolver, registry)
 
 
 @dataclass(eq=False, repr=False)
@@ -363,9 +360,10 @@ class Function(Value):
         return model.Func(module.root)
 
     def _resolve_used_extensions_inplace(
-        self, registry: ExtensionRegistry | None = None
-    ) -> ExtensionResolutionResult:
-        return self.body.used_extensions(registry)
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
+        result = self.body.used_extensions(registry)
+        resolver.extend_with_result(result)
 
 
 @dataclass
@@ -394,10 +392,9 @@ class Extension(Value):
         return model.Apply("compat.const_json", [type, model.Literal(json)])
 
     def _resolve_used_extensions_inplace(
-        self, registry: ExtensionRegistry | None = None
-    ) -> ExtensionResolutionResult:
-        self.typ, result = self.typ._resolve_used_extensions(registry)
-        return result
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
+        self.typ = self.typ._resolve_used_extensions(resolver, registry)
 
     def __str__(self) -> str:
         return f"{self.name}({self.val})"

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -53,9 +53,6 @@ class Value(Protocol):
             resolver: The resolved to report used extensions to.
             registry: A registry to resolve unresolved extensions from.
                 If None, opaque operations and types will not be resolved.
-
-        Returns:
-            The resolution result containing used and unresolved extensions.
         """
         ...
 

--- a/hugr-py/tests/test_custom.py
+++ b/hugr-py/tests/test_custom.py
@@ -4,6 +4,7 @@ import pytest
 
 from hugr import ext, model, ops, tys
 from hugr.build.dfg import Dfg
+from hugr.ext import UsedExtensionResolver
 from hugr.hugr import Hugr, Node
 from hugr.ops import AsExtOp, Custom, ExtOp
 from hugr.package import Package
@@ -150,17 +151,19 @@ def test_custom_type(ext_t: tys.ExtType, registry: ext.ExtensionRegistry):
     opaque = ext_t._to_serial().deserialize()
     assert isinstance(opaque, tys.Opaque)
     assert opaque.extension_version == ext_t.type_def.get_extension().version
-    resolved, _ = opaque._resolve_used_extensions(registry)
+    resolved = opaque._resolve_used_extensions(UsedExtensionResolver(), registry)
     assert resolved == ext_t
 
-    resolved, _ = opaque._resolve_used_extensions(ext.ExtensionRegistry())
+    resolved = opaque._resolve_used_extensions(
+        UsedExtensionResolver(), ext.ExtensionRegistry()
+    )
     assert resolved == opaque
 
     f_t = tys.FunctionType.endo([ext_t])
     f_t_opaque = f_t._to_serial().deserialize()
     assert isinstance(f_t_opaque.input[0], tys.Opaque)
 
-    resolved, _ = f_t_opaque._resolve_used_extensions(registry)
+    resolved = f_t_opaque._resolve_used_extensions(UsedExtensionResolver(), registry)
     assert resolved == f_t
 
 

--- a/hugr-py/tests/test_custom.py
+++ b/hugr-py/tests/test_custom.py
@@ -231,7 +231,7 @@ def test_registry_version_resolution():
         extension="versioned_ext",
         extension_version=ext.Version(0, 2, 3),
     )
-    resolved_ty, _ = opaque._resolve_used_extensions(reg)
+    resolved_ty = opaque._resolve_used_extensions(UsedExtensionResolver(), reg)
     assert isinstance(resolved_ty, tys.ExtType)
     assert resolved_ty.type_def.get_extension() is ext_0_2_5
 

--- a/hugr-py/tests/test_used_extensions.py
+++ b/hugr-py/tests/test_used_extensions.py
@@ -1,6 +1,7 @@
 # ruff: noqa: I001
 
 import hugr
+from hugr.ext import UsedExtensionResolver
 from hugr.package import Package
 import hugr.ops as ops
 import hugr.tys as tys
@@ -150,7 +151,10 @@ def test_op_signature_contains_same_extension() -> None:
 )
 def test_type_resolution(typ: tys.Type, extensions: list[ext.Extension]) -> None:
     """Test that Opaque types are tracked and resolved correctly."""
-    _, result = typ._resolve_used_extensions()
+    resolver = UsedExtensionResolver()
+    _ = typ._resolve_used_extensions(resolver)
+    result = resolver.result()
+
     for extension in extensions:
         assert extension.name in result.unresolved_extensions
     if extensions:
@@ -160,7 +164,9 @@ def test_type_resolution(typ: tys.Type, extensions: list[ext.Extension]) -> None
     test_registry = ext.ExtensionRegistry()
     for extension in extensions:
         test_registry.register(extension)
-    _, result = typ._resolve_used_extensions(test_registry)
+    resolver = UsedExtensionResolver()
+    _ = typ._resolve_used_extensions(resolver, test_registry)
+    result = resolver.result()
     for extension in extensions:
         assert extension.name in result.used_extensions.ids()
     assert not result.unresolved_types
@@ -193,7 +199,9 @@ def test_type_resolution(typ: tys.Type, extensions: list[ext.Extension]) -> None
 )
 def test_type_arg_resolution(arg: tys.TypeArg, extensions: list[ext.Extension]) -> None:
     """Test that type arguments are tracked and resolved correctly."""
-    _, result = arg._resolve_used_extensions()
+    resolver = UsedExtensionResolver()
+    _ = arg._resolve_used_extensions(resolver)
+    result = resolver.result()
     for extension in extensions:
         assert extension.name in result.unresolved_extensions
     if extensions:
@@ -203,7 +211,9 @@ def test_type_arg_resolution(arg: tys.TypeArg, extensions: list[ext.Extension]) 
     test_registry = ext.ExtensionRegistry()
     for extension in extensions:
         test_registry.register(extension)
-    _, result = arg._resolve_used_extensions(test_registry)
+    resolver = UsedExtensionResolver()
+    _ = arg._resolve_used_extensions(resolver, test_registry)
+    result = resolver.result()
     for extension in extensions:
         assert extension.name in result.used_extensions.ids()
     assert not result.unresolved_types
@@ -230,7 +240,9 @@ def test_type_param_resolution(
     param: tys.TypeParam, extensions: list[ext.Extension]
 ) -> None:
     """Test that type parameters are tracked and resolved correctly."""
-    _, result = param._resolve_used_extensions()
+    resolver = UsedExtensionResolver()
+    _ = param._resolve_used_extensions(resolver)
+    result = resolver.result()
     for extension in extensions:
         assert extension.name in result.unresolved_extensions
     if extensions:
@@ -240,7 +252,9 @@ def test_type_param_resolution(
     test_registry = ext.ExtensionRegistry()
     for extension in extensions:
         test_registry.register(extension)
-    _, result = param._resolve_used_extensions(test_registry)
+    resolver = UsedExtensionResolver()
+    _ = param._resolve_used_extensions(resolver, test_registry)
+    result = resolver.result()
     for extension in extensions:
         assert extension.name in result.used_extensions.ids()
     assert not result.unresolved_types
@@ -276,7 +290,10 @@ def test_type_param_resolution(
 )
 def test_op_resolution(op: ops.Op, extensions: list[ext.Extension]) -> None:
     """Test that ops are tracked and resolved correctly."""
-    _, result = op._resolve_used_extensions()
+    resolver = UsedExtensionResolver()
+    _ = op._resolve_used_extensions(resolver)
+    result = resolver.result()
+
     for extension in extensions:
         assert extension.name in result.unresolved_extensions
 
@@ -293,7 +310,9 @@ def test_op_resolution(op: ops.Op, extensions: list[ext.Extension]) -> None:
     test_ext_registry = ext.ExtensionRegistry()
     for extension in extensions:
         test_ext_registry.register(extension)
-    _, result = op._resolve_used_extensions(test_ext_registry)
+    resolver = UsedExtensionResolver()
+    _ = op._resolve_used_extensions(resolver, test_ext_registry)
+    result = resolver.result()
     for extension in extensions:
         assert extension.name in result.used_extensions.ids()
     assert not result.unresolved_ops
@@ -315,7 +334,9 @@ def test_op_resolution(op: ops.Op, extensions: list[ext.Extension]) -> None:
 )
 def test_value_resolution(value: val.Value, extensions: list[ext.Extension]) -> None:
     """Test that values are tracked and resolved correctly."""
-    result = value._resolve_used_extensions_inplace()
+    resolver = UsedExtensionResolver()
+    value._resolve_used_extensions_inplace(resolver)
+    result = resolver.result()
     for extension in extensions:
         assert extension.name in result.unresolved_extensions
 
@@ -323,7 +344,9 @@ def test_value_resolution(value: val.Value, extensions: list[ext.Extension]) -> 
     test_ext_registry = ext.ExtensionRegistry()
     for extension in extensions:
         test_ext_registry.register(extension)
-    result = value._resolve_used_extensions_inplace(test_ext_registry)
+    resolver = UsedExtensionResolver()
+    value._resolve_used_extensions_inplace(resolver, test_ext_registry)
+    result = resolver.result()
     for extension in extensions:
         assert extension.name in result.used_extensions.ids()
 


### PR DESCRIPTION
Initial status: Extension resolution takes about a second on a (private) medium size hugr:
<img width="537" height="389" alt="image" src="https://github.com/user-attachments/assets/59c60a01-2857-4b3c-9461-1c0cb13fcf7e" />

The refactor to using a specialised extension resolver avoids new `ExtensionResult` objects and allows some function calls to be cached in the Python JIT cache, since they suddenly return `None`. This already brings the performance up by 37%:
<img width="465" height="363" alt="image" src="https://github.com/user-attachments/assets/5c3f79c3-8e2d-41ed-a423-73559e46a8cc" />

Furthermore, the refactor allows to easily lazify version coalesce, which was very expensive due to how often individual versions had to be compared. Thus, performance jumps by another 8x:
<img width="265" height="283" alt="image" src="https://github.com/user-attachments/assets/9ce35026-c0ed-4407-ba5f-b28c2068448a" />