### PR TITLE
feat!: Reject early bad calls to `OpDef.instantiate`

### DIFF
--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -263,33 +263,40 @@ class OpDef(ExtensionObject):
             args: Type arguments corresponding to the type parameters of the definition.
             concrete_signature: Concrete function type of the operation, only required
                 if the operation is polymorphic.
+
+        Raises:
+            ValueError: if a `concrete_signature` arg is not provided to a `OpDef`
+                which requires type parameters, or if the wrong number of args are
+                provided for the `OpDef`.
+
         """
         num_args = len(args) if args else 0
         if self.signature.poly_func is not None:
             params = self.signature.poly_func.params
             if num_args > len(params):
                 msg = (
-                    f"Too many args: Op {self.name} takes {len(params)} args, "
-                    f"but was given {num_args}"
+                    f"Too many args: Op {self.qualified_name()} takes {len(params)}"
+                    f" args, but was given {num_args}"
                 )
-                raise TypeError(msg)
+                raise ValueError(msg)
             elif len(params) > num_args:
                 msg = (
-                    f"Not enough args: Op {self.name} takes {len(params)} args, "
-                    f"but was given {num_args}"
+                    f"Not enough args: Op {self.qualified_name()} takes {len(params)}"
+                    f" args, but was given {num_args}"
                 )
-                raise TypeError(msg)
+                raise ValueError(msg)
 
         if num_args > 0 and concrete_signature is None:
             url_base = "https://quantinuum.github.io/hugr/generated"
             url = f"{url_base}/hugr.ext.OpDef.html#hugr.ext.OpDef.instantiate"
             msg = (
                 f"Signature not provided:\n"
-                f"  Concrete signature required for polymorphic Op `{self.name}`.\n"
+                f"  Concrete signature required for polymorphic Op "
+                f"`{self.qualified_name()}`.\n"
                 f"  See documentation for `OpDef.instantiate`:\n"
                 f"  {url}"
             )
-            raise TypeError(msg)
+            raise ValueError(msg)
 
         return ops.ExtOp(self, concrete_signature, list(args or []))
 

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -264,6 +264,33 @@ class OpDef(ExtensionObject):
             concrete_signature: Concrete function type of the operation, only required
                 if the operation is polymorphic.
         """
+        num_args = len(args) if args else 0
+        if self.signature.poly_func is not None:
+            params = self.signature.poly_func.params
+            if num_args > len(params):
+                msg = (
+                    f"Too many args: Op {self.name} takes {len(params)} args, "
+                    f"but was given {num_args}"
+                )
+                raise TypeError(msg)
+            elif len(params) > num_args:
+                msg = (
+                    f"Not enough args: Op {self.name} takes {len(params)} args, "
+                    f"but was given {num_args}"
+                )
+                raise TypeError(msg)
+
+        if num_args > 0 and concrete_signature is None:
+            url_base = "https://quantinuum.github.io/hugr/generated"
+            url = f"{url_base}/hugr.ext.OpDef.html#hugr.ext.OpDef.instantiate"
+            msg = (
+                f"Signature not provided:\n"
+                f"  Concrete signature required for polymorphic Op `{self.name}`.\n"
+                f"  See documentation for `OpDef.instantiate`:\n"
+                f"  {url}"
+            )
+            raise TypeError(msg)
+
         return ops.ExtOp(self, concrete_signature, list(args or []))
 
 

--- a/hugr-py/tests/errors/__snapshots__/test_instantiation_without_sig.ambr
+++ b/hugr-py/tests/errors/__snapshots__/test_instantiation_without_sig.ambr
@@ -1,0 +1,9 @@
+# serializer version: 1
+# name: test_instantiation_without_sig
+  '''
+  Signature not provided:
+    Concrete signature required for polymorphic Op `ineg`.
+    See documentation for `OpDef.instantiate`:
+    https://quantinuum.github.io/hugr/generated/hugr.ext.OpDef.html#hugr.ext.OpDef.instantiate
+  '''
+# ---

--- a/hugr-py/tests/errors/__snapshots__/test_instantiation_without_sig.ambr
+++ b/hugr-py/tests/errors/__snapshots__/test_instantiation_without_sig.ambr
@@ -2,7 +2,7 @@
 # name: test_instantiation_without_sig
   '''
   Signature not provided:
-    Concrete signature required for polymorphic Op `ineg`.
+    Concrete signature required for polymorphic Op `arithmetic.int.ineg`.
     See documentation for `OpDef.instantiate`:
     https://quantinuum.github.io/hugr/generated/hugr.ext.OpDef.html#hugr.ext.OpDef.instantiate
   '''

--- a/hugr-py/tests/errors/__snapshots__/test_insufficient_args.ambr
+++ b/hugr-py/tests/errors/__snapshots__/test_insufficient_args.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: test_insufficient_args_err
+  'Not enough args: Op ineg takes 1 args, but was given 0'
+# ---

--- a/hugr-py/tests/errors/__snapshots__/test_insufficient_args.ambr
+++ b/hugr-py/tests/errors/__snapshots__/test_insufficient_args.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: test_insufficient_args_err
-  'Not enough args: Op ineg takes 1 args, but was given 0'
+  'Not enough args: Op arithmetic.int.ineg takes 1 args, but was given 0'
 # ---

--- a/hugr-py/tests/errors/__snapshots__/test_too_many_args.ambr
+++ b/hugr-py/tests/errors/__snapshots__/test_too_many_args.ambr
@@ -1,4 +1,4 @@
 # serializer version: 1
 # name: test_too_many_args_err
-  'Too many args: Op ineg takes 1 args, but was given 2'
+  'Too many args: Op arithmetic.int.ineg takes 1 args, but was given 2'
 # ---

--- a/hugr-py/tests/errors/__snapshots__/test_too_many_args.ambr
+++ b/hugr-py/tests/errors/__snapshots__/test_too_many_args.ambr
@@ -1,0 +1,4 @@
+# serializer version: 1
+# name: test_too_many_args_err
+  'Too many args: Op ineg takes 1 args, but was given 2'
+# ---

--- a/hugr-py/tests/errors/test_instantiation_without_sig.py
+++ b/hugr-py/tests/errors/test_instantiation_without_sig.py
@@ -15,5 +15,5 @@ def test_instantiation_without_sig(snapshot):
         node = dfg.add_op(op, *dfg.inputs())
         dfg.set_outputs(node)
         pytest.fail("Didn't raise an error")
-    except TypeError as e:
+    except ValueError as e:
         error_snap(str(e), snapshot)

--- a/hugr-py/tests/errors/test_instantiation_without_sig.py
+++ b/hugr-py/tests/errors/test_instantiation_without_sig.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from hugr.build.dfg import Dfg
+from hugr.std.int import INT_OPS_EXTENSION, INT_T
+from hugr.tys import BoundedNatArg
+from tests.errors.util import error_snap
+
+
+def test_instantiation_without_sig(snapshot):
+    try:
+        dfg = Dfg(INT_T)
+        op = INT_OPS_EXTENSION.operations["ineg"].instantiate([BoundedNatArg(4)])
+        node = dfg.add_op(op, *dfg.inputs())
+        dfg.set_outputs(node)
+        pytest.fail("Didn't raise an error")
+    except TypeError as e:
+        error_snap(str(e), snapshot)

--- a/hugr-py/tests/errors/test_insufficient_args.py
+++ b/hugr-py/tests/errors/test_insufficient_args.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from hugr.build.dfg import Dfg
+from hugr.std.int import INT_OPS_EXTENSION, INT_T
+from tests.errors.util import error_snap
+
+
+def test_insufficient_args_err(snapshot):
+    try:
+        dfg = Dfg(INT_T)
+        op = INT_OPS_EXTENSION.operations["ineg"].instantiate()
+        node = dfg.add_op(op, *dfg.inputs())
+        dfg.set_outputs(node)
+        pytest.fail("Didn't raise an error")
+    except TypeError as e:
+        error_snap(str(e), snapshot)

--- a/hugr-py/tests/errors/test_insufficient_args.py
+++ b/hugr-py/tests/errors/test_insufficient_args.py
@@ -14,5 +14,5 @@ def test_insufficient_args_err(snapshot):
         node = dfg.add_op(op, *dfg.inputs())
         dfg.set_outputs(node)
         pytest.fail("Didn't raise an error")
-    except TypeError as e:
+    except ValueError as e:
         error_snap(str(e), snapshot)

--- a/hugr-py/tests/errors/test_too_many_args.py
+++ b/hugr-py/tests/errors/test_too_many_args.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from hugr.build.dfg import Dfg
+from hugr.std.int import INT_OPS_EXTENSION, INT_T
+from hugr.tys import BoundedNatArg
+from tests.errors.util import error_snap
+
+
+def test_too_many_args_err(snapshot):
+    try:
+        dfg = Dfg(INT_T)
+        op = INT_OPS_EXTENSION.operations["ineg"].instantiate(
+            [BoundedNatArg(4), BoundedNatArg(5)]
+        )
+        node = dfg.add_op(op, *dfg.inputs())
+        dfg.set_outputs(node)
+        pytest.fail("Didn't raise an error")
+    except TypeError as e:
+        error_snap(str(e), snapshot)

--- a/hugr-py/tests/errors/test_too_many_args.py
+++ b/hugr-py/tests/errors/test_too_many_args.py
@@ -17,5 +17,5 @@ def test_too_many_args_err(snapshot):
         node = dfg.add_op(op, *dfg.inputs())
         dfg.set_outputs(node)
         pytest.fail("Didn't raise an error")
-    except TypeError as e:
+    except ValueError as e:
         error_snap(str(e), snapshot)

--- a/hugr-py/tests/errors/util.py
+++ b/hugr-py/tests/errors/util.py
@@ -1,0 +1,6 @@
+from syrupy.assertion import SnapshotAssertion
+
+
+def error_snap(err: str, snap: SnapshotAssertion | None = None):
+    if snap is not None:
+        assert err == snap


### PR DESCRIPTION
`OpDef.instantiate` requires a concrete signature to be provided in order to add a polymorphic operation to the graph. Otherwise, types in the operation's signature will be left out, meaning the resulting hugr wont validate, as in #3189.

Here, I try to raise this error earlier, by checking if the concrete signature is necessary, as well as raising errors for an incorrect number of type args.

---
### Aside
The signature of instantiate: 
```python
instantiate(args: Sequence[TypeArg] | None, sig: FunctionType | None)
```
should really be
```python
instantiate(concrete: tuple[Sequence[TypeArg], FunctionType] | None)
```
since the `FunctionType` needs to be provided whenever any type args are given. But this isn't usually done in python, so I thought I'd get pushback for the ugly API

---


BREAKING CHANGE: Raise errors in bad calls to `OpDef.instantiate`