### PR TITLE
perf: Avoid computing unused sub offsets during link establishment

### DIFF
--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -43,7 +43,6 @@ from hugr.ops import (
     is_dataflow_op,
 )
 from hugr.tys import Kind, OrderKind, Type, ValueKind
-from hugr.utils import BiMap
 
 from .node_port import (
     Direction,
@@ -54,6 +53,7 @@ from .node_port import (
     PortOffset,
     ToNode,
     _SubPort,
+    _NodeLinks,
 )
 
 if TYPE_CHECKING:
@@ -126,13 +126,13 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
     # List of nodes, with None for deleted nodes.
     _nodes: list[NodeData | None]
     # Bidirectional map of links between ports.
-    _links: BiMap[_SO, _SI]
+    _links: _NodeLinks
     # List of free node indices, populated when nodes are deleted.
     _free_nodes: list[Node]
 
     def __init__(self, entrypoint_op: OpVarCov | None = None) -> None:
         self._free_nodes = []
-        self._links = BiMap()
+        self._links = _NodeLinks()
         self._nodes = []
         self.entrypoint = Node(0)
         self.module_root = Node(0)
@@ -474,18 +474,6 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         self._free_nodes.append(node)
         return weight
 
-    def _unused_sub_offset(self, port: P) -> _SubPort[P]:
-        d: dict[_SO, _SI] | dict[_SI, _SO]
-        match port:
-            case OutPort(_):
-                d = self._links.fwd
-            case InPort(_):
-                d = self._links.bck
-        sub_port = _SubPort(port)
-        while sub_port in d:
-            sub_port = sub_port.next_sub_offset()
-        return sub_port
-
     def has_link(self, src: OutPort, dst: InPort) -> bool:
         """Check if there is a link between two ports.
 
@@ -518,12 +506,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             >>> list(df.hugr.linked_ports(df.input_node[0]))
             [InPort(Node(6), 0)]
         """
-        src_sub = self._unused_sub_offset(src)
-        dst_sub = self._unused_sub_offset(dst)
-        # if self._links.get_left(dst_sub) is not None:
-        #     dst = replace(dst, _sub_offset=dst._sub_offset + 1)
-        self._links.insert_left(src_sub, dst_sub)
-
+        self._links.establish_link(src, dst)
         self[src.node]._num_outs = max(self[src.node]._num_outs, src.offset + 1)
         self[dst.node]._num_inps = max(self[dst.node]._num_inps, dst.offset + 1)
 

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -52,8 +52,8 @@ from .node_port import (
     OutPort,
     PortOffset,
     ToNode,
-    _SubPort,
     _NodeLinks,
+    _SubPort,
 )
 
 if TYPE_CHECKING:

--- a/hugr-py/src/hugr/hugr/base.py
+++ b/hugr-py/src/hugr/hugr/base.py
@@ -90,7 +90,6 @@ _SO = _SubPort[OutPort]
 _SI = _SubPort[InPort]
 
 P = TypeVar("P", InPort, OutPort)
-K = TypeVar("K", InPort, OutPort)
 OpVar = TypeVar("OpVar", bound=Op)
 OpVarCov = TypeVar("OpVarCov", bound=Op, covariant=True)
 
@@ -464,10 +463,12 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         parent = self[node].parent
         if parent:
             self[parent].children.remove(node)
-        for inp, _ in self.incoming_links(node):
-            self._links.delete_right(_SubPort(inp))
-        for out, _ in self.outgoing_links(node):
-            self._links.delete_left(_SubPort(out))
+        for offset in range(self.num_in_ports(node)):
+            self._links.disconnect_port(node.inp(offset))
+        self._links.disconnect_port(node.inp(-1))
+        for offset in range(self.num_out_ports(node)):
+            self._links.disconnect_port(node.out(offset))
+        self._links.disconnect_port(node.out(-1))
 
         weight, self._nodes[node.idx] = self._nodes[node.idx], None
 
@@ -541,14 +542,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             src: Source port.
             dst: Destination port.
         """
-        try:
-            sub_offset = next(
-                i for i, inp in enumerate(self.linked_ports(src)) if inp == dst
-            )
-            self._links.delete_left(_SubPort(src, sub_offset))
-        except StopIteration:
-            return
-        # TODO make sure sub-offset is handled correctly
+        self._links.delete_link(src, dst)
 
     def entrypoint_op(self) -> OpVarCov:
         """The operation of the root node.
@@ -615,15 +609,6 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         """
         return self[node]._num_outs
 
-    def _linked_ports(
-        self, port: P, links: dict[_SubPort[P], _SubPort[K]]
-    ) -> Iterable[K]:
-        sub_port = _SubPort(port)
-        while sub_port in links:
-            # sub offset not used in API
-            yield links[sub_port].port
-            sub_port = sub_port.next_sub_offset()
-
     @overload
     def linked_ports(self, port: OutPort) -> Iterable[InPort]: ...
     @overload
@@ -644,11 +629,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             [InPort(Node(6), 0)]
 
         """
-        match port:
-            case OutPort(_):
-                return self._linked_ports(port, self._links.fwd)
-            case InPort(_):
-                return self._linked_ports(port, self._links.bck)
+        return self._links.linked_ports(port)
 
     # TODO: single linked port
 
@@ -683,19 +664,26 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         return (p.node for p in self.linked_ports(node.inp(-1)))
 
     def _node_links(
-        self, node: ToNode, links: dict[_SubPort[P], _SubPort[K]]
-    ) -> Iterable[tuple[P, list[K]]]:
-        try:
-            direction = next(iter(links.keys())).port.direction
-        except StopIteration:
+        self, node: ToNode, direction: Direction
+    ) -> Iterable[tuple[InPort | OutPort, list[InPort] | list[OutPort]]]:
+        node = node.to_node()
+        if node not in self:
             return
+
         # iterate over known offsets
         for offset in range(self.num_ports(node, direction)):
-            port = cast("P", node.port(offset, direction))
-            yield port, list(self._linked_ports(port, links))
+            port = node.port(offset, direction)
+            linked_ports = cast(
+                "list[InPort] | list[OutPort]",
+                list(self._links.linked_ports(port)),
+            )
+            yield port, linked_ports
 
-        order_port = cast("P", node.port(-1, direction))
-        linked_order = list(self._linked_ports(order_port, links))
+        order_port = node.port(-1, direction)
+        linked_order = cast(
+            "list[InPort] | list[OutPort]",
+            list(self._links.linked_ports(order_port)),
+        )
         if linked_order:
             yield order_port, linked_order
 
@@ -719,7 +707,10 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             >>> list(df.hugr.outgoing_links(df.input_node))
             [(OutPort(Node(5), 0), [InPort(Node(6), 0), InPort(Node(6), 1)]), (OutPort(Node(5), -1), [InPort(Node(6), -1)])]
         """  # noqa: E501
-        return self._node_links(node, self._links.fwd)
+        return cast(
+            "Iterable[tuple[OutPort, list[InPort]]]",
+            self._node_links(node, Direction.OUTGOING),
+        )
 
     def incoming_links(self, node: ToNode) -> Iterable[tuple[InPort, list[OutPort]]]:
         """Iterator over incoming links to a given node.
@@ -741,7 +732,10 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
             >>> list(df.hugr.incoming_links(df.output_node))
             [(InPort(Node(6), 0), [OutPort(Node(5), 0)]), (InPort(Node(6), 1), [OutPort(Node(5), 0)]), (InPort(Node(6), -1), [OutPort(Node(5), -1)])]
         """  # noqa: E501
-        return self._node_links(node, self._links.bck)
+        return cast(
+            "Iterable[tuple[InPort, list[OutPort]]]",
+            self._node_links(node, Direction.INCOMING),
+        )
 
     def neighbours(
         self, node: ToNode, direction: Direction | None = None
@@ -834,7 +828,7 @@ class Hugr(Mapping[Node, NodeData], Generic[OpVarCov]):
         """
         return sum(len(links) for (_, links) in self.outgoing_links(node))
 
-    # TODO: num_links and _linked_ports
+    # TODO: num_links
 
     def port_kind(self, port: InPort | OutPort) -> Kind:
         """The kind of a `port`.

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -237,8 +237,10 @@ class _SubPort(Generic[P]):
     def next_sub_offset(self) -> Self:
         return replace(self, sub_offset=self.sub_offset + 1)
 
+
 _SO = _SubPort[OutPort]
 _SI = _SubPort[InPort]
+
 
 @dataclass(frozen=True)
 class _NodeLinks:

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -243,7 +243,7 @@ _SI = _SubPort[InPort]
 @dataclass(frozen=True)
 class _NodeLinks:
     _inner: BiMap[_SO, _SI] = field(init=False, default_factory=BiMap)
-    _max_subs: dict[_SO | _SI, int] = field(init=False, default_factory=dict)
+    _max_subs: dict[OutPort | InPort, int] = field(init=False, default_factory=dict)
 
     def _unused_sub_offset(self, port: P) -> _SubPort[P]:
         max_sub = self._max_subs.get(port, -1)

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import (
@@ -14,8 +15,6 @@ from typing import (
 )
 
 from typing_extensions import Self
-
-from hugr.utils import BiMap
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -242,36 +241,105 @@ _SO = _SubPort[OutPort]
 _SI = _SubPort[InPort]
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, eq=False)
 class _NodeLinks:
-    _inner: BiMap[_SO, _SI] = field(init=False, default_factory=BiMap)
-    _max_subs: dict[OutPort | InPort, int] = field(init=False, default_factory=dict)
+    """Bidirectional sparse-subport storage for the links in a HUGR.
+
+    Subport offsets are monotonically allocated per port, and are not reused
+    after deletion. The global map retains deterministic link insertion order,
+    while the endpoint maps make queries and removals proportional to a port's
+    degree without scanning through unused sub-offsets.
+    """
+
+    #: All links in global insertion order.
+    _items: dict[_SO, _SI] = field(init=False, default_factory=dict)
+    #: Links indexed by their outgoing parent port.
+    _fwd: dict[OutPort, dict[_SO, _SI]] = field(init=False, default_factory=dict)
+    #: Links indexed by their incoming parent port.
+    _bck: dict[InPort, dict[_SI, _SO]] = field(init=False, default_factory=dict)
+    #: Highest sub-offset allocated for each parent port.
+    _max_subs: dict[OutPort | InPort, int] = field(
+        init=False, default_factory=dict, repr=False
+    )
+
+    def __eq__(self, other: object) -> bool:
+        """Compare logical links, ignoring their internal allocation history."""
+        if not isinstance(other, _NodeLinks):
+            return NotImplemented
+        links = Counter((src.port, dst.port) for src, dst in self.items())
+        other_links = Counter((src.port, dst.port) for src, dst in other.items())
+        return links == other_links
 
     def _unused_sub_offset(self, port: P) -> _SubPort[P]:
+        """Allocate the next monotonic sub-offset for ``port``."""
         max_sub = self._max_subs.get(port, -1)
         self._max_subs[port] = max_sub + 1
 
         return _SubPort(port, sub_offset=max_sub + 1)
 
-    def establish_link(self, src: OutPort, dst: InPort):
+    def establish_link(self, src: OutPort, dst: InPort) -> None:
+        """Establish a link using fresh subports at both endpoints."""
         src_sub = self._unused_sub_offset(src)
         dst_sub = self._unused_sub_offset(dst)
 
-        self._inner.insert_left(src_sub, dst_sub)
+        self._items[src_sub] = dst_sub
+        self._fwd.setdefault(src, {})[src_sub] = dst_sub
+        self._bck.setdefault(dst, {})[dst_sub] = src_sub
 
-    def delete_left(self, key: _SO):
-        self._inner.delete_left(key)
+    def _delete_left(self, src: _SO) -> None:
+        """Delete a link identified by its outgoing subport."""
+        dst = self._items.pop(src)
 
-    def delete_right(self, key: _SI):
-        self._inner.delete_right(key)
+        outgoing = self._fwd[src.port]
+        del outgoing[src]
+        if not outgoing:
+            del self._fwd[src.port]
 
-    def items(self):
-        return self._inner.items()
+        incoming = self._bck[dst.port]
+        del incoming[dst]
+        if not incoming:
+            del self._bck[dst.port]
 
-    @property
-    def fwd(self):
-        return self._inner.fwd
+    def delete_link(self, src: OutPort, dst: InPort) -> None:
+        """Delete the first link between the given parent ports, if present."""
+        outgoing = self._fwd.get(src, {})
+        incoming = self._bck.get(dst, {})
 
-    @property
-    def bck(self):
-        return self._inner.bck
+        if len(outgoing) <= len(incoming):
+            src_sub = next(
+                (sub for sub, linked in outgoing.items() if linked.port == dst), None
+            )
+        else:
+            src_sub = next(
+                (linked for linked in incoming.values() if linked.port == src), None
+            )
+        if src_sub is not None:
+            self._delete_left(src_sub)
+
+    def disconnect_port(self, port: InPort | OutPort) -> None:
+        """Delete every link incident to ``port``."""
+        match port:
+            case OutPort(_):
+                outgoing = tuple(self._fwd.get(port, {}))
+            case InPort(_):
+                outgoing = tuple(self._bck.get(port, {}).values())
+        for src in outgoing:
+            self._delete_left(src)
+
+    @overload
+    def linked_ports(self, port: OutPort) -> Iterator[InPort]: ...
+
+    @overload
+    def linked_ports(self, port: InPort) -> Iterator[OutPort]: ...
+
+    def linked_ports(self, port: OutPort | InPort):
+        """Iterate ports linked to ``port`` without assuming dense sub-offsets."""
+        match port:
+            case OutPort(_):
+                return (sub.port for sub in self._fwd.get(port, {}).values())
+            case InPort(_):
+                return (sub.port for sub in self._bck.get(port, {}).values())
+
+    def items(self) -> Iterator[tuple[_SO, _SI]]:
+        """Iterate all stored links in insertion order."""
+        return iter(self._items.items())

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -15,6 +15,8 @@ from typing import (
 
 from typing_extensions import Self
 
+from hugr.utils import BiMap
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -234,3 +236,40 @@ class _SubPort(Generic[P]):
 
     def next_sub_offset(self) -> Self:
         return replace(self, sub_offset=self.sub_offset + 1)
+
+_SO = _SubPort[OutPort]
+_SI = _SubPort[InPort]
+
+@dataclass(frozen=True)
+class _NodeLinks:
+    _inner: BiMap[_SO, _SI] = field(init=False, default_factory=BiMap)
+    _max_subs: dict[_SO | _SI, int] = field(init=False, default_factory=dict)
+
+    def _unused_sub_offset(self, port: P) -> _SubPort[P]:
+        max_sub = self._max_subs.get(port, -1)
+        self._max_subs[port] = max_sub + 1
+
+        return _SubPort(port, sub_offset=max_sub + 1)
+
+    def establish_link(self, src: OutPort, dst: InPort):
+        src_sub = self._unused_sub_offset(src)
+        dst_sub = self._unused_sub_offset(dst)
+
+        self._inner.insert_left(src_sub, dst_sub)
+
+    def delete_left(self, key: _SO):
+        self._inner.delete_left(key)
+
+    def delete_right(self, key: _SI):
+        self._inner.delete_right(key)
+
+    def items(self):
+        return self._inner.items()
+
+    @property
+    def fwd(self):
+        return self._inner.fwd
+
+    @property
+    def bck(self):
+        return self._inner.bck

--- a/hugr-py/src/hugr/hugr/node_port.py
+++ b/hugr-py/src/hugr/hugr/node_port.py
@@ -37,12 +37,17 @@ class _Port:
     offset: PortOffset
     direction: ClassVar[Direction]
 
+    def __hash__(self) -> int:
+        # Hash the integer identity directly, avoiding nested dataclass hashes.
+        return hash((self.node.idx, self.offset))
+
 
 @dataclass(frozen=True, eq=True, order=True)
 class InPort(_Port):
     """Incoming port, defined by the `node` it belongs to and the port `offset`."""
 
     direction: ClassVar[Direction] = Direction.INCOMING
+    __hash__ = _Port.__hash__
 
     def __repr__(self) -> str:
         return f"InPort({self.node}, {self.offset})"
@@ -61,6 +66,7 @@ class OutPort(_Port, Wire):
     """Outgoing port, defined by the `node` it belongs to and the port `offset`."""
 
     direction: ClassVar[Direction] = Direction.OUTGOING
+    __hash__ = _Port.__hash__
 
     def out_port(self) -> OutPort:
         return self
@@ -233,6 +239,10 @@ class _SubPort(Generic[P]):
     port: P
     sub_offset: int = 0
 
+    def __hash__(self) -> int:
+        """Hash the flattened port and sub-offset identity."""
+        return hash((self.port.node.idx, self.port.offset, self.sub_offset))
+
     def next_sub_offset(self) -> Self:
         return replace(self, sub_offset=self.sub_offset + 1)
 
@@ -253,10 +263,14 @@ class _NodeLinks:
 
     #: All links in global insertion order.
     _items: dict[_SO, _SI] = field(init=False, default_factory=dict)
-    #: Links indexed by their outgoing parent port.
-    _fwd: dict[OutPort, dict[_SO, _SI]] = field(init=False, default_factory=dict)
-    #: Links indexed by their incoming parent port.
-    _bck: dict[InPort, dict[_SI, _SO]] = field(init=False, default_factory=dict)
+    #: Links indexed by their outgoing parent port and sub-offset.
+    #
+    # We use the offset `int` instead of `_SI` to avoid unnecessary hashing.
+    _fwd: dict[OutPort, dict[int, _SI]] = field(init=False, default_factory=dict)
+    #: Links indexed by their incoming parent port and sub-offset.
+    #
+    # We use the offset `int` instead of `_SI` to avoid unnecessary hashing.
+    _bck: dict[InPort, dict[int, _SO]] = field(init=False, default_factory=dict)
     #: Highest sub-offset allocated for each parent port.
     _max_subs: dict[OutPort | InPort, int] = field(
         init=False, default_factory=dict, repr=False
@@ -283,20 +297,20 @@ class _NodeLinks:
         dst_sub = self._unused_sub_offset(dst)
 
         self._items[src_sub] = dst_sub
-        self._fwd.setdefault(src, {})[src_sub] = dst_sub
-        self._bck.setdefault(dst, {})[dst_sub] = src_sub
+        self._fwd.setdefault(src, {})[src_sub.sub_offset] = dst_sub
+        self._bck.setdefault(dst, {})[dst_sub.sub_offset] = src_sub
 
     def _delete_left(self, src: _SO) -> None:
         """Delete a link identified by its outgoing subport."""
         dst = self._items.pop(src)
 
         outgoing = self._fwd[src.port]
-        del outgoing[src]
+        del outgoing[src.sub_offset]
         if not outgoing:
             del self._fwd[src.port]
 
         incoming = self._bck[dst.port]
-        del incoming[dst]
+        del incoming[dst.sub_offset]
         if not incoming:
             del self._bck[dst.port]
 
@@ -306,8 +320,16 @@ class _NodeLinks:
         incoming = self._bck.get(dst, {})
 
         if len(outgoing) <= len(incoming):
-            src_sub = next(
-                (sub for sub, linked in outgoing.items() if linked.port == dst), None
+            src_sub_offset = next(
+                (
+                    sub_offset
+                    for sub_offset, linked in outgoing.items()
+                    if linked.port == dst
+                ),
+                None,
+            )
+            src_sub = (
+                _SubPort(src, src_sub_offset) if src_sub_offset is not None else None
             )
         else:
             src_sub = next(
@@ -320,7 +342,9 @@ class _NodeLinks:
         """Delete every link incident to ``port``."""
         match port:
             case OutPort(_):
-                outgoing = tuple(self._fwd.get(port, {}))
+                outgoing = tuple(
+                    _SubPort(port, sub_offset) for sub_offset in self._fwd.get(port, {})
+                )
             case InPort(_):
                 outgoing = tuple(self._bck.get(port, {}).values())
         for src in outgoing:

--- a/hugr-py/src/hugr/utils.py
+++ b/hugr-py/src/hugr/utils.py
@@ -11,6 +11,8 @@ from collections.abc import (
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Generic, Protocol, TypeVar
 
+from typing_extensions import deprecated
+
 if TYPE_CHECKING:
     from hugr.tys import TypeArg
 
@@ -27,6 +29,7 @@ class NotBijection(Exception):
 
 
 @dataclass()
+@deprecated("Will be removed in a future version.")  # Since 0.18.5
 class BiMap(MutableMapping, Generic[L, R]):
     """Bidirectional map backed by two dictionaries, between left types `L` and
     right types `R`.

--- a/hugr-py/tests/test_hugr_build.py
+++ b/hugr-py/tests/test_hugr_build.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html
+from copy import deepcopy
 
 import pytest
 
@@ -110,6 +111,61 @@ def test_multiport(snapshot):
 
     assert list(h.hugr.linked_ports(ou_n.inp(0))) == [in_n.out(0)]
     validate(h.hugr, snap=snapshot)
+
+
+def test_sparse_subports():
+    dfg = Dfg(tys.Bool)
+    h = dfg.hugr
+    src = dfg.input_node.out(0)
+    dst = dfg.output_node
+    dst_0, dst_1, dst_2 = dst.inp(0), dst.inp(1), dst.inp(2)
+
+    h.add_link(src, dst_0)
+    h.add_link(src, dst_1)
+    h.delete_link(src, dst_0)
+
+    assert list(h.linked_ports(src)) == [dst_1]
+    assert list(h.linked_ports(dst_1)) == [src]
+
+    h.add_link(src, dst_2)
+    assert list(h.linked_ports(src)) == [dst_1, dst_2]
+
+    h.delete_link(src, dst_1)
+    assert list(h.linked_ports(src)) == [dst_2]
+
+
+def test_delete_node_with_fanout():
+    h = Hugr(ops.DFG([]))
+    src = h.add_node(Not, num_outs=1)
+    dst_0 = h.add_node(Not)
+    dst_1 = h.add_node(Not)
+
+    h.add_link(src.out(0), dst_0.inp(0))
+    h.add_link(src.out(0), dst_1.inp(0))
+    h.delete_node(src)
+
+    assert list(h.links()) == []
+    assert list(h.linked_ports(dst_0.inp(0))) == []
+    assert list(h.linked_ports(dst_1.inp(0))) == []
+
+    replacement = h.add_node(Not, num_outs=1)
+    assert replacement == src
+    h.add_link(replacement.out(0), dst_0.inp(0))
+    assert list(h.linked_ports(replacement.out(0))) == [dst_0.inp(0)]
+    assert list(h.linked_ports(dst_0.inp(0))) == [replacement.out(0)]
+
+
+def test_link_allocation_history_does_not_affect_equality():
+    h = Hugr(ops.DFG([]))
+    src = h.add_node(Not, num_outs=1)
+    dst = h.add_node(Not)
+    h.add_link(src.out(0), dst.inp(0))
+    equivalent = deepcopy(h)
+
+    h.delete_link(src.out(0), dst.inp(0))
+    h.add_link(src.out(0), dst.inp(0))
+
+    assert h == equivalent
 
 
 def test_add_op(snapshot):


### PR DESCRIPTION
We previously also had scenarios where sub offsets contained holes (e.g. when links were broken as a last act), so it should make no real difference in functionality where there are more or less holes in sub offsets. In Python, it should also not have much of a performance impact. This change seems to pass all tests in `guppylang` as well, so I presume it is fine.