### PR TITLE
fix: ConstFold panic on rotating/shifting by large values

### DIFF
--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -434,6 +434,15 @@ mod test {
     #[case::idiv(IntOpDef::idiv_u.with_log_width(5), &[37, 8], &[4], 5)]
     #[case::imod(IntOpDef::imod_u.with_log_width(5), &[43, 8], &[3], 5)]
     #[case::ipow(IntOpDef::ipow.with_log_width(5), &[2, 8], &[256], 5)]
+    #[case::ishl_large_amount(IntOpDef::ishl.with_log_width(6), &[1, 70], &[0], 6)]
+    #[case::ishr_large_amount(
+        IntOpDef::ishr.with_log_width(6),
+        &[1 << 40, 70],
+        &[0],
+        6
+    )]
+    #[case::irotl_multiple_of_width(IntOpDef::irotl.with_log_width(6), &[1, 64], &[1], 6)]
+    #[case::irotr_multiple_of_width(IntOpDef::irotr.with_log_width(6), &[1, 128], &[1], 6)]
     #[case::iu_to_s(IntOpDef::iu_to_s.with_log_width(5), &[42], &[42], 5)]
     #[case::is_to_u(IntOpDef::is_to_u.with_log_width(5), &[42], &[42], 5)]
     #[should_panic(expected = "too large to be converted to signed")]

--- a/hugr-core/src/std_extensions/arithmetic/int_ops/const_fold.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops/const_fold.rs
@@ -1032,13 +1032,13 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
                     if n0.log_width() != logwidth0 || n1.log_width() != logwidth0 {
                         None
                     } else {
+                        let width = 1u64 << logwidth0;
                         Some(vec![(
                             0.into(),
                             Value::extension(
                                 ConstInt::new_u(
                                     logwidth0,
-                                    (n0.value_u() << n1.value_u())
-                                        & bitmask_from_logwidth(logwidth0),
+                                    shift_left(n0.value_u(), n1.value_u(), width),
                                 )
                                 .unwrap(),
                             ),
@@ -1059,10 +1059,15 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
                     if n0.log_width() != logwidth0 || n1.log_width() != logwidth0 {
                         None
                     } else {
+                        let width = 1u64 << logwidth0;
                         Some(vec![(
                             0.into(),
                             Value::extension(
-                                ConstInt::new_u(logwidth0, n0.value_u() >> n1.value_u()).unwrap(),
+                                ConstInt::new_u(
+                                    logwidth0,
+                                    shift_right(n0.value_u(), n1.value_u(), width),
+                                )
+                                .unwrap(),
                             ),
                         )])
                     }
@@ -1083,15 +1088,11 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
                     } else {
                         let n = n0.value_u();
                         let w = 1 << logwidth0;
-                        let k = n1.value_u() % w; // equivalent rotation amount
                         Some(vec![(
                             0.into(),
                             Value::extension(
-                                ConstInt::new_u(
-                                    logwidth0,
-                                    ((n << k) & bitmask_from_width(w)) | (n >> (w - k)),
-                                )
-                                .unwrap(),
+                                ConstInt::new_u(logwidth0, rotate_left(n, n1.value_u(), w))
+                                    .unwrap(),
                             ),
                         )])
                     }
@@ -1112,15 +1113,11 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
                     } else {
                         let n = n0.value_u();
                         let w = 1 << logwidth0;
-                        let k = n1.value_u() % w; // equivalent rotation amount
                         Some(vec![(
                             0.into(),
                             Value::extension(
-                                ConstInt::new_u(
-                                    logwidth0,
-                                    ((n << (w - k)) & bitmask_from_width(w)) | (n >> k),
-                                )
-                                .unwrap(),
+                                ConstInt::new_u(logwidth0, rotate_right(n, n1.value_u(), w))
+                                    .unwrap(),
                             ),
                         )])
                     }
@@ -1170,4 +1167,54 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
             ),
         },
     });
+}
+
+/// Shift `value` left within a `width`-bit integer, filling from the right with
+/// zeroes.
+///
+/// `width` must be between one and 64 bits. Shifting by the width or more
+/// discards every bit, rather than relying on the host integer shift
+/// behaviour.
+fn shift_left(value: u64, amount: u64, width: u64) -> u64 {
+    if amount >= width {
+        0
+    } else {
+        (value << amount) & bitmask_from_width(width)
+    }
+}
+
+/// Shift `value` right within a `width`-bit integer, filling from the left
+/// with zeroes.
+///
+/// `width` must be between one and 64 bits. Shifting by the width or more
+/// discards every bit, rather than relying on the host integer shift
+/// behaviour.
+fn shift_right(value: u64, amount: u64, width: u64) -> u64 {
+    if amount >= width { 0 } else { value >> amount }
+}
+
+/// Rotate `value` left within a `width`-bit integer.
+///
+/// `width` must be between one and 64 bits.
+fn rotate_left(value: u64, amount: u64, width: u64) -> u64 {
+    let amount = amount % width;
+    if amount == 0 {
+        // Do not panic when rotating a 64-bit value by 64 bits.
+        value
+    } else {
+        ((value << amount) & bitmask_from_width(width)) | (value >> (width - amount))
+    }
+}
+
+/// Rotate `value` right within a `width`-bit integer.
+///
+/// `width` must be between one and 64 bits.
+fn rotate_right(value: u64, amount: u64, width: u64) -> u64 {
+    let amount = amount % width;
+    if amount == 0 {
+        // Do not panic when rotating a 64-bit value by 64 bits.
+        value
+    } else {
+        ((value << (width - amount)) & bitmask_from_width(width)) | (value >> amount)
+    }
 }

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -599,6 +599,11 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                 .unwrap_basic();
             Ok(vec![r])
         }),
+        // NOTE: LLVM's shl/lshr define a shift by a count greater or equal to the operand width as poison.
+        // The operation definition does not restrict the shift count, so the lowering here is inconsistent.
+        //
+        // TODO: Improve this lowering.
+        // <https://github.com/Quantinuum/hugr/issues/3155>
         IntOpDef::ishl => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
             Ok(vec![
                 ctx.builder()
@@ -606,6 +611,11 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                     .as_basic_value_enum(),
             ])
         }),
+        // NOTE: LLVM's shl/lshr define a shift by a count greater or equal to the operand width as poison.
+        // The operation definition does not restrict the shift count, so the lowering here is inconsistent.
+        //
+        // TODO: Improve this lowering.
+        // <https://github.com/Quantinuum/hugr/issues/3155>
         IntOpDef::ishr => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
             Ok(vec![
                 ctx.builder()


### PR DESCRIPTION
Fixes #3135.

Avoids panics when constant folding rotations and shifts by amounts larger than the int width, following the op definition.

Note that the op semantics do not match the LLVM lowering on these cases.
I opened an issue about it: https://github.com/Quantinuum/hugr/issues/3155