### PR TITLE
fix: Docstring formatting

### DIFF
--- a/hugr-py/src/hugr/build/cfg.py
+++ b/hugr-py/src/hugr/build/cfg.py
@@ -65,7 +65,7 @@ class Cfg(ParentBuilder[ops.CFG], AbstractContextManager):
 
     Args:
         input_types: The input types for the CFG. Outputs are computed
-        by propagating types through the control flow graph to the exit block.
+            by propagating types through the control flow graph to the exit block.
 
     Examples:
         >>> cfg = Cfg(tys.Bool, tys.Unit)
@@ -197,7 +197,8 @@ class Cfg(ParentBuilder[ops.CFG], AbstractContextManager):
 
         Args:
             pred: The wire from the predecessor block to the new block. The
-            port of the wire determines the branching index of the new block.
+                port of the wire determines the branching index of the new
+                block.
 
 
         Returns:

--- a/hugr-py/src/hugr/build/cond_loop.py
+++ b/hugr-py/src/hugr/build/cond_loop.py
@@ -98,7 +98,7 @@ class Conditional(ParentBuilder[ops.Conditional], AbstractContextManager):
     Args:
         sum_ty: The sum type to branch on.
         other_inputs: The inputs for the conditional that aren't included in the
-        sum variants. These are passed to all cases.
+            sum variants. These are passed to all cases.
 
     Examples:
         >>> cond = Conditional(tys.Bool, [tys.Qubit])
@@ -200,8 +200,8 @@ class Conditional(ParentBuilder[ops.Conditional], AbstractContextManager):
 
         Args:
             case_id: The index of the case to build. Input types for the case
-            are the corresponding variant of the sum type concatenated with the
-            other inputs to the conditional.
+                are the corresponding variant of the sum type concatenated with
+                the other inputs to the conditional.
 
         Returns:
             The new case builder.

--- a/hugr-py/src/hugr/build/dfg.py
+++ b/hugr-py/src/hugr/build/dfg.py
@@ -128,7 +128,7 @@ class DfBase(ParentBuilder[DP], DefinitionBuilder, AbstractContextManager):
             parent_op: The parent operation of the new dataflow graph.
             hugr: The host HUGR instance to build the dataflow graph in.
             parent: Parent of new dataflow graph's root node: defaults to the
-            host HUGR entrypoint.
+                  host HUGR entrypoint.
 
         Example:
             >>> hugr = Hugr()
@@ -382,7 +382,7 @@ class DfBase(ParentBuilder[DP], DefinitionBuilder, AbstractContextManager):
 
         Args:
             cond_wire: The wire holding the value (of Sum type) to branch the
-            conditional on.
+                conditional on.
             args: Remaining input wires to the conditional.
 
         Returns:
@@ -462,7 +462,7 @@ class DfBase(ParentBuilder[DP], DefinitionBuilder, AbstractContextManager):
         Args:
             just_inputs: input wires for types that are only inputs to the loop body.
             rest: input wires for types that are inputs and outputs of the loop
-            body.
+                body.
 
         Returns:
             Builder for new nested TailLoop.
@@ -609,7 +609,7 @@ class DfBase(ParentBuilder[DP], DefinitionBuilder, AbstractContextManager):
             args: The input wires to the function call.
             instantiation: The concrete function type to call (needed if polymorphic).
             type_args: The type arguments for the function (needed if
-            polymorphic).
+                polymorphic).
 
         Returns:
             The node holding the :class:`Call <hugr.ops.Call>` operation.
@@ -693,7 +693,7 @@ class Dfg(DfBase[ops.DFG]):
 
     Args:
         input_types: The input types of the the dataflow graph. Output types are
-        calculated by propagating types through the graph.
+            calculated by propagating types through the graph.
 
     Example:
         >>> dfg = Dfg(tys.Bool)

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -262,7 +262,7 @@ class OpDef(ExtensionObject):
         Args:
             args: Type arguments corresponding to the type parameters of the definition.
             concrete_signature: Concrete function type of the operation, only required
-            if the operation is polymorphic.
+                if the operation is polymorphic.
         """
         return ops.ExtOp(self, concrete_signature, list(args or []))
 


### PR DESCRIPTION
If multiline comments start new lines at the same indentation as the argument, the first word gets interpreted as an argument name and the formatting gets messed up!