### PR TITLE
fix: avoid poisoned values when using ishl/ishr whith large shift amounts

### DIFF
--- a/hugr-llvm/src/extension/collections/borrow_array.rs
+++ b/hugr-llvm/src/extension/collections/borrow_array.rs
@@ -2874,10 +2874,12 @@ mod test {
     #[rstest]
     fn exec_shift_by_64(mut exec_ctx: TestContext, #[values(false, true)] right: bool) {
         const SHIFTED_VAL: u64 = 35;
-        // This test generates LLVM code to shift a 64-bit value right/left by 64 places.
-        // This is a no-op in LLVM, rather than producing 0 as one might expect.
+        // This test generates LLVM code to shift a 64-bit value right/left by 64 and 65 places.
+        // We expect 0 as result.
         use hugr_core::std_extensions::arithmetic::int_ops::IntOpDef;
         let int_ty = int_type(6); // 64-bit integer
+
+        // shift by 64
         let hugr = SimpleHugrConfig::new()
             .with_outs([int_ty.clone()])
             .with_extensions(exec_registry())
@@ -2899,7 +2901,31 @@ mod test {
             cge.add_default_prelude_extensions()
                 .add_default_int_extensions()
         });
-        assert_eq!(exec_ctx.exec_hugr_u64(hugr, "main"), SHIFTED_VAL);
+        assert_eq!(exec_ctx.exec_hugr_u64(hugr, "main"), 0);
+
+        // shift by 65
+        let hugr = SimpleHugrConfig::new()
+            .with_outs([int_ty.clone()])
+            .with_extensions(exec_registry())
+            .finish(|mut builder| {
+                let minus_one = builder.add_load_value(ConstInt::new_u(6, SHIFTED_VAL).unwrap());
+                let shift = builder.add_load_value(ConstInt::new_u(6, 65).unwrap());
+                let op = if right {
+                    IntOpDef::ishr
+                } else {
+                    IntOpDef::ishl
+                };
+                let result = builder
+                    .add_dataflow_op(op.with_log_width(6), [minus_one, shift])
+                    .unwrap()
+                    .out_wire(0);
+                builder.finish_hugr_with_outputs([result]).unwrap()
+            });
+        exec_ctx.add_extensions(|cge| {
+            cge.add_default_prelude_extensions()
+                .add_default_int_extensions()
+        });
+        assert_eq!(exec_ctx.exec_hugr_u64(hugr, "main"), 0);
     }
 
     #[rstest]

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -1429,6 +1429,40 @@ mod test {
     }
 
     #[rstest]
+    #[case::ishl_i8_below_width("ishl", 3, 0xff, 7, 0x80)]
+    #[case::ishl_i8_at_width("ishl", 3, 0xff, 8, 0)]
+    #[case::ishl_i8_above_width("ishl", 3, 0xff, 9, 0)]
+    #[case::ishl_i8_max_amount("ishl", 3, 0xff, 0xff, 0)]
+    #[case::ishr_i8_below_width("ishr", 3, 0xff, 7, 1)]
+    #[case::ishr_i8_at_width("ishr", 3, 0xff, 8, 0)]
+    #[case::ishr_i8_above_width("ishr", 3, 0xff, 9, 0)]
+    #[case::ishr_i8_max_amount("ishr", 3, 0xff, 0xff, 0)]
+    #[case::ishl_i64_below_width("ishl", 6, u64::MAX, 63, 1_u64 << 63)]
+    #[case::ishl_i64_at_width("ishl", 6, u64::MAX, 64, 0)]
+    #[case::ishl_i64_max_amount("ishl", 6, u64::MAX, u64::MAX, 0)]
+    #[case::ishr_i64_below_width("ishr", 6, u64::MAX, 63, 1)]
+    #[case::ishr_i64_at_width("ishr", 6, u64::MAX, 64, 0)]
+    #[case::ishr_i64_max_amount("ishr", 6, u64::MAX, u64::MAX, 0)]
+    fn test_exec_shift(
+        int_exec_ctx: TestContext,
+        #[case] op: &str,
+        #[case] log_width: u8,
+        #[case] lhs: u64,
+        #[case] rhs: u64,
+        #[case] expected: u64,
+    ) {
+        let ty = INT_TYPES[log_width as usize].clone();
+        let inputs = [
+            ConstInt::new_u(log_width, lhs).unwrap(),
+            ConstInt::new_u(log_width, rhs).unwrap(),
+        ];
+        let ext_op = make_int_op(op, log_width);
+
+        let hugr = test_int_op_with_results::<2>(ext_op, log_width, Some(inputs), ty);
+        int_exec_ctx.check_int_hugr(hugr, "main", log_width, expected, false);
+    }
+
+    #[rstest]
     #[case::imax("imax_s", 1, 2, 2)]
     #[case::imax("imax_s", 2, 1, 2)]
     #[case::imax("imax_s", 2, 2, 2)]

--- a/hugr-llvm/src/extension/int.rs
+++ b/hugr-llvm/src/extension/int.rs
@@ -599,29 +599,11 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
                 .unwrap_basic();
             Ok(vec![r])
         }),
-        // NOTE: LLVM's shl/lshr define a shift by a count greater or equal to the operand width as poison.
-        // The operation definition does not restrict the shift count, so the lowering here is inconsistent.
-        //
-        // TODO: Improve this lowering.
-        // <https://github.com/Quantinuum/hugr/issues/3155>
-        IntOpDef::ishl => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
-            Ok(vec![
-                ctx.builder()
-                    .build_left_shift(lhs.into_int_value(), rhs.into_int_value(), "")?
-                    .as_basic_value_enum(),
-            ])
+        IntOpDef::ishl => emit_custom_binary_op(context, args, |ctx, inputs, _| {
+            emit_shift_op(ctx, inputs, ShiftBuilder::Left)
         }),
-        // NOTE: LLVM's shl/lshr define a shift by a count greater or equal to the operand width as poison.
-        // The operation definition does not restrict the shift count, so the lowering here is inconsistent.
-        //
-        // TODO: Improve this lowering.
-        // <https://github.com/Quantinuum/hugr/issues/3155>
-        IntOpDef::ishr => emit_custom_binary_op(context, args, |ctx, (lhs, rhs), _| {
-            Ok(vec![
-                ctx.builder()
-                    .build_right_shift(lhs.into_int_value(), rhs.into_int_value(), false, "")?
-                    .as_basic_value_enum(),
-            ])
+        IntOpDef::ishr => emit_custom_binary_op(context, args, |ctx, inputs, _| {
+            emit_shift_op(ctx, inputs, ShiftBuilder::Right)
         }),
         IntOpDef::ieq => emit_icmp(context, args, inkwell::IntPredicate::EQ),
         IntOpDef::ine => emit_icmp(context, args, inkwell::IntPredicate::NE),
@@ -761,6 +743,43 @@ fn emit_int_op<'c, H: HugrView<Node = Node>>(
         }),
         _ => Err(anyhow!("IntOpEmitter: unimplemented op: {}", op.op_id())),
     }
+}
+
+enum ShiftBuilder {
+    Left,
+    Right,
+}
+/// Produce the LLVM code for a shift operation, either left or right.
+///
+/// An oversized LLVM shift produces poison, to be consistent with the hugr semantics, we first check that the shift count is
+/// less than the bit width of the value being shifted, and if not, we return 0 (instead of the llvm poisoned value).
+fn emit_shift_op<'c, H>(
+    ctx: &mut EmitFuncContext<'c, '_, H>,
+    (lhs, rhs): (BasicValueEnum<'c>, BasicValueEnum<'c>),
+    shift: ShiftBuilder,
+) -> Result<Vec<BasicValueEnum<'c>>>
+where
+    H: HugrView<Node = Node>,
+{
+    let lhs = lhs.into_int_value();
+    let rhs = rhs.into_int_value();
+    let int_ty = lhs.get_type();
+    let bit_width = int_ty.const_int(u64::from(int_ty.get_bit_width()), false);
+    let shift_is_valid =
+        ctx.builder()
+            .build_int_compare(IntPredicate::ULT, rhs, bit_width, "shift_is_valid")?;
+    let shifted = match shift {
+        ShiftBuilder::Left => ctx.builder().build_left_shift(lhs, rhs, "shifted")?,
+        ShiftBuilder::Right => ctx
+            .builder()
+            .build_right_shift(lhs, rhs, false, "shifted")?,
+    };
+    Ok(vec![ctx.builder().build_select(
+        shift_is_valid,
+        shifted,
+        int_ty.const_zero(),
+        "shift_result",
+    )?])
 }
 
 // Helper to get the log width arg to an int op when it's the only argument


### PR DESCRIPTION
closes #3155

To ensure consistent behaviour with respect to the hugr declared semantics, we lower the shift operation into the following LLVM sequence:
```llvm
%shift_is_valid = icmp ult i64 %rhs, 64
%shifted = shl i64 %lhs, %rhs
%shift_result = select i1 %shift_is_valid, i64 %shifted, i64 0
```
where we first check the validity of the shift, and then we pick the shifted value only if the shift was valid (0 otherwise).
