### PR TITLE
perf!: Reuse shared types during HUGR import

### DIFF
--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -13,7 +13,10 @@ use crate::builder::{
 use crate::envelope::EnvelopeConfig;
 use crate::extension::prelude::{ConstUsize, bool_t, usize_custom_t, usize_t};
 use crate::extension::resolution::WeakExtensionRegistry;
-use crate::extension::resolution::{resolve_op_extensions, resolve_op_types_extensions};
+use crate::extension::resolution::{
+    resolve_op_extensions, resolve_op_types_extensions,
+    resolve_type_extensions as resolve_type_extension_refs,
+};
 use crate::extension::{
     ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE, PRELUDE_REGISTRY, TypeDefBound, Version,
 };
@@ -145,6 +148,20 @@ fn resolve_custom_type_uses_highest_compatible_extension() {
         panic!("expected custom type");
     };
     assert_eq!(custom.extension_version(), Some(&Version::new(0, 2, 5)));
+}
+
+/// Resolving an already-resolved type should preserve its shared storage.
+#[test]
+fn resolving_current_type_extensions_preserves_shared_storage() {
+    let registry = std_reg();
+    let weak_registry = WeakExtensionRegistry::from(&registry);
+    let original = usize_t();
+    let mut resolved = original.clone();
+    assert!(original.shares_storage_with(&resolved));
+
+    resolve_type_extension_refs(&mut resolved, &weak_registry).unwrap();
+
+    assert!(original.shares_storage_with(&resolved));
 }
 
 /// Create a new test extension with a single operation.

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -225,13 +225,89 @@ pub(super) fn resolve_type_exts(
     extensions: &WeakExtensionRegistry,
     used_extensions: &mut WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    const EMPTY: Type = Type::new_unit_sum(0); // as no Type::default()
-    let mut tm = std::mem::replace(typ, EMPTY).into();
+    if collect_current_type_exts(typ, extensions, used_extensions) {
+        return Ok(());
+    }
+
+    let mut tm = std::mem::replace(typ, Type::new_unit_sum(0)).into();
     let r = resolve_term_exts(node, &mut tm, extensions, used_extensions);
     *typ = tm
         .try_into()
         .expect("Resolving extensions cannot change kind from RuntimeType");
     r
+}
+
+/// Collects extension references when they already match the target registry.
+///
+/// Imported types already contain the correct weak references. Detecting that
+/// case before requesting mutable access preserves their shared backing.
+fn collect_current_type_exts(
+    typ: &Type,
+    extensions: &WeakExtensionRegistry,
+    used_extensions: &mut WeakExtensionRegistry,
+) -> bool {
+    if !term_extension_refs_match(typ, extensions) {
+        return false;
+    }
+
+    let mut current_extensions = WeakExtensionRegistry::default();
+    let mut missing_extensions = ExtensionSet::new();
+    collect_term_exts(typ, &mut current_extensions, &mut missing_extensions);
+
+    if !missing_extensions.is_empty() {
+        return false;
+    }
+
+    for (id, version, extension) in current_extensions {
+        used_extensions.register(id, version, extension);
+    }
+    true
+}
+
+/// Checks every custom type reference against the target registry.
+fn term_extension_refs_match(term: &Term, extensions: &WeakExtensionRegistry) -> bool {
+    match term {
+        Term::ExtensionType(custom) => {
+            let current = custom.extension_ref();
+            current.upgrade().is_some()
+                && extensions
+                    .get_req(custom.extension(), custom.extension_version())
+                    .is_some_and(|(_, expected)| current.ptr_eq(expected))
+                && custom
+                    .args()
+                    .iter()
+                    .all(|arg| term_extension_refs_match(arg, extensions))
+        }
+        Term::FunctionType(func) => {
+            term_extension_refs_match(&func.input, extensions)
+                && term_extension_refs_match(&func.output, extensions)
+        }
+        Term::SumType(SumType::General(general)) => general
+            .rows()
+            .iter()
+            .all(|row| term_extension_refs_match(row, extensions)),
+        Term::ConstKind(typ) => term_extension_refs_match(typ, extensions),
+        Term::List(children)
+        | Term::ListConcat(children)
+        | Term::Tuple(children)
+        | Term::TupleConcat(children) => children
+            .iter()
+            .all(|child| term_extension_refs_match(child, extensions)),
+        Term::ListKind(item_type) => term_extension_refs_match(item_type, extensions),
+        Term::TupleKind(item_types) => term_extension_refs_match(item_types, extensions),
+        Term::Variable(_)
+        | Term::TypeKind(_)
+        | Term::StaticKind
+        | Term::BoundedNatKind(_)
+        | Term::StringKind
+        | Term::BytesKind
+        | Term::FloatKind
+        | Term::BoundedNat(_)
+        | Term::String(_)
+        | Term::Bytes(_)
+        | Term::Float(_)
+        | Term::SumType(SumType::Unit { .. }) => true,
+    }
 }
 
 /// Update all weak Extension pointers in the [`CustomType`]s inside a [`Term`].

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -267,18 +267,7 @@ pub(crate) fn import_described_hugr(
 ) -> (ModuleDesc, Result<Hugr, ImportError>) {
     // TODO: Module should know about the number of edges, so that we can use a vector here.
     // For now we use a hashmap, which will be slower.
-    let mut ctx = Context {
-        module,
-        hugr: Hugr::new(),
-        link_ports: FxHashMap::default(),
-        static_edges: Vec::new(),
-        extensions,
-        nodes: FxHashMap::default(),
-        local_vars: FxHashMap::default(),
-        custom_name_cache: FxHashMap::default(),
-        region_scope: table::RegionId::default(),
-        description: ModuleDesc::default(),
-    };
+    let mut ctx = Context::new(module, extensions);
 
     if let Some(s) = get_generator(&ctx) {
         ctx.description.set_generator(s);
@@ -326,12 +315,32 @@ struct Context<'a> {
 
     custom_name_cache: FxHashMap<&'a str, (ExtensionId, SmolStr)>,
 
+    /// Successfully imported runtime types, keyed by their model table id.
+    type_cache: FxHashMap<table::TermId, Type>,
+
     region_scope: table::RegionId,
 
     description: ModuleDesc,
 }
 
 impl<'a> Context<'a> {
+    /// Creates the state used to import one model module.
+    fn new(module: &'a table::Module<'a>, extensions: &'a ExtensionRegistry) -> Self {
+        Self {
+            module,
+            hugr: Hugr::new(),
+            link_ports: FxHashMap::default(),
+            static_edges: Vec::new(),
+            extensions,
+            nodes: FxHashMap::default(),
+            local_vars: FxHashMap::default(),
+            custom_name_cache: FxHashMap::default(),
+            type_cache: FxHashMap::default(),
+            region_scope: table::RegionId::default(),
+            description: ModuleDesc::default(),
+        }
+    }
+
     /// Get the signature of the node with the given `NodeId`.
     fn get_node_signature(&mut self, node: table::NodeId) -> Result<Signature, ImportErrorInner> {
         let node_data = self.get_node(node)?;
@@ -1551,7 +1560,13 @@ impl<'a> Context<'a> {
     }
 
     fn import_type(&mut self, term_id: table::TermId) -> Result<Type, ImportErrorInner> {
-        Ok(Type::try_from(self.import_term(term_id)?)?)
+        if let Some(typ) = self.type_cache.get(&term_id) {
+            return Ok(typ.clone());
+        }
+
+        let typ = Type::try_from(self.import_term(term_id)?)?;
+        self.type_cache.insert(term_id, typ.clone());
+        Ok(typ)
     }
 
     fn import_term_with_bound(
@@ -1921,9 +1936,9 @@ impl<'a> Context<'a> {
         let elems = self.import_closed_list(term_id)?;
         Ok(elems
             .into_iter()
-            .map(|id| self.import_term(id))
+            .map(|id| self.import_type(id))
             .collect::<Result<Vec<_>, _>>()?
-            .try_into()?)
+            .into())
     }
 
     fn import_custom_name(
@@ -2244,9 +2259,42 @@ impl LocalVar {
 
 #[cfg(test)]
 mod test {
-    use crate::Hugr;
+    use std::str::FromStr;
+
+    use crate::{Hugr, std_extensions::std_reg};
+    use hugr_model::v0::{self as model, table};
     use rstest::rstest;
     use std::path::PathBuf;
+
+    use super::Context;
+
+    /// Check that type imports of the same term share the same underlying storage.
+    #[rstest]
+    fn repeated_runtime_type_imports_share_storage() {
+        let ast = model::ast::Package::from_str(include_str!(
+            "../../hugr-model/tests/fixtures/model-add.edn"
+        ))
+        .unwrap();
+        let bump = model::bumpalo::Bump::new();
+        let package = ast.resolve(&bump).unwrap();
+        let module = &package.modules[0];
+        let registry = std_reg();
+        let mut context = Context::new(module, &registry);
+
+        let (term_id, first) = (0..module.terms.len())
+            .map(table::TermId::new)
+            .find_map(|term_id| {
+                context
+                    .import_type(term_id)
+                    .ok()
+                    .filter(|typ| typ.as_extension().is_some())
+                    .map(|typ| (term_id, typ))
+            })
+            .expect("fixture should contain an extension type");
+        let second = context.import_type(term_id).unwrap();
+
+        assert!(first.shares_storage_with(&second));
+    }
 
     #[rstest]
     fn test_import_cases(#[files("../test_files/import_tests/*.hugr")] case: PathBuf) {

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -265,8 +265,6 @@ pub(crate) fn import_described_hugr(
     module: &table::Module,
     extensions: &ExtensionRegistry,
 ) -> (ModuleDesc, Result<Hugr, ImportError>) {
-    // TODO: Module should know about the number of edges, so that we can use a vector here.
-    // For now we use a hashmap, which will be slower.
     let mut ctx = Context::new(module, extensions);
 
     if let Some(s) = get_generator(&ctx) {
@@ -326,6 +324,8 @@ struct Context<'a> {
 impl<'a> Context<'a> {
     /// Creates the state used to import one model module.
     fn new(module: &'a table::Module<'a>, extensions: &'a ExtensionRegistry) -> Self {
+        // TODO: Module should know about the number of edges, so that we can use a vector here.
+        // For now we use a hashmap, which will be slower.
         Self {
             module,
             hugr: Hugr::new(),

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -570,6 +570,12 @@ impl Type {
 
 impl Transformable for Type {
     fn transform<T: TypeTransformer>(&mut self, tr: &T) -> Result<bool, T::Err> {
+        // Note that this forces cloning the type even if the transformation
+        // does not actually change it.
+        //
+        // The resulting types are always unique.
+        //
+        // TODO: Can we keep the sharing of types after transformation via some cache?
         self.0.make_mut().transform(tr)
     }
 }

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -29,6 +29,7 @@ use itertools::{Either, Itertools as _};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
+use std::sync::Arc;
 
 use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
 
@@ -371,10 +372,7 @@ impl From<SumType> for Type {
     }
 }
 
-#[derive(
-    Clone, Debug, Eq, Hash, PartialEq, derive_more::Display, serde::Serialize, serde::Deserialize,
-)]
-#[display("{_0}")]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 #[serde(
     into = "serialize::SerSimpleType",
     try_from = "serialize::SerSimpleType"
@@ -401,17 +399,80 @@ impl From<SumType> for Type {
 /// let func_type: Type = Type::new_function(Signature::new_endo([]));
 /// assert_eq!(func_type.least_upper_bound(), TypeBound::Copyable);
 /// ```
-pub struct Type(Term);
+pub struct Type(TypeStorage);
+
+/// The backing storage for a [`Type`].
+///
+/// Runtime-created types use reference-counted storage so cloning a type does
+/// not recursively clone its term tree. The static variant keeps simple type
+/// constants allocation-free.
+#[derive(Clone)]
+enum TypeStorage {
+    Static(&'static Term),
+    Shared(Arc<Term>),
+}
+
+/// The term backing the allocation-free [`Type::UNIT`] constant.
+static UNIT_TERM: Term = Term::SumType(SumType::Unit { size: 1 });
+
+impl TypeStorage {
+    /// Returns the stored term independent of the storage strategy.
+    fn as_term(&self) -> &Term {
+        match self {
+            Self::Static(term) => term,
+            Self::Shared(term) => term,
+        }
+    }
+
+    /// Returns a mutable term, cloning shared or static storage when needed.
+    fn make_mut(&mut self) -> &mut Term {
+        if let Self::Static(term) = self {
+            *self = Self::Shared(Arc::new((*term).clone()));
+        }
+
+        let Self::Shared(term) = self else {
+            unreachable!("static type storage was converted to shared storage")
+        };
+        Arc::make_mut(term)
+    }
+
+    /// Consumes the storage, avoiding a clone when shared storage is unique.
+    fn into_term(self) -> Term {
+        match self {
+            Self::Static(term) => term.clone(),
+            Self::Shared(term) => {
+                Arc::try_unwrap(term).unwrap_or_else(|term| term.as_ref().clone())
+            }
+        }
+    }
+}
 
 impl Type {
     /// An empty `TypeRow` or `TypeRowRV`. Provided here for convenience
     pub const EMPTY_TYPEROW: TypeRow = TypeRow::new();
     /// Unit type (empty tuple).
-    pub const UNIT: Self = Self(Term::SumType(SumType::Unit { size: 1 }));
+    pub const UNIT: Self = Self(TypeStorage::Static(&UNIT_TERM));
+
+    /// Wraps a validated runtime type term in shared storage.
+    fn from_term(term: Term) -> Self {
+        Self(TypeStorage::Shared(Arc::new(term)))
+    }
+
+    /// Returns whether two types use the same backing allocation.
+    ///
+    /// Used for testing only.
+    #[cfg(test)]
+    pub(crate) fn shares_storage_with(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (TypeStorage::Static(left), TypeStorage::Static(right)) => std::ptr::eq(*left, *right),
+            (TypeStorage::Shared(left), TypeStorage::Shared(right)) => Arc::ptr_eq(left, right),
+            _ => false,
+        }
+    }
 
     /// Initialize a new function type.
     pub fn new_function(fun_ty: impl Into<FuncValueType>) -> Self {
-        Self(Term::FunctionType(Box::new(fun_ty.into())))
+        Self::from_term(Term::FunctionType(Box::new(fun_ty.into())))
     }
 
     /// Initialize a new tuple type by providing the elements.
@@ -431,21 +492,21 @@ impl Type {
         R: Into<TypeRowRV>,
     {
         let st = SumType::new(variants);
-        Self(Term::SumType(st))
+        Self::from_term(Term::SumType(st))
     }
 
     /// Initialize a new custom type.
     // TODO remove? Extensions/TypeDefs should just provide `Type` directly
     #[must_use]
-    pub const fn new_extension(opaque: CustomType) -> Self {
-        Self(Term::ExtensionType(opaque))
+    pub fn new_extension(opaque: CustomType) -> Self {
+        Self::from_term(Term::ExtensionType(opaque))
     }
 
     /// New `UnitSum` with empty Tuple variants
     #[must_use]
-    pub const fn new_unit_sum(size: u8) -> Self {
+    pub fn new_unit_sum(size: u8) -> Self {
         // should be the only way to avoid going through SumType::new
-        Self(Term::SumType(SumType::new_unary(size)))
+        Self::from_term(Term::SumType(SumType::new_unary(size)))
     }
 
     /// New use (occurrence) of the type variable with specified index.
@@ -454,18 +515,18 @@ impl Type {
     /// than required for the use.
     #[must_use]
     pub fn new_var_use(idx: usize, bound: TypeBound) -> Self {
-        Self(Term::new_var_use(idx, bound))
+        Self::from_term(Term::new_var_use(idx, bound))
     }
 
     /// Report the least upper [`TypeBound`]
     #[inline(always)]
-    pub const fn least_upper_bound(&self) -> TypeBound {
-        self.0.least_upper_bound().unwrap()
+    pub fn least_upper_bound(&self) -> TypeBound {
+        self.deref().least_upper_bound().unwrap()
     }
 
     /// Report if the type is copyable - i.e.the least upper bound of the type
     /// is contained by the copyable bound.
-    pub const fn copyable(&self) -> bool {
+    pub fn copyable(&self) -> bool {
         TypeBound::Copyable.contains(self.least_upper_bound())
     }
 
@@ -477,7 +538,7 @@ impl Type {
     /// [validate]: crate::types::type_param::TypeArg::validate
     /// [TypeDef]: crate::extension::TypeDef
     pub(crate) fn validate(&self, var_decls: &[TypeParam]) -> Result<(), SignatureError> {
-        self.0.validate(var_decls)?;
+        self.deref().validate(var_decls)?;
         Ok(())
     }
 
@@ -486,7 +547,7 @@ impl Type {
     /// Always produces exactly one type, but may narrow the bound (from
     /// [TypeBound::Linear] to [TypeBound::Copyable]).
     fn substitute(&self, s: &Substitution) -> Self {
-        Self(self.0.substitute(s))
+        Self::from_term(self.deref().substitute(s))
     }
 
     /// Returns a registry with the concrete extensions used by this type.
@@ -509,7 +570,7 @@ impl Type {
 
 impl Transformable for Type {
     fn transform<T: TypeTransformer>(&mut self, tr: &T) -> Result<bool, T::Err> {
-        self.0.transform(tr)
+        self.0.make_mut().transform(tr)
     }
 }
 
@@ -517,7 +578,33 @@ impl Deref for Type {
     type Target = Term;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        self.0.as_term()
+    }
+}
+
+impl std::fmt::Debug for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Type").field(self.deref()).finish()
+    }
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.deref().fmt(f)
+    }
+}
+
+impl PartialEq for Type {
+    fn eq(&self, other: &Self) -> bool {
+        self.deref() == other.deref()
+    }
+}
+
+impl Eq for Type {}
+
+impl std::hash::Hash for Type {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.deref().hash(state);
     }
 }
 
@@ -526,7 +613,7 @@ impl TryFrom<Term> for Type {
 
     fn try_from(t: Term) -> Result<Self, TermKindError> {
         match t.is_runtime_type() {
-            true => Ok(Self(t)),
+            true => Ok(Self::from_term(t)),
             false => Err(TermKindError::KindMismatch {
                 term: Box::new(t),
                 kind: Box::new(TypeBound::Linear.into()),
@@ -537,7 +624,7 @@ impl TryFrom<Term> for Type {
 
 impl From<Type> for Term {
     fn from(t: Type) -> Self {
-        t.0
+        t.0.into_term()
     }
 }
 
@@ -747,9 +834,13 @@ pub(crate) mod test {
         let lin = e.get_type(&LIN).unwrap().instantiate([]).unwrap();
 
         let lin_to_usize = FnTransformer(|ct: &CustomType| (*ct == lin).then_some(usize_t()));
-        let mut t = Type::new_extension(lin.clone());
+        let original = Type::new_extension(lin.clone());
+        let mut t = original.clone();
+        assert!(original.shares_storage_with(&t));
         assert_eq!(t.transform(&lin_to_usize), Ok(true));
         assert_eq!(t, usize_t());
+        assert_eq!(original, Type::new_extension(lin.clone()));
+        assert!(!original.shares_storage_with(&t));
 
         for coln in [
             list_type,

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -435,12 +435,14 @@ impl TypeStorage {
         };
         Arc::make_mut(term)
     }
+}
 
+impl From<TypeStorage> for Term {
     /// Consumes the storage, avoiding a clone when shared storage is unique.
-    fn into_term(self) -> Term {
-        match self {
-            Self::Static(term) => term.clone(),
-            Self::Shared(term) => {
+    fn from(storage: TypeStorage) -> Term {
+        match storage {
+            TypeStorage::Static(term) => term.clone(),
+            TypeStorage::Shared(term) => {
                 Arc::try_unwrap(term).unwrap_or_else(|term| term.as_ref().clone())
             }
         }
@@ -454,6 +456,8 @@ impl Type {
     pub const UNIT: Self = Self(TypeStorage::Static(&UNIT_TERM));
 
     /// Wraps a validated runtime type term in shared storage.
+    ///
+    /// The caller should check term is a valid type.
     fn from_term(term: Term) -> Self {
         Self(TypeStorage::Shared(Arc::new(term)))
     }
@@ -630,7 +634,7 @@ impl TryFrom<Term> for Type {
 
 impl From<Type> for Term {
     fn from(t: Type) -> Self {
-        t.0.into_term()
+        t.0.into()
     }
 }
 

--- a/hugr-core/src/types/type_param.rs
+++ b/hugr-core/src/types/type_param.rs
@@ -676,7 +676,7 @@ impl Transformable for Term {
         match self {
             Term::ExtensionType(custom_type) => {
                 if let Some(nt) = tr.apply_custom(custom_type)? {
-                    *self = nt.0;
+                    *self = nt.into();
                     Ok(true)
                 } else {
                     let args_changed = custom_type.args_mut().transform(tr)?;

--- a/hugr-llvm/src/types.rs
+++ b/hugr-llvm/src/types.rs
@@ -121,7 +121,7 @@ pub mod test {
     use crate::{test::*, types::HugrFuncType};
 
     #[rstest]
-    #[case(0,HugrFuncType::new(type_row!(Type::new_unit_sum(2)), type_row!()))]
+    #[case(0,HugrFuncType::new([Type::new_unit_sum(2)], type_row!()))]
     #[case(1, HugrFuncType::new([Type::new_unit_sum(1)], [Type::new_unit_sum(3)]))]
     #[case(2,HugrFuncType::new(vec![], vec![Type::new_unit_sum(1), Type::new_unit_sum(1)]))]
     fn func_types(#[case] _id: i32, #[with(_id)] llvm_ctx: TestContext, #[case] ft: HugrFuncType) {
@@ -156,7 +156,7 @@ pub mod test {
     #[case(4, INT_TYPES[6].clone())]
     #[case(5, Type::new_sum([vec![INT_TYPES[2].clone()]]))]
     #[case(6, Type::new_sum([vec![INT_TYPES[6].clone(),Type::new_unit_sum(1)], vec![Type::new_unit_sum(2), INT_TYPES[2].clone()]]))]
-    #[case(7, Type::new_function(HugrFuncType::new(type_row!(Type::new_unit_sum(2)), [Type::new_unit_sum(3)])))]
+    #[case(7, Type::new_function(HugrFuncType::new([Type::new_unit_sum(2)], [Type::new_unit_sum(3)])))]
     fn ext_types(#[case] _id: i32, #[with(_id)] mut llvm_ctx: TestContext, #[case] t: Type) {
         use crate::CodegenExtsBuilder;
 


### PR DESCRIPTION
Use an `Arc` under `Type` to avoid multiple decodings of the same type.

BREAKING CHANGE: Some `Type` methods are no longer `const`