### PR TITLE
feat(cli): include edge counts in describe output

### DIFF
--- a/hugr-cli/src/describe.rs
+++ b/hugr-cli/src/describe.rs
@@ -266,6 +266,8 @@ struct ModuleSummary {
     #[tabled(display("display::option", "n/a"))]
     num_nodes: Option<usize>,
     #[tabled(display("display::option", "n/a"))]
+    num_edges: Option<usize>,
+    #[tabled(display("display::option", "n/a"))]
     entrypoint_node: Option<usize>,
     #[tabled(display("display::option", "n/a"))]
     entrypoint_op: Option<String>,
@@ -285,6 +287,7 @@ impl From<&ModuleDesc> for ModuleSummary {
         };
         Self {
             num_nodes: desc.num_nodes,
+            num_edges: desc.num_edges,
             entrypoint_node,
             entrypoint_op,
             generator: desc.generator.clone(),

--- a/hugr-cli/tests/describe.rs
+++ b/hugr-cli/tests/describe.rs
@@ -179,6 +179,7 @@ fn test_describe_default(package_with_exts_default_file: NamedTempFile, mut desc
           },
           "generator": "my_generator-v2.0.0",
           "num_nodes": 6,
+          "num_edges": 2,
           "used_extensions_resolved": [
             {
               "name": "resolved_ext",
@@ -214,6 +215,7 @@ fn test_describe_packaged_extensions(
         .assert()
         .success()
         .stdout(contains("my_generator-v2.0.0"))
+        .stdout(contains("num_edges"))
         .stdout(contains("Resolved extensions:"))
         .stdout(contains("Packaged extensions:"))
         .stdout(contains("used_ext").not())
@@ -443,6 +445,15 @@ fn test_schema(mut describe_cmd: Command) {
             },
             "num_nodes": {
               "description": "Number of nodes in the module.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint",
+              "minimum": 0
+            },
+            "num_edges": {
+              "description": "Number of edges in the module.",
               "type": [
                 "integer",
                 "null"

--- a/hugr-core/src/envelope/description.rs
+++ b/hugr-core/src/envelope/description.rs
@@ -354,6 +354,10 @@ pub struct ModuleDesc {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub num_nodes: Option<usize>,
+    /// Number of edges in the module.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub num_edges: Option<usize>,
     /// The entrypoint node and the corresponding operation type.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
@@ -380,6 +384,11 @@ impl ModuleDesc {
     /// Sets the number of nodes in the module.
     pub fn set_num_nodes(&mut self, num_nodes: usize) {
         self.num_nodes = Some(num_nodes);
+    }
+
+    /// Sets the number of edges in the module.
+    pub fn set_num_edges(&mut self, num_edges: usize) {
+        self.num_edges = Some(num_edges);
     }
 
     /// Sets the entrypoint of the module.
@@ -490,9 +499,15 @@ impl ModuleDesc {
         self.set_num_nodes(hugr.num_nodes());
     }
 
+    /// Loads the number of edges in the module from the HUGR.
+    pub(crate) fn load_num_edges(&mut self, hugr: &impl HugrView) {
+        self.set_num_edges(hugr.num_edges());
+    }
+
     /// Loads full description of the module from the HUGR.
     pub(crate) fn load_from_hugr(&mut self, hugr: &impl HugrView<Node = Node>) {
         self.load_num_nodes(hugr);
+        self.load_num_edges(hugr);
         self.load_entrypoint(hugr);
         self.load_generator(hugr);
         self.load_used_extensions_resolved(hugr);
@@ -588,6 +603,12 @@ mod test {
     fn test_module_desc_set_num_nodes(mut empty_module_desc: ModuleDesc) {
         empty_module_desc.set_num_nodes(10);
         assert_eq!(empty_module_desc.num_nodes, Some(10));
+    }
+
+    #[rstest]
+    fn test_module_desc_set_num_edges(mut empty_module_desc: ModuleDesc) {
+        empty_module_desc.set_num_edges(20);
+        assert_eq!(empty_module_desc.num_edges, Some(20));
     }
 
     #[rstest]

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -298,6 +298,7 @@ pub(crate) fn import_described_hugr(
             return (ctx.description, Err(ImportError { inner: e }));
         }
     }
+    ctx.description.set_num_edges(ctx.hugr.num_edges());
     (ctx.description, Ok(ctx.hugr))
 }
 

--- a/hugr-py/src/hugr/cli.py
+++ b/hugr-py/src/hugr/cli.py
@@ -93,6 +93,7 @@ class ModuleDesc(BaseModel):
         entrypoint: The entrypoint node of the module, if present.
         generator: Name and version of the generator that created this module.
         num_nodes: Total number of nodes in the module.
+        num_edges: Total number of edges in the module.
         public_symbols: List of public symbol names exported by the module.
         used_extensions_generator: Extensions claimed by the generator in metadata.
         used_extensions_resolved: Extensions actually used by the module operations.
@@ -101,6 +102,7 @@ class ModuleDesc(BaseModel):
     entrypoint: EntrypointDesc | None = None
     generator: str | None = None
     num_nodes: int | None = None
+    num_edges: int | None = None
     public_symbols: list[str] | None = None
     used_extensions_generator: list[ExtensionDesc] | None = None
     used_extensions_resolved: list[ExtensionDesc] | None = None

--- a/hugr-py/tests/test_cli.py
+++ b/hugr-py/tests/test_cli.py
@@ -122,6 +122,8 @@ def test_describe_json_basic(simple_hugr_bytes: bytes):
     assert isinstance(module, cli.ModuleDesc)
     assert module.num_nodes is not None
     assert module.num_nodes > 0
+    assert module.num_edges is not None
+    assert module.num_edges == 0
 
 
 def test_describe_json_with_packaged_extensions(hugr_with_extension_bytes: bytes):
@@ -165,6 +167,7 @@ def test_failed_describe(hugr_using_ext):
     mod = desc.modules[0]
     assert mod is not None
     assert mod.num_nodes == 8  # computed before error
+    assert mod.num_edges == 2  # computed before extension resolution error
     assert isinstance(desc.error, str)
     assert "requires extension ext" in desc.error
 


### PR DESCRIPTION
## Summary

- add module edge counts to HUGR package descriptions
- display edge counts in human-readable and JSON describe output
- expose edge counts through the Python description model
- retain exact edge counts when extension resolution fails after graph import