### PR TITLE
fix: Fix pointer to hugr cli function

### DIFF
--- a/hugr-py/pyproject.toml
+++ b/hugr-py/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 
 [project.scripts]
-hugr = "hugr._hugr:run_cli"
+hugr = "hugr._hugr.model:run_cli"
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
In #2764, the `_hugr` module in `hugr-py` was updated, but this script was missed!
