### PR TITLE
chore: Release hugr 0.27.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "hugr"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "bumpalo",
  "criterion",
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-cli"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-core"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-llvm"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-model"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "hugr-persistent"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "delegate",
  "derive_more 2.1.1",

--- a/hugr-cli/Cargo.toml
+++ b/hugr-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-cli"
-version = "0.27.1"
+version = "0.27.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -23,7 +23,7 @@ tracing = ["dep:tracing", "dep:tracing-subscriber"]
 clap = { workspace = true, features = ["derive", "cargo"] }
 clap-verbosity-flag.workspace = true
 derive_more = { workspace = true, features = ["display", "error", "from"] }
-hugr = { path = "../hugr", version = "0.27.1" }
+hugr = { path = "../hugr", version = "0.27.2" }
 serde_json.workspace = true
 serde = { workspace = true, features = ["derive"] }
 clio = { workspace = true, features = ["clap-parse"] }

--- a/hugr-core/CHANGELOG.md
+++ b/hugr-core/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## [0.27.2](https://github.com/quantinuum/hugr/compare/hugr-core-v0.27.1...hugr-core-v0.27.2) - 2026-07-14
+
+### Bug Fixes
+
+- Display source error for errors during payload reads ([#3120](https://github.com/quantinuum/hugr/pull/3120))
+- ConstFold panic on rotating/shifting by large values ([#3156](https://github.com/quantinuum/hugr/pull/3156))
+- Fix partial const folding of logic.eq ([#3154](https://github.com/quantinuum/hugr/pull/3154))
+
 ## [0.27.1](https://github.com/Quantinuum/hugr/compare/hugr-core-v0.27.0...hugr-core-v0.27.1) - 2026-05-05
 
 ### Bug Fixes

--- a/hugr-core/Cargo.toml
+++ b/hugr-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-core"
-version = "0.27.1"
+version = "0.27.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -28,7 +28,7 @@ bench = false
 name = "model"
 
 [dependencies]
-hugr-model = { version = "0.27.1", path = "../hugr-model" }
+hugr-model = { version = "0.27.2", path = "../hugr-model" }
 
 cgmath = { workspace = true, features = ["serde"] }
 delegate = { workspace = true }

--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -101,7 +101,7 @@ pub enum ReadError {
     #[error(transparent)]
     EnvelopeHeader(#[from] Box<HeaderError>),
     /// Error reading the package payload.
-    #[error("Error reading package payload in envelope.")]
+    #[error("Error reading package payload in envelope: {source}")]
     Payload {
         /// The source error.
         source: Box<PayloadError>,

--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -577,7 +577,7 @@ impl PartialEq<dyn CustomConst> for ConstExternalSymbol {
 #[typetag::serde]
 impl CustomConst for ConstExternalSymbol {
     fn name(&self) -> ValueName {
-        format!("@{}", &self.symbol).into()
+        format!("@{}", self.symbol).into()
     }
 
     fn equal_consts(&self, other: &dyn CustomConst) -> bool {
@@ -706,10 +706,10 @@ impl MakeExtensionOp for MakeTuple {
     {
         let def = TupleOpDef::from_def(ext_op.def())?;
         if def != TupleOpDef::MakeTuple {
-            return Err(OpLoadError::NotMember(ext_op.unqualified_id().to_string()))?;
+            return Err(OpLoadError::NotMember(ext_op.unqualified_id().to_string()));
         }
         let [TypeArg::List(elems)] = ext_op.args() else {
-            return Err(SignatureError::InvalidTypeArgs)?;
+            return Err(SignatureError::InvalidTypeArgs.into());
         };
         let tys: Result<Vec<Type>, _> = elems
             .iter()
@@ -761,10 +761,10 @@ impl MakeExtensionOp for UnpackTuple {
     {
         let def = TupleOpDef::from_def(ext_op.def())?;
         if def != TupleOpDef::UnpackTuple {
-            return Err(OpLoadError::NotMember(ext_op.unqualified_id().to_string()))?;
+            return Err(OpLoadError::NotMember(ext_op.unqualified_id().to_string()));
         }
         let [Term::List(elems)] = ext_op.args() else {
-            return Err(SignatureError::InvalidTypeArgs)?;
+            return Err(SignatureError::InvalidTypeArgs.into());
         };
         let tys: Result<Vec<Type>, _> = elems
             .iter()

--- a/hugr-core/src/std_extensions/arithmetic/int_ops.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops.rs
@@ -434,6 +434,15 @@ mod test {
     #[case::idiv(IntOpDef::idiv_u.with_log_width(5), &[37, 8], &[4], 5)]
     #[case::imod(IntOpDef::imod_u.with_log_width(5), &[43, 8], &[3], 5)]
     #[case::ipow(IntOpDef::ipow.with_log_width(5), &[2, 8], &[256], 5)]
+    #[case::ishl_large_amount(IntOpDef::ishl.with_log_width(6), &[1, 70], &[0], 6)]
+    #[case::ishr_large_amount(
+        IntOpDef::ishr.with_log_width(6),
+        &[1 << 40, 70],
+        &[0],
+        6
+    )]
+    #[case::irotl_multiple_of_width(IntOpDef::irotl.with_log_width(6), &[1, 64], &[1], 6)]
+    #[case::irotr_multiple_of_width(IntOpDef::irotr.with_log_width(6), &[1, 128], &[1], 6)]
     #[case::iu_to_s(IntOpDef::iu_to_s.with_log_width(5), &[42], &[42], 5)]
     #[case::is_to_u(IntOpDef::is_to_u.with_log_width(5), &[42], &[42], 5)]
     #[should_panic(expected = "too large to be converted to signed")]

--- a/hugr-core/src/std_extensions/arithmetic/int_ops/const_fold.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_ops/const_fold.rs
@@ -1032,13 +1032,13 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
                     if n0.log_width() != logwidth0 || n1.log_width() != logwidth0 {
                         None
                     } else {
+                        let width = 1u64 << logwidth0;
                         Some(vec![(
                             0.into(),
                             Value::extension(
                                 ConstInt::new_u(
                                     logwidth0,
-                                    (n0.value_u() << n1.value_u())
-                                        & bitmask_from_logwidth(logwidth0),
+                                    shift_left(n0.value_u(), n1.value_u(), width),
                                 )
                                 .unwrap(),
                             ),
@@ -1059,10 +1059,15 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
                     if n0.log_width() != logwidth0 || n1.log_width() != logwidth0 {
                         None
                     } else {
+                        let width = 1u64 << logwidth0;
                         Some(vec![(
                             0.into(),
                             Value::extension(
-                                ConstInt::new_u(logwidth0, n0.value_u() >> n1.value_u()).unwrap(),
+                                ConstInt::new_u(
+                                    logwidth0,
+                                    shift_right(n0.value_u(), n1.value_u(), width),
+                                )
+                                .unwrap(),
                             ),
                         )])
                     }
@@ -1083,15 +1088,11 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
                     } else {
                         let n = n0.value_u();
                         let w = 1 << logwidth0;
-                        let k = n1.value_u() % w; // equivalent rotation amount
                         Some(vec![(
                             0.into(),
                             Value::extension(
-                                ConstInt::new_u(
-                                    logwidth0,
-                                    ((n << k) & bitmask_from_width(w)) | (n >> (w - k)),
-                                )
-                                .unwrap(),
+                                ConstInt::new_u(logwidth0, rotate_left(n, n1.value_u(), w))
+                                    .unwrap(),
                             ),
                         )])
                     }
@@ -1112,15 +1113,11 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
                     } else {
                         let n = n0.value_u();
                         let w = 1 << logwidth0;
-                        let k = n1.value_u() % w; // equivalent rotation amount
                         Some(vec![(
                             0.into(),
                             Value::extension(
-                                ConstInt::new_u(
-                                    logwidth0,
-                                    ((n << (w - k)) & bitmask_from_width(w)) | (n >> k),
-                                )
-                                .unwrap(),
+                                ConstInt::new_u(logwidth0, rotate_right(n, n1.value_u(), w))
+                                    .unwrap(),
                             ),
                         )])
                     }
@@ -1170,4 +1167,54 @@ pub(super) fn set_fold(op: &IntOpDef, def: &mut OpDef) {
             ),
         },
     });
+}
+
+/// Shift `value` left within a `width`-bit integer, filling from the right with
+/// zeroes.
+///
+/// `width` must be between one and 64 bits. Shifting by the width or more
+/// discards every bit, rather than relying on the host integer shift
+/// behaviour.
+fn shift_left(value: u64, amount: u64, width: u64) -> u64 {
+    if amount >= width {
+        0
+    } else {
+        (value << amount) & bitmask_from_width(width)
+    }
+}
+
+/// Shift `value` right within a `width`-bit integer, filling from the left
+/// with zeroes.
+///
+/// `width` must be between one and 64 bits. Shifting by the width or more
+/// discards every bit, rather than relying on the host integer shift
+/// behaviour.
+fn shift_right(value: u64, amount: u64, width: u64) -> u64 {
+    if amount >= width { 0 } else { value >> amount }
+}
+
+/// Rotate `value` left within a `width`-bit integer.
+///
+/// `width` must be between one and 64 bits.
+fn rotate_left(value: u64, amount: u64, width: u64) -> u64 {
+    let amount = amount % width;
+    if amount == 0 {
+        // Do not panic when rotating a 64-bit value by 64 bits.
+        value
+    } else {
+        ((value << amount) & bitmask_from_width(width)) | (value >> (width - amount))
+    }
+}
+
+/// Rotate `value` right within a `width`-bit integer.
+///
+/// `width` must be between one and 64 bits.
+fn rotate_right(value: u64, amount: u64, width: u64) -> u64 {
+    let amount = amount % width;
+    if amount == 0 {
+        // Do not panic when rotating a 64-bit value by 64 bits.
+        value
+    } else {
+        ((value << (width - amount)) & bitmask_from_width(width)) | (value >> amount)
+    }
 }

--- a/hugr-core/src/std_extensions/logic.rs
+++ b/hugr-core/src/std_extensions/logic.rs
@@ -43,10 +43,10 @@ impl ConstFold for LogicOp {
             }
             Self::Eq => {
                 let inps = read_inputs(consts)?;
-                let res = inps.iter().copied().reduce(|a, b| a == b)?;
-                // If we have only some inputs, we can still fold to false, but not to true
-                (!res || inps.len() as u64 == 2)
-                    .then_some(vec![(0.into(), ops::Value::from_bool(res))])
+                let [lhs, rhs] = inps.as_slice() else {
+                    return None;
+                };
+                Some(vec![(0.into(), ops::Value::from_bool(lhs == rhs))])
             }
             Self::Not => {
                 let inps = read_inputs(consts)?;
@@ -241,11 +241,21 @@ pub(crate) mod test {
     #[rstest]
     #[case(LogicOp::And, [Some(true), None], None)]
     #[case(LogicOp::And, [Some(false), None], Some(false))]
+    #[case(LogicOp::And, [None, Some(true)], None)]
+    #[case(LogicOp::And, [None, Some(false)], Some(false))]
+    #[case(LogicOp::Or, [Some(false), None], None)]
+    #[case(LogicOp::Or, [Some(true), None], Some(true))]
     #[case(LogicOp::Or, [None, Some(false)], None)]
     #[case(LogicOp::Or, [None, Some(true)], Some(true))]
+    #[case(LogicOp::Eq, [None, Some(false)], None)]
     #[case(LogicOp::Eq, [None, Some(true)], None)]
+    #[case(LogicOp::Eq, [Some(false), None], None)]
+    #[case(LogicOp::Eq, [Some(true), None], None)]
     #[case(LogicOp::Not, [None], None)]
     #[case(LogicOp::Xor, [None, Some(true)], None)]
+    #[case(LogicOp::Xor, [None, Some(false)], None)]
+    #[case(LogicOp::Xor, [Some(true), None], None)]
+    #[case(LogicOp::Xor, [Some(false), None], None)]
     fn partial_const_fold(
         #[case] op: LogicOp,
         #[case] ins: impl IntoIterator<Item = Option<bool>>,

--- a/hugr-llvm/CHANGELOG.md
+++ b/hugr-llvm/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## [0.27.2](https://github.com/quantinuum/hugr/compare/hugr-llvm-v0.27.1...hugr-llvm-v0.27.2) - 2026-07-14
+
+### Bug Fixes
+
+- ConstFold panic on rotating/shifting by large values ([#3156](https://github.com/quantinuum/hugr/pull/3156))
+
 ## [0.27.1](https://github.com/Quantinuum/hugr/compare/hugr-llvm-v0.27.0...hugr-llvm-v0.27.1) - 2026-05-05
 
 ### Documentation

--- a/hugr-llvm/Cargo.toml
+++ b/hugr-llvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-llvm"
-version = "0.27.1"
+version = "0.27.2"
 description = "A general and extensible crate for lowering HUGRs into LLVM IR"
 
 edition.workspace = true
@@ -26,7 +26,7 @@ workspace = true
 
 [dependencies]
 inkwell = { version = ">=0.9.0, <0.10", default-features = false }
-hugr-core = { path = "../hugr-core", version = "0.27.1" }
+hugr-core = { path = "../hugr-core", version = "0.27.2" }
 anyhow.workspace = true
 itertools.workspace = true
 delegate.workspace = true

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -599,6 +599,11 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                 .unwrap_basic();
             Ok(vec![r])
         }),
+        // NOTE: LLVM's shl/lshr define a shift by a count greater or equal to the operand width as poison.
+        // The operation definition does not restrict the shift count, so the lowering here is inconsistent.
+        //
+        // TODO: Improve this lowering.
+        // <https://github.com/Quantinuum/hugr/issues/3155>
         IntOpDef::ishl => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
             Ok(vec![
                 ctx.builder()
@@ -606,6 +611,11 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                     .as_basic_value_enum(),
             ])
         }),
+        // NOTE: LLVM's shl/lshr define a shift by a count greater or equal to the operand width as poison.
+        // The operation definition does not restrict the shift count, so the lowering here is inconsistent.
+        //
+        // TODO: Improve this lowering.
+        // <https://github.com/Quantinuum/hugr/issues/3155>
         IntOpDef::ishr => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
             Ok(vec![
                 ctx.builder()

--- a/hugr-model/Cargo.toml
+++ b/hugr-model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-model"
-version = "0.27.1"
+version = "0.27.2"
 readme = "README.md"
 documentation = "https://docs.rs/hugr-model/"
 description = "Data model for Quantinuum's HUGR intermediate representation"

--- a/hugr-persistent/Cargo.toml
+++ b/hugr-persistent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr-persistent"
-version = "0.6.1"
+version = "0.6.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 license = { workspace = true }
@@ -16,7 +16,7 @@ categories = ["compilers"]
 name = "persistent_walker_example"
 
 [dependencies]
-hugr-core = { path = "../hugr-core", version = "0.27.1" }
+hugr-core = { path = "../hugr-core", version = "0.27.2" }
 
 derive_more = { workspace = true, features = [
     "display",

--- a/hugr-py/Cargo.toml
+++ b/hugr-py/Cargo.toml
@@ -21,9 +21,9 @@ bench = false
 
 [dependencies]
 bumpalo = { workspace = true, features = ["collections"] }
-hugr-core = { version = "0.27.1", path = "../hugr-core", default-features = false }
-hugr-cli = { version = "0.27.1", path = "../hugr-cli", default-features = false }
-hugr-model = { version = "0.27.1", path = "../hugr-model", default-features = false, features = [
+hugr-core = { version = "0.27.2", path = "../hugr-core", default-features = false }
+hugr-cli = { version = "0.27.2", path = "../hugr-cli", default-features = false }
+hugr-model = { version = "0.27.2", path = "../hugr-model", default-features = false, features = [
     "pyo3",
 ] }
 pastey.workspace = true

--- a/hugr/CHANGELOG.md
+++ b/hugr/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.27.2](https://github.com/quantinuum/hugr/compare/hugr-v0.27.1...hugr-v0.27.2) - 2026-07-14
+
+### Bug Fixes
+
+- Display source error for errors during payload reads ([#3120](https://github.com/quantinuum/hugr/pull/3120))
+- ConstFold panic on rotating/shifting by large values ([#3156](https://github.com/quantinuum/hugr/pull/3156))
+- Fix partial const folding of logic.eq ([#3154](https://github.com/quantinuum/hugr/pull/3154))
+
 ## [0.27.1](https://github.com/Quantinuum/hugr/compare/hugr-v0.27.0...hugr-v0.27.1) - 2026-05-05
 
 ### Bug Fixes

--- a/hugr/Cargo.toml
+++ b/hugr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hugr"
-version = "0.27.1"
+version = "0.27.2"
 edition = { workspace = true }
 rust-version = { workspace = true }
 
@@ -31,10 +31,10 @@ zstd = ["hugr-core/zstd"]
 persistent_unstable = ["hugr-persistent"]
 
 [dependencies]
-hugr-model = { path = "../hugr-model", version = "0.27.1" }
-hugr-core = { path = "../hugr-core", version = "0.27.1" }
-hugr-llvm = { path = "../hugr-llvm", version = "0.27.1", optional = true }
-hugr-persistent = { path = "../hugr-persistent", version = "0.6.1", optional = true }
+hugr-model = { path = "../hugr-model", version = "0.27.2" }
+hugr-core = { path = "../hugr-core", version = "0.27.2" }
+hugr-llvm = { path = "../hugr-llvm", version = "0.27.2", optional = true }
+hugr-persistent = { path = "../hugr-persistent", version = "0.6.2", optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }


### PR DESCRIPTION
Cherry-picked fixes backported to the last `guppy 0.21`-compatible hugr.

(best viewed as individual commits).

I will not merge this PR, but fast-forward the `release/hugr-v0.27` branch instead.