### PR TITLE
refactor: Add a shared TypeResolverContext to avoid repeated resolution

### DIFF
--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -26,10 +26,7 @@ pub use weak_registry::WeakExtensionRegistry;
 
 pub(crate) use ops::{collect_op_extension, resolve_op_extensions};
 pub(crate) use types::{collect_op_types_extensions, collect_signature_exts, collect_term_exts};
-pub(crate) use types_mut::resolve_op_types_extensions;
-use types_mut::{
-    resolve_custom_type_exts, resolve_term_exts, resolve_type_exts, resolve_value_exts,
-};
+pub(crate) use types_mut::TypeExtensionResolver;
 
 use derive_more::{Display, Error, From};
 
@@ -46,8 +43,7 @@ pub fn resolve_type_extensions(
     typ: &mut Type,
     extensions: &WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    let mut used_extensions = WeakExtensionRegistry::default();
-    resolve_type_exts(None, typ, extensions, &mut used_extensions)
+    TypeExtensionResolver::new(extensions).resolve_type(None, typ)
 }
 
 /// Update all weak Extension pointers in a custom type.
@@ -55,8 +51,7 @@ pub fn resolve_custom_type_extensions(
     typ: &mut CustomType,
     extensions: &WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    let mut used_extensions = WeakExtensionRegistry::default();
-    resolve_custom_type_exts(None, typ, extensions, &mut used_extensions)
+    TypeExtensionResolver::new(extensions).resolve_custom_type(None, typ)
 }
 
 /// Update all weak Extension pointers inside a type argument.
@@ -64,8 +59,7 @@ pub fn resolve_typearg_extensions(
     arg: &mut TypeArg,
     extensions: &WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    let mut used_extensions = WeakExtensionRegistry::default();
-    resolve_term_exts(None, arg, extensions, &mut used_extensions)
+    TypeExtensionResolver::new(extensions).resolve_term(None, arg)
 }
 
 /// Update all weak Extension pointers inside a constant value.
@@ -73,8 +67,7 @@ pub fn resolve_value_extensions(
     value: &mut Value,
     extensions: &WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    let mut used_extensions = WeakExtensionRegistry::default();
-    resolve_value_exts(None, value, extensions, &mut used_extensions)
+    TypeExtensionResolver::new(extensions).resolve_value(None, value)
 }
 
 /// Errors that can occur during extension resolution.

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -64,12 +64,12 @@ fn resolve_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: Ex
 
     let dummy_node = portgraph::NodeIndex::new(0).into();
 
-    resolve_op_extensions(dummy_node, &mut deser_op, &extensions).unwrap();
-
     let weak_extensions: WeakExtensionRegistry = (&extensions).into();
     resolve_op_types_extensions(Some(dummy_node), &mut deser_op, &weak_extensions)
         .unwrap()
         .for_each(|_| ());
+
+    resolve_op_extensions(dummy_node, &mut deser_op, &extensions).unwrap();
 
     let deser_extensions = deser_op.used_extensions().unwrap();
 

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -14,16 +14,16 @@ use crate::envelope::EnvelopeConfig;
 use crate::extension::prelude::{ConstUsize, bool_t, usize_custom_t, usize_t};
 use crate::extension::resolution::WeakExtensionRegistry;
 use crate::extension::resolution::{
-    resolve_op_extensions, resolve_op_types_extensions,
-    resolve_type_extensions as resolve_type_extension_refs,
+    resolve_op_extensions, resolve_type_extensions as resolve_type_extension_refs,
 };
 use crate::extension::{
     ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE, PRELUDE_REGISTRY, TypeDefBound, Version,
 };
+use crate::hugr::HugrMut;
 use crate::ops::constant::CustomConst;
 use crate::ops::constant::test::CustomTestValue;
 use crate::ops::dataflow::IOTrait;
-use crate::ops::{CallIndirect, ExtensionOp, Input, NamedOp, OpType, OpaqueOp, Tag, Value};
+use crate::ops::{CallIndirect, ExtensionOp, Input, NamedOp, OpType, OpaqueOp, Output, Tag, Value};
 use crate::package::Package;
 use crate::std_extensions::arithmetic::conversions::{self, ConvertOpDef};
 use crate::std_extensions::arithmetic::float_types::{self, ConstF64, float64_type};
@@ -34,6 +34,8 @@ use crate::std_extensions::std_reg;
 use crate::types::type_param::TypeParam;
 use crate::types::{CustomType, PolyFuncType, Signature, Term, Type, TypeBound};
 use crate::{Extension, Hugr, HugrView, type_row};
+
+use super::types_mut::resolve_op_types_extensions;
 
 #[rstest]
 #[case::empty(Input { types: type_row![]}, ExtensionRegistry::default())]
@@ -162,6 +164,46 @@ fn resolving_current_type_extensions_preserves_shared_storage() {
     resolve_type_extension_refs(&mut resolved, &weak_registry).unwrap();
 
     assert!(original.shares_storage_with(&resolved));
+}
+
+/// Shared stale types should be resolved once and reuse the resolved storage.
+#[test]
+fn resolving_shared_stale_types_reuses_resolved_storage() {
+    let ext_id = ExtensionId::new_unchecked("shared_type_ext");
+    let version = Version::new(1, 0, 0);
+    let stale_extension = make_versioned_extension(&ext_id, version.clone());
+    let shared_type: Type = stale_extension
+        .get_type("MyType")
+        .unwrap()
+        .instantiate([])
+        .unwrap()
+        .into();
+
+    let mut hugr = Hugr::new();
+    let root = hugr.module_root();
+    let input = hugr.add_node_with_parent(root, Input::new([shared_type.clone()]));
+    let output = hugr.add_node_with_parent(root, Output::new([shared_type]));
+    drop(stale_extension);
+
+    let current_extension = make_versioned_extension(&ext_id, version);
+    let registry = ExtensionRegistry::new([current_extension.clone()]);
+    hugr.resolve_extension_defs(&registry).unwrap();
+
+    let OpType::Input(input_op) = hugr.get_optype(input) else {
+        panic!("expected input op");
+    };
+    let OpType::Output(output_op) = hugr.get_optype(output) else {
+        panic!("expected output op");
+    };
+    let input_type = &input_op.types[0];
+    let output_type = &output_op.types[0];
+    assert!(input_type.shares_storage_with(output_type));
+
+    let Term::ExtensionType(custom) = &**input_type else {
+        panic!("expected custom type");
+    };
+    let resolved_extension = custom.extension_ref().upgrade().unwrap();
+    assert!(Arc::ptr_eq(&resolved_extension, &current_extension));
 }
 
 /// Create a new test extension with a single operation.

--- a/hugr-core/src/extension/resolution/types.rs
+++ b/hugr-core/src/extension/resolution/types.rs
@@ -3,8 +3,8 @@
 //!
 //! Fails if any of the weak extension pointers have been invalidated.
 //!
-//! See [`super::resolve_op_types_extensions`] for a mutating version that
-//! updates the weak links to point to the correct extensions.
+//! See [`crate::Hugr::resolve_extension_defs`] for a mutating operation that
+//! updates weak links across a complete HUGR.
 
 use super::{ExtensionCollectionError, WeakExtensionRegistry};
 use crate::Node;
@@ -19,8 +19,8 @@ use crate::types::{FuncValueType, Signature, SumType, Term, TypeRow};
 /// happens when deserializing a HUGR. On such cases, we return an error with
 /// the missing extension names.
 ///
-/// Use [`super::resolve_op_types_extensions`] instead to update the weak references and
-/// ensure they point to valid extensions.
+/// Use [`crate::Hugr::resolve_extension_defs`] instead to update weak references
+/// across a complete HUGR and collect its extensions in one pass.
 ///
 /// # Attributes
 ///

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -3,7 +3,10 @@
 //!
 //! For a non-mutating option see [`super::collect_op_types_extensions`].
 
+use std::hash::{Hash, Hasher};
 use std::sync::Weak;
+
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::types::collect_term_exts;
 use super::{ExtensionResolutionError, WeakExtensionRegistry};
@@ -12,289 +15,426 @@ use crate::ops::{OpType, Value};
 use crate::types::{CustomType, FuncValueType, Signature, SumType, Term, Type, TypeRow, TypeRowRV};
 use crate::{Extension, Node};
 
-/// Replace the dangling extension pointer in the [`CustomType`]s inside an
-/// optype with a valid pointer to the extension in the `extensions`
-/// registry.
+/// An allocation-identity key that keeps its type storage alive while cached.
 ///
-/// Returns an iterator over the used extensions.
-///
-/// This is a helper function used right after deserializing a Hugr.
-pub fn resolve_op_types_extensions(
-    node: Option<Node>,
-    op: &mut OpType,
-    extensions: &WeakExtensionRegistry,
-) -> Result<impl Iterator<Item = Weak<Extension>> + use<>, ExtensionResolutionError> {
-    let mut used = WeakExtensionRegistry::default();
-    let used_extensions = &mut used;
-    match op {
-        OpType::ExtensionOp(ext) => {
-            for arg in ext.args_mut() {
-                resolve_term_exts(node, arg, extensions, used_extensions)?;
-            }
-            resolve_signature_exts(node, ext.signature_mut(), extensions, used_extensions)?;
-        }
-        OpType::FuncDefn(f) => {
-            resolve_signature_exts(
-                node,
-                f.signature_mut().body_mut(),
-                extensions,
-                used_extensions,
-            )?;
-        }
-        OpType::FuncDecl(f) => {
-            resolve_signature_exts(
-                node,
-                f.signature_mut().body_mut(),
-                extensions,
-                used_extensions,
-            )?;
-        }
-        OpType::Const(c) => resolve_value_exts(node, &mut c.value, extensions, used_extensions)?,
-        OpType::Input(inp) => {
-            resolve_type_row_exts(node, &mut inp.types, extensions, used_extensions)?;
-        }
-        OpType::Output(out) => {
-            resolve_type_row_exts(node, &mut out.types, extensions, used_extensions)?;
-        }
-        OpType::Call(c) => {
-            resolve_signature_exts(node, c.func_sig.body_mut(), extensions, used_extensions)?;
-            resolve_signature_exts(node, &mut c.instantiation, extensions, used_extensions)?;
-            for arg in &mut c.type_args {
-                resolve_term_exts(node, arg, extensions, used_extensions)?;
-            }
-        }
-        OpType::CallIndirect(c) => {
-            resolve_signature_exts(node, &mut c.signature, extensions, used_extensions)?;
-        }
-        OpType::LoadConstant(lc) => {
-            resolve_type_exts(node, &mut lc.datatype, extensions, used_extensions)?;
-        }
-        OpType::LoadFunction(lf) => {
-            resolve_signature_exts(node, lf.func_sig.body_mut(), extensions, used_extensions)?;
-            resolve_signature_exts(node, &mut lf.instantiation, extensions, used_extensions)?;
-            for arg in &mut lf.type_args {
-                resolve_term_exts(node, arg, extensions, used_extensions)?;
-            }
-        }
-        OpType::DFG(dfg) => {
-            resolve_signature_exts(node, &mut dfg.signature, extensions, used_extensions)?;
-        }
-        OpType::OpaqueOp(op) => {
-            for arg in op.args_mut() {
-                resolve_term_exts(node, arg, extensions, used_extensions)?;
-            }
-            resolve_signature_exts(node, op.signature_mut(), extensions, used_extensions)?;
-        }
-        OpType::Tag(t) => {
-            for variant in &mut t.variants {
-                resolve_type_row_exts(node, variant, extensions, used_extensions)?;
-            }
-        }
-        OpType::DataflowBlock(db) => {
-            resolve_type_row_exts(node, &mut db.inputs, extensions, used_extensions)?;
-            resolve_type_row_exts(node, &mut db.other_outputs, extensions, used_extensions)?;
-            for row in &mut db.sum_rows {
-                resolve_type_row_exts(node, row, extensions, used_extensions)?;
-            }
-        }
-        OpType::ExitBlock(e) => {
-            resolve_type_row_exts(node, &mut e.cfg_outputs, extensions, used_extensions)?;
-        }
-        OpType::TailLoop(tl) => {
-            resolve_type_row_exts(node, &mut tl.just_inputs, extensions, used_extensions)?;
-            resolve_type_row_exts(node, &mut tl.just_outputs, extensions, used_extensions)?;
-            resolve_type_row_exts(node, &mut tl.rest, extensions, used_extensions)?;
-        }
-        OpType::CFG(cfg) => {
-            resolve_signature_exts(node, &mut cfg.signature, extensions, used_extensions)?;
-        }
-        OpType::Conditional(cond) => {
-            for row in &mut cond.sum_rows {
-                resolve_type_row_exts(node, row, extensions, used_extensions)?;
-            }
-            resolve_type_row_exts(node, &mut cond.other_inputs, extensions, used_extensions)?;
-            resolve_type_row_exts(node, &mut cond.outputs, extensions, used_extensions)?;
-        }
-        OpType::Case(case) => {
-            resolve_signature_exts(node, &mut case.signature, extensions, used_extensions)?;
-        }
-        // Ignore optypes that do not store a signature.
-        OpType::Module(_) | OpType::AliasDecl(_) | OpType::AliasDefn(_) => {}
+/// It wraps a [`Type`], but compares and hashes based on the underlying storage
+/// pointer rather than the type's structural content.
+#[derive(Clone)]
+struct TypeStorageKey(Type);
+
+impl TypeStorageKey {
+    /// Creates a key retaining the type's current backing allocation.
+    fn new(typ: &Type) -> Self {
+        Self(typ.clone())
     }
-    Ok(used.into_iter().map(|(_, _, ext)| ext))
 }
 
-/// Update all weak Extension pointers in the [`CustomType`]s inside a [Signature].
-///
-/// Adds the extensions used in the signature to the `used_extensions` registry.
-pub(super) fn resolve_signature_exts(
-    node: Option<Node>,
-    signature: &mut Signature,
-    extensions: &WeakExtensionRegistry,
-    used_extensions: &mut WeakExtensionRegistry,
-) -> Result<(), ExtensionResolutionError> {
-    resolve_type_row_exts(node, &mut signature.input, extensions, used_extensions)?;
-    resolve_type_row_exts(node, &mut signature.output, extensions, used_extensions)?;
-    Ok(())
+impl PartialEq for TypeStorageKey {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.0.storage_ptr(), other.0.storage_ptr())
+    }
 }
 
-/// Update all weak Extension pointers in the [`CustomType`]s inside a [FuncValueType].
+impl Eq for TypeStorageKey {}
+
+impl Hash for TypeStorageKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.storage_ptr().hash(state);
+    }
+}
+
+/// State shared while resolving type extensions across a HUGR.
 ///
-/// Adds the extensions used in the signature to the `used_extensions` registry.
+/// Resolved types are cached by backing-allocation identity. This both avoids
+/// retraversing imported types and lets stale siblings reuse the first resolved
+/// copy instead of independently cloning their shared term tree.
+pub(crate) struct TypeExtensionResolver<'a> {
+    extensions: &'a WeakExtensionRegistry,
+    used_extensions: WeakExtensionRegistry,
+    seen_types: FxHashSet<TypeStorageKey>,
+    resolved_types: FxHashMap<TypeStorageKey, Type>,
+}
+
+impl<'a> TypeExtensionResolver<'a> {
+    /// Creates a resolver for one target extension registry.
+    pub(crate) fn new(extensions: &'a WeakExtensionRegistry) -> Self {
+        Self {
+            extensions,
+            used_extensions: WeakExtensionRegistry::default(),
+            seen_types: FxHashSet::default(),
+            resolved_types: FxHashMap::default(),
+        }
+    }
+
+    /// Resolves all type references stored in an operation.
+    pub(crate) fn resolve_op(
+        &mut self,
+        node: Option<Node>,
+        op: &mut OpType,
+    ) -> Result<(), ExtensionResolutionError> {
+        match op {
+            OpType::ExtensionOp(ext) => {
+                for arg in ext.args_mut() {
+                    self.resolve_term(node, arg)?;
+                }
+                self.resolve_signature(node, ext.signature_mut())?;
+            }
+            OpType::FuncDefn(f) => {
+                self.resolve_signature(node, f.signature_mut().body_mut())?;
+            }
+            OpType::FuncDecl(f) => {
+                self.resolve_signature(node, f.signature_mut().body_mut())?;
+            }
+            OpType::Const(c) => self.resolve_value(node, &mut c.value)?,
+            OpType::Input(inp) => self.resolve_type_row(node, &mut inp.types)?,
+            OpType::Output(out) => self.resolve_type_row(node, &mut out.types)?,
+            OpType::Call(c) => {
+                self.resolve_signature(node, c.func_sig.body_mut())?;
+                self.resolve_signature(node, &mut c.instantiation)?;
+                for arg in &mut c.type_args {
+                    self.resolve_term(node, arg)?;
+                }
+            }
+            OpType::CallIndirect(c) => self.resolve_signature(node, &mut c.signature)?,
+            OpType::LoadConstant(lc) => self.resolve_type(node, &mut lc.datatype)?,
+            OpType::LoadFunction(lf) => {
+                self.resolve_signature(node, lf.func_sig.body_mut())?;
+                self.resolve_signature(node, &mut lf.instantiation)?;
+                for arg in &mut lf.type_args {
+                    self.resolve_term(node, arg)?;
+                }
+            }
+            OpType::DFG(dfg) => self.resolve_signature(node, &mut dfg.signature)?,
+            OpType::OpaqueOp(op) => {
+                for arg in op.args_mut() {
+                    self.resolve_term(node, arg)?;
+                }
+                self.resolve_signature(node, op.signature_mut())?;
+            }
+            OpType::Tag(t) => {
+                for variant in &mut t.variants {
+                    self.resolve_type_row(node, variant)?;
+                }
+            }
+            OpType::DataflowBlock(db) => {
+                self.resolve_type_row(node, &mut db.inputs)?;
+                self.resolve_type_row(node, &mut db.other_outputs)?;
+                for row in &mut db.sum_rows {
+                    self.resolve_type_row(node, row)?;
+                }
+            }
+            OpType::ExitBlock(e) => self.resolve_type_row(node, &mut e.cfg_outputs)?,
+            OpType::TailLoop(tl) => {
+                self.resolve_type_row(node, &mut tl.just_inputs)?;
+                self.resolve_type_row(node, &mut tl.just_outputs)?;
+                self.resolve_type_row(node, &mut tl.rest)?;
+            }
+            OpType::CFG(cfg) => self.resolve_signature(node, &mut cfg.signature)?,
+            OpType::Conditional(cond) => {
+                for row in &mut cond.sum_rows {
+                    self.resolve_type_row(node, row)?;
+                }
+                self.resolve_type_row(node, &mut cond.other_inputs)?;
+                self.resolve_type_row(node, &mut cond.outputs)?;
+            }
+            OpType::Case(case) => self.resolve_signature(node, &mut case.signature)?,
+            // Ignore optypes that do not store a signature.
+            OpType::Module(_) | OpType::AliasDecl(_) | OpType::AliasDefn(_) => {}
+        }
+        Ok(())
+    }
+
+    /// Consumes the resolver and returns all extensions found during resolution.
+    pub(crate) fn into_used_extensions(self) -> impl Iterator<Item = Weak<Extension>> + use<> {
+        self.used_extensions.into_iter().map(|(_, _, ext)| ext)
+    }
+
+    /// Resolves extensions inside a function signature.
+    fn resolve_signature(
+        &mut self,
+        node: Option<Node>,
+        signature: &mut Signature,
+    ) -> Result<(), ExtensionResolutionError> {
+        self.resolve_type_row(node, &mut signature.input)?;
+        self.resolve_type_row(node, &mut signature.output)
+    }
+
+    /// Resolves extensions inside a runtime function type.
+    fn resolve_func_type(
+        &mut self,
+        node: Option<Node>,
+        signature: &mut FuncValueType,
+    ) -> Result<(), ExtensionResolutionError> {
+        self.resolve_type_row_rv(node, &mut signature.input)?;
+        self.resolve_type_row_rv(node, &mut signature.output)
+    }
+
+    /// Resolves every type in a closed type row.
+    fn resolve_type_row(
+        &mut self,
+        node: Option<Node>,
+        row: &mut TypeRow,
+    ) -> Result<(), ExtensionResolutionError> {
+        for typ in row.iter_mut() {
+            self.resolve_type(node, typ)?;
+        }
+        Ok(())
+    }
+
+    /// Resolves extensions inside a possibly-open runtime type row.
+    fn resolve_type_row_rv(
+        &mut self,
+        node: Option<Node>,
+        row: &mut TypeRowRV,
+    ) -> Result<(), ExtensionResolutionError> {
+        let mut term = Term::from(std::mem::take(row));
+        self.resolve_term(node, &mut term)?;
+        *row = TypeRowRV::try_from(term)
+            .expect("Resolving extensions cannot change kind from ListType(RuntimeType)");
+        Ok(())
+    }
+
+    /// Resolves one custom type and records its defining extension.
+    pub(super) fn resolve_custom_type(
+        &mut self,
+        node: Option<Node>,
+        custom: &mut CustomType,
+    ) -> Result<(), ExtensionResolutionError> {
+        for arg in custom.args_mut() {
+            self.resolve_term(node, arg)?;
+        }
+
+        let ext_id = custom.extension();
+        let (version, extension) = self
+            .extensions
+            .get_req(ext_id, custom.extension_version())
+            .ok_or_else(|| {
+                ExtensionResolutionError::missing_type_extension(
+                    node,
+                    custom.name(),
+                    ext_id,
+                    self.extensions,
+                )
+            })?;
+
+        self.used_extensions
+            .register(ext_id.clone(), version.clone(), extension.clone());
+        custom.update_extension(extension.clone());
+        Ok(())
+    }
+
+    /// Resolves one runtime type, reusing work for shared backing allocations.
+    pub(super) fn resolve_type(
+        &mut self,
+        node: Option<Node>,
+        typ: &mut Type,
+    ) -> Result<(), ExtensionResolutionError> {
+        let original_key = TypeStorageKey::new(typ);
+        if self.seen_types.contains(&original_key) {
+            return Ok(());
+        }
+        if let Some(resolved) = self.resolved_types.get(&original_key) {
+            typ.clone_from(resolved);
+            return Ok(());
+        }
+
+        if self.collect_current_type_extensions(typ) {
+            self.seen_types.insert(original_key);
+            return Ok(());
+        }
+
+        self.resolve_term(node, typ.term_mut())?;
+
+        // Map stale siblings to the resolved value and record its new backing
+        // allocation as already traversed.
+        let resolved_key = TypeStorageKey::new(typ);
+        self.resolved_types.insert(original_key, typ.clone());
+        self.seen_types.insert(resolved_key);
+        Ok(())
+    }
+
+    /// Collects references from a type only if they match the target registry.
+    fn collect_current_type_extensions(&mut self, typ: &Type) -> bool {
+        let mut current_extensions = WeakExtensionRegistry::default();
+        if !collect_current_term_extensions(typ, self.extensions, &mut current_extensions) {
+            return false;
+        }
+
+        for (id, version, extension) in current_extensions {
+            self.used_extensions.register(id, version, extension);
+        }
+        true
+    }
+
+    /// Resolves extensions recursively inside an arbitrary term.
+    pub(super) fn resolve_term(
+        &mut self,
+        node: Option<Node>,
+        term: &mut Term,
+    ) -> Result<(), ExtensionResolutionError> {
+        match term {
+            Term::ExtensionType(custom) => self.resolve_custom_type(node, custom)?,
+            Term::FunctionType(function) => self.resolve_func_type(node, function)?,
+            Term::SumType(SumType::General(general)) => {
+                for row in general.rows_mut() {
+                    self.resolve_type_row_rv(node, row)?;
+                }
+            }
+            Term::ConstKind(typ) => self.resolve_type(node, typ)?,
+            Term::List(children)
+            | Term::ListConcat(children)
+            | Term::Tuple(children)
+            | Term::TupleConcat(children) => {
+                for child in children.iter_mut() {
+                    self.resolve_term(node, child)?;
+                }
+            }
+            Term::ListKind(item_type) => self.resolve_term(node, item_type.as_mut())?,
+            Term::TupleKind(item_types) => self.resolve_term(node, item_types.as_mut())?,
+            Term::Variable(_)
+            | Term::TypeKind(_)
+            | Term::StaticKind
+            | Term::BoundedNatKind(_)
+            | Term::StringKind
+            | Term::BytesKind
+            | Term::FloatKind
+            | Term::BoundedNat(_)
+            | Term::String(_)
+            | Term::Bytes(_)
+            | Term::Float(_)
+            | Term::SumType(SumType::Unit { .. }) => {}
+        }
+        Ok(())
+    }
+
+    /// Resolves extensions recursively inside a constant value.
+    pub(super) fn resolve_value(
+        &mut self,
+        node: Option<Node>,
+        value: &mut Value,
+    ) -> Result<(), ExtensionResolutionError> {
+        match value {
+            Value::Extension { e } => {
+                e.value_mut().update_extensions(self.extensions)?;
+
+                // Custom constants should return types with valid extensions
+                // after their own extension update.
+                let typ = e.get_type();
+                let mut missing = ExtensionSet::new();
+                collect_term_exts(&typ, &mut self.used_extensions, &mut missing);
+                if !missing.is_empty() {
+                    return Err(ExtensionResolutionError::InvalidConstTypes {
+                        value: e.name(),
+                        missing_extensions: missing,
+                    });
+                }
+            }
+            Value::Sum(sum) => {
+                if let SumType::General(general) = &mut sum.sum_type {
+                    for row in general.rows_mut() {
+                        self.resolve_type_row_rv(node, row)?;
+                    }
+                }
+                for value in &mut sum.values {
+                    self.resolve_value(node, value)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Resolves a function type while merging its extensions into an existing
+/// accumulator used by extension-definition loading.
 pub(super) fn resolve_func_type_exts(
     node: Option<Node>,
     signature: &mut FuncValueType,
     extensions: &WeakExtensionRegistry,
     used_extensions: &mut WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
-    resolve_typerow_rv_exts(node, &mut signature.input, extensions, used_extensions)?;
-    resolve_typerow_rv_exts(node, &mut signature.output, extensions, used_extensions)?;
-    Ok(())
-}
-
-/// Update all weak Extension pointers in the [`CustomType`]s inside a type row.
-///
-/// Adds the extensions used in the row to the `used_extensions` registry.
-pub(super) fn resolve_type_row_exts(
-    node: Option<Node>,
-    row: &mut TypeRow,
-    extensions: &WeakExtensionRegistry,
-    used_extensions: &mut WeakExtensionRegistry,
-) -> Result<(), ExtensionResolutionError> {
-    for ty in row.iter_mut() {
-        resolve_type_exts(node, ty, extensions, used_extensions)?;
+    let mut resolver = TypeExtensionResolver::new(extensions);
+    resolver.resolve_func_type(node, signature)?;
+    for (id, version, extension) in resolver.used_extensions {
+        used_extensions.register(id, version, extension);
     }
     Ok(())
 }
 
-/// Update all weak Extension pointers in the [`CustomType`]s inside a type row.
+/// Replace extension pointers in an optype using a standalone resolver.
 ///
-/// Adds the extensions used in the row to the `used_extensions` registry.
-fn resolve_typerow_rv_exts(
+/// Returns an iterator over the used extensions. HUGR-wide resolution uses a
+/// shared [`TypeExtensionResolver`] directly so its type cache spans all ops.
+#[cfg(test)]
+pub(super) fn resolve_op_types_extensions(
     node: Option<Node>,
-    row: &mut TypeRowRV,
+    op: &mut OpType,
     extensions: &WeakExtensionRegistry,
-    used_extensions: &mut WeakExtensionRegistry,
-) -> Result<(), ExtensionResolutionError> {
-    let mut t = Term::from(std::mem::take(row));
-    resolve_term_exts(node, &mut t, extensions, used_extensions)?;
-    *row = TypeRowRV::try_from(t)
-        .expect("Resolving extensions cannot change kind from ListType(RuntimeType)");
-    Ok(())
+) -> Result<impl Iterator<Item = Weak<Extension>> + use<>, ExtensionResolutionError> {
+    let mut resolver = TypeExtensionResolver::new(extensions);
+    resolver.resolve_op(node, op)?;
+    Ok(resolver.into_used_extensions())
 }
 
-/// Update all weak Extension pointers in a [`CustomType`].
+/// Collects extension references while verifying that they match a registry.
 ///
-/// Adds the extensions used in the type to the `used_extensions` registry.
-pub(super) fn resolve_custom_type_exts(
-    node: Option<Node>,
-    custom: &mut CustomType,
-    extensions: &WeakExtensionRegistry,
-    used_extensions: &mut WeakExtensionRegistry,
-) -> Result<(), ExtensionResolutionError> {
-    for arg in custom.args_mut() {
-        resolve_term_exts(node, arg, extensions, used_extensions)?;
-    }
-
-    let ext_id = custom.extension();
-    let (version, ext) = extensions
-        .get_req(ext_id, custom.extension_version())
-        .ok_or_else(|| {
-            ExtensionResolutionError::missing_type_extension(
-                node,
-                custom.name(),
-                ext_id,
-                extensions,
-            )
-        })?;
-
-    // Add the extension to the used extensions registry,
-    // and update the CustomType with the valid pointer.
-    used_extensions.register(ext_id.clone(), version.clone(), ext.clone());
-    custom.update_extension(ext.clone());
-
-    Ok(())
-}
-
-/// Update all weak Extension pointers in the [`CustomType`]s inside a [`Type`].
-///
-/// Adds the extensions used in the type to the `used_extensions` registry.
-pub(super) fn resolve_type_exts(
-    node: Option<Node>,
-    typ: &mut Type,
-    extensions: &WeakExtensionRegistry,
-    used_extensions: &mut WeakExtensionRegistry,
-) -> Result<(), ExtensionResolutionError> {
-    if collect_current_type_exts(typ, extensions, used_extensions) {
-        return Ok(());
-    }
-
-    let mut tm = std::mem::replace(typ, Type::new_unit_sum(0)).into();
-    let r = resolve_term_exts(node, &mut tm, extensions, used_extensions);
-    *typ = tm
-        .try_into()
-        .expect("Resolving extensions cannot change kind from RuntimeType");
-    r
-}
-
-/// Collects extension references when they already match the target registry.
-///
-/// Imported types already contain the correct weak references. Detecting that
-/// case before requesting mutable access preserves their shared backing.
-fn collect_current_type_exts(
-    typ: &Type,
+/// Results are accumulated separately and committed only when the complete
+/// term matches, keeping the already-resolved fast path to one traversal.
+fn collect_current_term_extensions(
+    term: &Term,
     extensions: &WeakExtensionRegistry,
     used_extensions: &mut WeakExtensionRegistry,
 ) -> bool {
-    if !term_extension_refs_match(typ, extensions) {
-        return false;
-    }
-
-    let mut current_extensions = WeakExtensionRegistry::default();
-    let mut missing_extensions = ExtensionSet::new();
-    collect_term_exts(typ, &mut current_extensions, &mut missing_extensions);
-
-    if !missing_extensions.is_empty() {
-        return false;
-    }
-
-    for (id, version, extension) in current_extensions {
-        used_extensions.register(id, version, extension);
-    }
-    true
-}
-
-/// Checks every custom type reference against the target registry.
-fn term_extension_refs_match(term: &Term, extensions: &WeakExtensionRegistry) -> bool {
     match term {
         Term::ExtensionType(custom) => {
+            if !custom
+                .args()
+                .iter()
+                .all(|arg| collect_current_term_extensions(arg, extensions, used_extensions))
+            {
+                return false;
+            }
+
             let current = custom.extension_ref();
-            current.upgrade().is_some()
-                && extensions
-                    .get_req(custom.extension(), custom.extension_version())
-                    .is_some_and(|(_, expected)| current.ptr_eq(expected))
-                && custom
-                    .args()
-                    .iter()
-                    .all(|arg| term_extension_refs_match(arg, extensions))
+            let Some(extension) = current.upgrade() else {
+                return false;
+            };
+            let Some((_, expected)) =
+                extensions.get_req(custom.extension(), custom.extension_version())
+            else {
+                return false;
+            };
+            if !current.ptr_eq(expected) {
+                return false;
+            }
+
+            used_extensions.register(
+                extension.name().clone(),
+                extension.version().clone(),
+                current,
+            );
+            true
         }
-        Term::FunctionType(func) => {
-            term_extension_refs_match(&func.input, extensions)
-                && term_extension_refs_match(&func.output, extensions)
+        Term::FunctionType(function) => {
+            collect_current_term_extensions(&function.input, extensions, used_extensions)
+                && collect_current_term_extensions(&function.output, extensions, used_extensions)
         }
         Term::SumType(SumType::General(general)) => general
             .rows()
             .iter()
-            .all(|row| term_extension_refs_match(row, extensions)),
-        Term::ConstKind(typ) => term_extension_refs_match(typ, extensions),
+            .all(|row| collect_current_term_extensions(row, extensions, used_extensions)),
+        Term::ConstKind(typ) => collect_current_term_extensions(typ, extensions, used_extensions),
         Term::List(children)
         | Term::ListConcat(children)
         | Term::Tuple(children)
         | Term::TupleConcat(children) => children
             .iter()
-            .all(|child| term_extension_refs_match(child, extensions)),
-        Term::ListKind(item_type) => term_extension_refs_match(item_type, extensions),
-        Term::TupleKind(item_types) => term_extension_refs_match(item_types, extensions),
+            .all(|child| collect_current_term_extensions(child, extensions, used_extensions)),
+        Term::ListKind(item_type) => {
+            collect_current_term_extensions(item_type, extensions, used_extensions)
+        }
+        Term::TupleKind(item_types) => {
+            collect_current_term_extensions(item_types, extensions, used_extensions)
+        }
         Term::Variable(_)
         | Term::TypeKind(_)
         | Term::StaticKind
@@ -308,95 +448,4 @@ fn term_extension_refs_match(term: &Term, extensions: &WeakExtensionRegistry) ->
         | Term::Float(_)
         | Term::SumType(SumType::Unit { .. }) => true,
     }
-}
-
-/// Update all weak Extension pointers in the [`CustomType`]s inside a [`Term`].
-///
-/// Adds the extensions used in the term to the `used_extensions` registry.
-pub(super) fn resolve_term_exts(
-    node: Option<Node>,
-    term: &mut Term,
-    extensions: &WeakExtensionRegistry,
-    used_extensions: &mut WeakExtensionRegistry,
-) -> Result<(), ExtensionResolutionError> {
-    match term {
-        Term::ExtensionType(custom) => {
-            resolve_custom_type_exts(node, custom, extensions, used_extensions)?;
-        }
-        Term::FunctionType(f) => {
-            resolve_func_type_exts(node, &mut *f, extensions, used_extensions)?;
-        }
-        Term::SumType(SumType::General(general)) => {
-            for row in general.rows_mut() {
-                resolve_typerow_rv_exts(node, row, extensions, used_extensions)?;
-            }
-        }
-        Term::ConstKind(ty) => resolve_type_exts(node, ty, extensions, used_extensions)?,
-        Term::List(children)
-        | Term::ListConcat(children)
-        | Term::Tuple(children)
-        | Term::TupleConcat(children) => {
-            for child in children.iter_mut() {
-                resolve_term_exts(node, child, extensions, used_extensions)?;
-            }
-        }
-        Term::ListKind(item_type) => {
-            resolve_term_exts(node, item_type.as_mut(), extensions, used_extensions)?;
-        }
-        Term::TupleKind(item_types) => {
-            resolve_term_exts(node, item_types.as_mut(), extensions, used_extensions)?;
-        }
-        Term::Variable(_)
-        | Term::TypeKind(_)
-        | Term::StaticKind
-        | Term::BoundedNatKind(_)
-        | Term::StringKind
-        | Term::BytesKind
-        | Term::FloatKind
-        | Term::BoundedNat(_)
-        | Term::String(_)
-        | Term::Bytes(_)
-        | Term::Float(_)
-        | Term::SumType(SumType::Unit { .. }) => {}
-    }
-    Ok(())
-}
-
-/// Update all weak Extension pointers in the [`CustomType`]s inside a [`Value`].
-///
-/// Adds the extensions used in the row to the `used_extensions` registry.
-pub(super) fn resolve_value_exts(
-    node: Option<Node>,
-    value: &mut Value,
-    extensions: &WeakExtensionRegistry,
-    used_extensions: &mut WeakExtensionRegistry,
-) -> Result<(), ExtensionResolutionError> {
-    match value {
-        Value::Extension { e } => {
-            e.value_mut().update_extensions(extensions)?;
-
-            // We expect that the `CustomConst::get_type` binary calls
-            // return types with valid extensions after we call `update_extensions`.
-            let typ = e.get_type();
-            let mut missing = ExtensionSet::new();
-            collect_term_exts(&typ, used_extensions, &mut missing);
-            if !missing.is_empty() {
-                return Err(ExtensionResolutionError::InvalidConstTypes {
-                    value: e.name(),
-                    missing_extensions: missing,
-                });
-            }
-        }
-        Value::Sum(s) => {
-            if let SumType::General(general) = &mut s.sum_type {
-                for row in general.rows_mut() {
-                    resolve_typerow_rv_exts(node, row, extensions, used_extensions)?;
-                }
-            }
-            s.values
-                .iter_mut()
-                .try_for_each(|v| resolve_value_exts(node, v, extensions, used_extensions))?;
-        }
-    }
-    Ok(())
 }

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -19,13 +19,13 @@ use crate::{Extension, Node};
 ///
 /// It wraps a [`Type`], but compares and hashes based on the underlying storage
 /// pointer rather than the type's structural content.
-#[derive(Clone)]
+#[derive(Clone, Eq)]
 struct TypeStorageKey(Type);
 
 impl TypeStorageKey {
     /// Creates a key retaining the type's current backing allocation.
-    fn new(typ: &Type) -> Self {
-        Self(typ.clone())
+    fn new(typ: Type) -> Self {
+        Self(typ)
     }
 }
 
@@ -34,8 +34,6 @@ impl PartialEq for TypeStorageKey {
         std::ptr::eq(self.0.storage_ptr(), other.0.storage_ptr())
     }
 }
-
-impl Eq for TypeStorageKey {}
 
 impl Hash for TypeStorageKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -229,7 +227,7 @@ impl<'a> TypeExtensionResolver<'a> {
         node: Option<Node>,
         typ: &mut Type,
     ) -> Result<(), ExtensionResolutionError> {
-        let original_key = TypeStorageKey::new(typ);
+        let original_key = TypeStorageKey::new(typ.clone());
         if self.seen_types.contains(&original_key) {
             return Ok(());
         }
@@ -247,7 +245,7 @@ impl<'a> TypeExtensionResolver<'a> {
 
         // Map stale siblings to the resolved value and record its new backing
         // allocation as already traversed.
-        let resolved_key = TypeStorageKey::new(typ);
+        let resolved_key = TypeStorageKey::new(typ.clone());
         self.resolved_types.insert(original_key, typ.clone());
         self.seen_types.insert(resolved_key);
         Ok(())

--- a/hugr-core/src/hugr.rs
+++ b/hugr-core/src/hugr.rs
@@ -32,8 +32,7 @@ pub use self::views::HugrView;
 use crate::core::NodeIndex;
 use crate::envelope::{self, EnvelopeConfig, ReadError, WriteError};
 use crate::extension::resolution::{
-    ExtensionResolutionError, WeakExtensionRegistry, resolve_op_extensions,
-    resolve_op_types_extensions,
+    ExtensionResolutionError, TypeExtensionResolver, WeakExtensionRegistry, resolve_op_extensions,
 };
 use crate::extension::{EMPTY_REG, ExtensionId, ExtensionRegistry, ExtensionSet, Version};
 use crate::metadata::RawMetadataValue;
@@ -295,6 +294,7 @@ impl Hugr {
         let mut seen_extensions = BTreeSet::<(ExtensionId, Version)>::new();
 
         let weak_extensions: WeakExtensionRegistry = extensions.into();
+        let mut type_resolver = TypeExtensionResolver::new(&weak_extensions);
         for pg_node in self.graph.nodes_iter() {
             let node: Node = pg_node.into();
             let op = &mut self.op_types[pg_node];
@@ -305,16 +305,16 @@ impl Hugr {
                     used_extensions.register(extension.clone());
                 }
             }
-            for extension in
-                resolve_op_types_extensions(Some(node), op, &weak_extensions)?.map(|weak| {
-                    weak.upgrade()
-                        .expect("Extension comes from a valid registry")
-                })
-            {
-                let extension_key = (extension.name().clone(), extension.version().clone());
-                if seen_extensions.insert(extension_key) {
-                    used_extensions.register(extension);
-                }
+            type_resolver.resolve_op(Some(node), op)?;
+        }
+
+        for weak in type_resolver.into_used_extensions() {
+            let extension = weak
+                .upgrade()
+                .expect("Extension comes from a valid registry");
+            let extension_key = (extension.name().clone(), extension.version().clone());
+            if seen_extensions.insert(extension_key) {
+                used_extensions.register(extension);
             }
         }
 

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -462,16 +462,29 @@ impl Type {
         Self(TypeStorage::Shared(Arc::new(term)))
     }
 
+    /// Returns a pointer identifying the current backing allocation.
+    ///
+    /// This is only used for equality checks to avoid repeated computations.
+    pub(crate) fn storage_ptr(&self) -> *const Term {
+        match &self.0 {
+            TypeStorage::Static(term) => std::ptr::from_ref(*term),
+            TypeStorage::Shared(term) => Arc::as_ptr(term),
+        }
+    }
+
+    /// Returns mutable access to the backing term using copy-on-write.
+    ///
+    /// Callers must preserve the invariant that the term is a runtime type.
+    pub(crate) fn term_mut(&mut self) -> &mut Term {
+        self.0.make_mut()
+    }
+
     /// Returns whether two types use the same backing allocation.
     ///
     /// Used for testing only.
     #[cfg(test)]
     pub(crate) fn shares_storage_with(&self, other: &Self) -> bool {
-        match (&self.0, &other.0) {
-            (TypeStorage::Static(left), TypeStorage::Static(right)) => std::ptr::eq(*left, *right),
-            (TypeStorage::Shared(left), TypeStorage::Shared(right)) => Arc::ptr_eq(left, right),
-            _ => false,
-        }
+        std::ptr::eq(self.storage_ptr(), other.storage_ptr())
     }
 
     /// Initialize a new function type.

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -33,6 +33,11 @@ impl From<Type> for SerSimpleType {
         if value == usize_t() {
             return SerSimpleType::I;
         }
+        // TODO: `value.into()` into a `Term` forces cloning of shared types
+        // inside `TypeStorage` before they are serialized.
+        //
+        // Avoiding this requires rewriting the serialization logic to handle
+        // shared storage directly.
         match value.into() {
             Term::ExtensionType(o) => SerSimpleType::Opaque(o),
             Term::FunctionType(sig) => SerSimpleType::G(sig),


### PR DESCRIPTION
Follow up to #3215.

Improves extension resolution in a hugr by keeping an internal context struct with cached resolution of type definitions.
Since the linked PR, types now share definitions via internal Arcs. That means that once we've process an instantiation of a Type during resolution we can quickly update any other type using the same Arc, avoiding unnecessary traversals.