### PR TITLE
feat: Standalone extension resolution on extension load

### DIFF
--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -299,16 +299,24 @@ class Extension:
         return self._to_serial().model_dump_json()
 
     @classmethod
-    def from_json(cls, json_str: str) -> Extension:
+    def from_json(
+        cls, json_str: str, registry: ExtensionRegistry | None = None
+    ) -> Extension:
         """Deserialize a JSON string to a Extension object.
 
         Args:
             json_str: The JSON string representing a Extension.
+            registry: If present, performs extension resolution on the
+                extension types referenced in the type and operation definitions
+                of the deserialized Extension.
 
         Returns:
             The deserialized Extension object.
         """
-        return ext_s.Extension.model_validate_json(json_str).deserialize()
+        ext = ext_s.Extension.model_validate_json(json_str).deserialize()
+        if registry is not None:
+            ext._resolve_used_extensions(registry)
+        return ext
 
     def add_op_def(self, op_def: OpDef) -> OpDef:
         """Add an operation definition to the extension.
@@ -339,17 +347,25 @@ class Extension:
     def _resolve_used_extensions(
         self, registry: ExtensionRegistry | None = None
     ) -> ExtensionResolutionResult:
-        """Collect extension dependencies from this extension's op signatures."""
+        """Resolve and collect dependencies throughout this extension definition."""
         if registry is not None and self.name not in registry:
             registry.register(self)
 
         resolver = UsedExtensionResolver()
         result = ExtensionResolutionResult()
+        for type_def in self.types.values():
+            type_def.params = [
+                param._resolve_used_extensions(resolver, registry)
+                for param in type_def.params
+            ]
+
         for op_def in self.operations.values():
             poly_func = op_def.signature.poly_func
             if poly_func is None:
                 continue
-            poly_func._resolve_used_extensions(resolver, registry)
+            resolved_poly_func = poly_func._resolve_used_extensions(resolver, registry)
+            assert isinstance(resolved_poly_func, tys.PolyFuncType)
+            op_def.signature.poly_func = resolved_poly_func
 
             for lower_func in op_def.lower_funcs:
                 lower_result = lower_func.hugr.used_extensions(registry)

--- a/hugr-py/tests/test_used_extensions.py
+++ b/hugr-py/tests/test_used_extensions.py
@@ -127,6 +127,36 @@ def test_op_signature_contains_same_extension() -> None:
     assert my_ext.name in exts.ids()
 
 
+def test_extension_from_json_resolves_types() -> None:
+    """Resolve opaque types throughout a deserialized extension definition."""
+    extension = ext.Extension("test.from_json", ext.Version(0, 1, 0))
+    extension.add_type_def(
+        ext.TypeDef(
+            name="Container",
+            description="A type parameterized by a constant.",
+            params=[tys.ConstParam(TEST_TYPE_OPAQUE)],
+            bound=ext.ExplicitBound(tys.TypeBound.Copyable),
+        )
+    )
+    extension.add_op_def(
+        ext.OpDef(
+            name="Make",
+            description="Return the referenced type.",
+            signature=ext.OpDefSig(tys.FunctionType([], [TEST_TYPE_OPAQUE])),
+        )
+    )
+    registry = ext.ExtensionRegistry.from_extensions([TEST_EXT])
+
+    loaded = ext.Extension.from_json(extension.to_json(), registry)
+
+    signature = loaded.get_op("Make").signature.poly_func
+    assert signature is not None
+    assert isinstance(signature.body.output[0], tys.ExtType)
+    [param] = loaded.get_type("Container").params
+    assert isinstance(param, tys.ConstParam)
+    assert isinstance(param.ty, tys.ExtType)
+
+
 @pytest.mark.parametrize(
     ("typ", "extensions"),
     [


### PR DESCRIPTION
Closes #3159 by adding a registry parameter to `Extension.from_json`, to perform extension resolution from.

drive-by: Fix type params in TypeDefs not being resolved.
drive-by: Fix polyfuncs in OpDefs not being updated to the resolved values (types in the signature were updated due to python aliasing, but params were not).