### PR TITLE
fix: Avoid breaking change to ExtensionValue present in hugr 0.18.1

### DIFF
--- a/hugr-py/src/hugr/std/prelude.py
+++ b/hugr-py/src/hugr/std/prelude.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from hugr import val
+from hugr import ext, val
 from hugr.std._util import _load_extension
 
 PRELUDE_EXTENSION = _load_extension("prelude")
@@ -30,3 +30,10 @@ class StringVal(val.ExtensionValue):
 
     def __str__(self) -> str:
         return f"{self.v}"
+
+    def _resolve_used_extensions_inplace(
+        self,
+        resolver: ext.UsedExtensionResolver,
+        registry: ext.ExtensionRegistry | None = None,
+    ) -> None:
+        resolver.register(PRELUDE_EXTENSION)

--- a/hugr-py/src/hugr/val.py
+++ b/hugr-py/src/hugr/val.py
@@ -413,3 +413,17 @@ class ExtensionValue(Value, Protocol):
     def to_model(self) -> model.Term:
         # Fallback
         return self.to_value().to_model()
+
+    def _resolve_used_extensions_inplace(
+        self, resolver: UsedExtensionResolver, registry: ExtensionRegistry | None = None
+    ) -> None:
+        """Resolve the extensions required to define this value.
+
+        This should be implemented by classes that conform to the ExtensionValue
+        protocol, ensuring any extension referenced internally are resolved
+        using the registry, and calling `UsedExtensionResolver.register` for any
+        extensions used by the value.
+        """
+        # TODO: This should probably be an abstract class, but we provide a
+        # default implementation here to avoid breaking the API.
+        return


### PR DESCRIPTION
#3152 introduced an abstract `Value._resolve_used_extensions_inplace` method.
This was a break to the interface, for downstream implementors of the protocol.

This PR adds a default implementation for the method. We should probably make abstract again in the next breaking release.

drive-by: Add missing implementation for `StringVal`