### PR TITLE
ci: Change dependabot version increase behaviour for py deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,7 @@ updates:
     labels:
       - "X-dependabot"
       - "A-python"
+    versioning-strategy: "widen"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
For python libraries we should avoid raising the minimal version of dependencies unless necessary.

This PR changes dependabot behaviour to widen the requirements and allow new versions as well as the current minimal ones when possible.
See https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--.

The release CI checks will make sure the minimal versions keep working.