### PR TITLE
fix: Narrow the type definition for hugr.qsystem.result.DataValue

### DIFF
--- a/hugr-py/src/hugr/qsystem/result.py
+++ b/hugr-py/src/hugr/qsystem/result.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 #: Primitive data types that can be returned by a result
 DataPrimitive = int | float | bool
 #: Data value that can be returned by a result: a primitive or a list of primitives
-DataValue = DataPrimitive | list[DataPrimitive]
+DataValue = DataPrimitive | list[int] | list[float] | list[bool]
 TaggedResult = tuple[str, DataValue]
 # Pattern to match register index in tag, e.g. "reg[0]"
 REG_INDEX_PATTERN = re.compile(r"^([a-z][\w_]*)\[(\d+)\]$")


### PR DESCRIPTION
The existing type definitions:
```
DataPrimitive = int | float | bool
DataValue = DataPrimitive | list[DataPrimitive]
```

allow DataValue to include heterogeneous lists of ints, floats and bools. However, as far as I know, the actual results are limited to being homogeneous lists - either list[int], list[float] or list[bool]. The existing definition is a little too lax.