### PR TITLE
perf: Reuse shared types during HUGR import

### DIFF
--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -13,7 +13,10 @@ use crate::builder::{
 use crate::envelope::EnvelopeConfig;
 use crate::extension::prelude::{ConstUsize, bool_t, usize_custom_t, usize_t};
 use crate::extension::resolution::WeakExtensionRegistry;
-use crate::extension::resolution::{resolve_op_extensions, resolve_op_types_extensions};
+use crate::extension::resolution::{
+    resolve_op_extensions, resolve_op_types_extensions,
+    resolve_type_extensions as resolve_type_extension_refs,
+};
 use crate::extension::{
     ExtensionId, ExtensionRegistry, ExtensionSet, PRELUDE, PRELUDE_REGISTRY, TypeDefBound,
 };
@@ -28,7 +31,7 @@ use crate::std_extensions::arithmetic::int_types::{self, int_type};
 use crate::std_extensions::collections::list::ListValue;
 use crate::std_extensions::std_reg;
 use crate::types::type_param::TypeParam;
-use crate::types::{PolyFuncType, Signature, Type, TypeBound};
+use crate::types::{PolyFuncType, Signature, Type, TypeBound, TypeEnum};
 use crate::{Extension, Hugr, HugrView, type_row};
 
 #[rstest]
@@ -71,6 +74,22 @@ fn resolve_type_extensions(#[case] op: impl Into<OpType>, #[case] extensions: Ex
         deser_extensions, extensions,
         "{deser_extensions} != {extensions}"
     );
+}
+
+/// Resolving an already-resolved type preserves its shared backing allocation.
+#[rstest]
+fn resolving_current_type_extensions_preserves_shared_storage() {
+    let registry = std_reg();
+    let weak_registry = WeakExtensionRegistry::from(&registry);
+    let original = Type::new(TypeEnum::Extension(
+        usize_t().as_extension().unwrap().clone(),
+    ));
+    let mut resolved = original.clone();
+    assert!(original.shares_storage_with(&resolved));
+
+    resolve_type_extension_refs(&mut resolved, &weak_registry).unwrap();
+
+    assert!(original.shares_storage_with(&resolved));
 }
 
 /// Create a new test extension with a single operation.

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -163,6 +163,10 @@ pub(super) fn resolve_type_exts<RV: MaybeRV>(
     extensions: &WeakExtensionRegistry,
     used_extensions: &mut WeakExtensionRegistry,
 ) -> Result<(), ExtensionResolutionError> {
+    if collect_current_type_exts(typ, extensions, used_extensions) {
+        return Ok(());
+    }
+
     match typ.as_type_enum_mut() {
         TypeEnum::Extension(custom) => {
             resolve_custom_type_exts(node, custom, extensions, used_extensions)?;
@@ -183,6 +187,96 @@ pub(super) fn resolve_type_exts<RV: MaybeRV>(
         | TypeEnum::Sum(SumType::Unit { .. }) => {}
     }
     Ok(())
+}
+
+/// Collects extension references when they already match the target registry.
+///
+/// Imported types already contain the correct weak references. Detecting that
+/// case before requesting mutable access preserves their shared backing.
+fn collect_current_type_exts<RV: MaybeRV>(
+    typ: &TypeBase<RV>,
+    extensions: &WeakExtensionRegistry,
+    used_extensions: &mut WeakExtensionRegistry,
+) -> bool {
+    if !type_extension_refs_match(typ, extensions) {
+        return false;
+    }
+
+    let mut current_extensions = WeakExtensionRegistry::default();
+    let mut missing_extensions = ExtensionSet::new();
+    collect_type_exts(typ, &mut current_extensions, &mut missing_extensions);
+    if !missing_extensions.is_empty() {
+        return false;
+    }
+
+    for (id, extension) in current_extensions.iter() {
+        used_extensions.register(id.clone(), extension.clone());
+    }
+    true
+}
+
+/// Checks every custom type reference against the target registry.
+fn type_extension_refs_match<RV: MaybeRV>(
+    typ: &TypeBase<RV>,
+    extensions: &WeakExtensionRegistry,
+) -> bool {
+    match typ.as_type_enum() {
+        TypeEnum::Extension(custom) => {
+            let current = custom.extension_ref();
+            current.upgrade().is_some()
+                && extensions
+                    .get(custom.extension())
+                    .is_some_and(|expected| current.ptr_eq(expected))
+                && custom
+                    .args()
+                    .iter()
+                    .all(|arg| term_extension_refs_match(arg, extensions))
+        }
+        TypeEnum::Function(func) => {
+            func.input
+                .iter()
+                .all(|typ| type_extension_refs_match(typ, extensions))
+                && func
+                    .output
+                    .iter()
+                    .all(|typ| type_extension_refs_match(typ, extensions))
+        }
+        TypeEnum::Sum(SumType::General { rows }) => rows.iter().all(|row| {
+            row.iter()
+                .all(|typ| type_extension_refs_match(typ, extensions))
+        }),
+        TypeEnum::Alias(_) | TypeEnum::RowVar(_) | TypeEnum::Variable(_, _) | TypeEnum::Sum(_) => {
+            true
+        }
+    }
+}
+
+/// Checks every custom type reference nested in a static term.
+fn term_extension_refs_match(term: &Term, extensions: &WeakExtensionRegistry) -> bool {
+    match term {
+        Term::Runtime(typ) => type_extension_refs_match(typ, extensions),
+        Term::ConstType(typ) => type_extension_refs_match(typ, extensions),
+        Term::List(children)
+        | Term::ListConcat(children)
+        | Term::Tuple(children)
+        | Term::TupleConcat(children) => children
+            .iter()
+            .all(|child| term_extension_refs_match(child, extensions)),
+        Term::ListType(item_type) | Term::TupleType(item_type) => {
+            term_extension_refs_match(item_type, extensions)
+        }
+        Term::Variable(_)
+        | Term::RuntimeType(_)
+        | Term::StaticType
+        | Term::BoundedNatType(_)
+        | Term::StringType
+        | Term::BytesType
+        | Term::FloatType
+        | Term::BoundedNat(_)
+        | Term::String(_)
+        | Term::Bytes(_)
+        | Term::Float(_) => true,
+    }
 }
 
 /// Update all weak Extension pointers in a [`CustomType`].

--- a/hugr-core/src/hugr/views/sibling_subgraph.rs
+++ b/hugr-core/src/hugr/views/sibling_subgraph.rs
@@ -550,7 +550,7 @@ impl<N: HugrNode> SiblingSubgraph<N> {
     }
 
     /// Check the validity of the subgraph, as described in the docs of
-    /// [`SiblingSubgraph::try_new`], but do not check convexity.    
+    /// [`SiblingSubgraph::try_new`], but do not check convexity.
     pub fn validate_skip_convexity(
         &self,
         hugr: &impl HugrView<Node = N>,

--- a/hugr-core/src/import.rs
+++ b/hugr-core/src/import.rs
@@ -3,7 +3,10 @@
 //! **Warning**: This module is still under development and is expected to change.
 //! It is included in the library to allow for early experimentation, and for
 //! the core and model to converge incrementally.
-use std::sync::Arc;
+use std::{
+    any::{Any, TypeId},
+    sync::Arc,
+};
 
 use crate::envelope::description::GeneratorDesc;
 use crate::metadata::{self, Metadata};
@@ -241,20 +244,7 @@ pub(crate) fn import_described_hugr(
     module: &table::Module,
     extensions: &ExtensionRegistry,
 ) -> (ModuleDesc, Result<Hugr, ImportError>) {
-    // TODO: Module should know about the number of edges, so that we can use a vector here.
-    // For now we use a hashmap, which will be slower.
-    let mut ctx = Context {
-        module,
-        hugr: Hugr::new(),
-        link_ports: FxHashMap::default(),
-        static_edges: Vec::new(),
-        extensions,
-        nodes: FxHashMap::default(),
-        local_vars: FxHashMap::default(),
-        custom_name_cache: FxHashMap::default(),
-        region_scope: table::RegionId::default(),
-        description: ModuleDesc::default(),
-    };
+    let mut ctx = Context::new(module, extensions);
 
     if let Some(s) = get_generator(&ctx) {
         ctx.description.set_generator(s);
@@ -302,12 +292,34 @@ struct Context<'a> {
 
     custom_name_cache: FxHashMap<&'a str, (ExtensionId, SmolStr)>,
 
+    /// Successfully imported runtime types, keyed by model id and row-variable kind.
+    type_cache: FxHashMap<(table::TermId, TypeId), Box<dyn Any>>,
+
     region_scope: table::RegionId,
 
     description: ModuleDesc,
 }
 
 impl<'a> Context<'a> {
+    /// Creates the state used to import one model module.
+    fn new(module: &'a table::Module<'a>, extensions: &'a ExtensionRegistry) -> Self {
+        // TODO: Module should know about the number of edges, so that we can use a vector here.
+        // For now we use a hashmap, which will be slower.
+        Self {
+            module,
+            hugr: Hugr::new(),
+            link_ports: FxHashMap::default(),
+            static_edges: Vec::new(),
+            extensions,
+            nodes: FxHashMap::default(),
+            local_vars: FxHashMap::default(),
+            custom_name_cache: FxHashMap::default(),
+            type_cache: FxHashMap::default(),
+            region_scope: table::RegionId::default(),
+            description: ModuleDesc::default(),
+        }
+    }
+
     /// Get the signature of the node with the given `NodeId`.
     fn get_node_signature(&mut self, node: table::NodeId) -> Result<Signature, ImportErrorInner> {
         let node_data = self.get_node(node)?;
@@ -1563,84 +1575,105 @@ impl<'a> Context<'a> {
         &mut self,
         term_id: table::TermId,
     ) -> Result<TypeBase<RV>, ImportErrorInner> {
-        (|| {
-            if let Some([_, _]) = self.match_symbol(term_id, model::CORE_FN)? {
-                let func_type = self.import_func_type::<RowVariable>(term_id)?;
-                return Ok(TypeBase::new_function(func_type));
-            }
+        let cache_key = (term_id, TypeId::of::<RV>());
+        if let Some(typ) = self
+            .type_cache
+            .get(&cache_key)
+            .and_then(|typ| typ.downcast_ref::<TypeBase<RV>>())
+        {
+            return Ok(typ.clone());
+        }
 
-            if let Some([variants]) = self.match_symbol(term_id, model::CORE_ADT)? {
-                let variants = (|| {
-                    self.import_closed_list(variants)?
-                        .iter()
-                        .map(|variant| self.import_type_row::<RowVariable>(*variant))
-                        .collect::<Result<Vec<_>, _>>()
-                })()
-                .map_err(|err| error_context!(err, "adt variants"))?;
+        let result = self
+            .import_type_uncached(term_id)
+            .map_err(|err| error_context!(err, "term {} as `Type`", term_id));
 
-                return Ok(TypeBase::new_sum(variants));
-            }
+        if let Ok(typ) = &result {
+            self.type_cache.insert(cache_key, Box::new(typ.clone()));
+        }
+        result
+    }
 
-            match self.get_term(term_id)? {
-                table::Term::Wildcard => Err(error_uninferred!("wildcard")),
+    /// Imports a runtime type without consulting or updating the type cache.
+    fn import_type_uncached<RV: MaybeRV>(
+        &mut self,
+        term_id: table::TermId,
+    ) -> Result<TypeBase<RV>, ImportErrorInner> {
+        if let Some([_, _]) = self.match_symbol(term_id, model::CORE_FN)? {
+            let func_type = self.import_func_type::<RowVariable>(term_id)?;
+            return Ok(TypeBase::new_function(func_type));
+        }
 
-                table::Term::Apply(symbol, args) => {
-                    let name = self.get_symbol_name(*symbol)?;
+        if let Some([variants]) = self.match_symbol(term_id, model::CORE_ADT)? {
+            let variants = (|| {
+                self.import_closed_list(variants)?
+                    .iter()
+                    .map(|variant| self.import_type_row::<RowVariable>(*variant))
+                    .collect::<Result<Vec<_>, _>>()
+            })()
+            .map_err(|err| error_context!(err, "adt variants"))?;
 
-                    let args = args
-                        .iter()
-                        .map(|arg| self.import_term(*arg))
-                        .collect::<Result<Vec<_>, _>>()
-                        .map_err(|err| {
-                            error_context!(err, "type argument of custom type `{}`", name)
+            return Ok(TypeBase::new_sum(variants));
+        }
+
+        match self.get_term(term_id)? {
+            table::Term::Wildcard => Err(error_uninferred!("wildcard")),
+
+            table::Term::Apply(symbol, args) => {
+                let name = self.get_symbol_name(*symbol)?;
+
+                let args = args
+                    .iter()
+                    .map(|arg| self.import_term(*arg))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|err| {
+                        error_context!(err, "type argument of custom type `{}`", name)
+                    })?;
+
+                let (extension, id) = self.import_custom_name(name)?;
+
+                let extension_ref =
+                    self.extensions
+                        .get(&extension)
+                        .ok_or_else(|| ExtensionError::Missing {
+                            missing_ext: extension.clone(),
+                            available: self.extensions.ids().cloned().collect(),
                         })?;
 
-                    let (extension, id) = self.import_custom_name(name)?;
+                let ext_type =
+                    extension_ref
+                        .get_type(&id)
+                        .ok_or_else(|| ExtensionError::MissingType {
+                            ext: extension.clone(),
+                            name: id.clone(),
+                        })?;
 
-                    let extension_ref =
-                        self.extensions
-                            .get(&extension)
-                            .ok_or_else(|| ExtensionError::Missing {
-                                missing_ext: extension.clone(),
-                                available: self.extensions.ids().cloned().collect(),
-                            })?;
+                let bound = ext_type.bound(&args);
 
-                    let ext_type =
-                        extension_ref
-                            .get_type(&id)
-                            .ok_or_else(|| ExtensionError::MissingType {
-                                ext: extension.clone(),
-                                name: id.clone(),
-                            })?;
-
-                    let bound = ext_type.bound(&args);
-
-                    Ok(TypeBase::new_extension(CustomType::new(
-                        id,
-                        args,
-                        extension,
-                        bound,
-                        &Arc::downgrade(extension_ref),
-                    )))
-                }
-
-                table::Term::Var(var @ table::VarId(_, index)) => {
-                    let local_var = self
-                        .local_vars
-                        .get(var)
-                        .ok_or(error_invalid!("unknown var {}", var))?;
-                    Ok(TypeBase::new_var_use(*index as _, local_var.bound))
-                }
-
-                // The following terms are not runtime types, but the core `Type` only contains runtime types.
-                // We therefore report a type error here.
-                table::Term::Literal(_)
-                | table::Term::List { .. }
-                | table::Term::Tuple { .. }
-                | table::Term::Func { .. } => Err(error_invalid!("expected a runtime type")),
+                Ok(TypeBase::new(TypeEnum::Extension(CustomType::new(
+                    id,
+                    args,
+                    extension,
+                    bound,
+                    &Arc::downgrade(extension_ref),
+                ))))
             }
-        })()
-        .map_err(|err| error_context!(err, "term {} as `Type`", term_id))
+
+            table::Term::Var(var @ table::VarId(_, index)) => {
+                let local_var = self
+                    .local_vars
+                    .get(var)
+                    .ok_or(error_invalid!("unknown var {}", var))?;
+                Ok(TypeBase::new_var_use(*index as _, local_var.bound))
+            }
+
+            // The following terms are not runtime types, but the core `Type` only contains runtime types.
+            // We therefore report a type error here.
+            table::Term::Literal(_)
+            | table::Term::List { .. }
+            | table::Term::Tuple { .. }
+            | table::Term::Func { .. } => Err(error_invalid!("expected a runtime type")),
+        }
     }
 
     fn get_func_type(
@@ -2148,5 +2181,44 @@ impl LocalVar {
             r#type,
             bound: TypeBound::Linear,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use hugr_model::v0::{self as model, table};
+    use rstest::rstest;
+
+    use super::Context;
+    use crate::std_extensions::std_reg;
+
+    /// Repeated imports of the same model type reuse their backing allocation.
+    #[rstest]
+    fn repeated_runtime_type_imports_share_storage() {
+        let ast = model::ast::Package::from_str(include_str!(
+            "../../hugr-model/tests/fixtures/model-add.edn"
+        ))
+        .unwrap();
+        let bump = model::bumpalo::Bump::new();
+        let package = ast.resolve(&bump).unwrap();
+        let module = &package.modules[0];
+        let registry = std_reg();
+        let mut context = Context::new(module, &registry);
+
+        let (term_id, first) = (0..module.terms.len())
+            .map(table::TermId::new)
+            .find_map(|term_id| {
+                context
+                    .import_type::<crate::types::NoRV>(term_id)
+                    .ok()
+                    .filter(|typ| typ.as_extension().is_some())
+                    .map(|typ| (term_id, typ))
+            })
+            .expect("fixture should contain an extension type");
+        let second = context.import_type::<crate::types::NoRV>(term_id).unwrap();
+
+        assert!(first.shares_storage_with(&second));
     }
 }

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -32,6 +32,7 @@ use itertools::{Either, Itertools as _};
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
 use crate::extension::{ExtensionRegistry, ExtensionSet, SignatureError};
 use crate::ops::AliasDecl;
@@ -373,8 +374,7 @@ impl<RV: MaybeRV> TypeEnum<RV> {
     }
 }
 
-#[derive(Clone, Debug, Eq, Hash, derive_more::Display, serde::Serialize, serde::Deserialize)]
-#[display("{_0}")]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 #[serde(
     into = "serialize::SerSimpleType",
     try_from = "serialize::SerSimpleType"
@@ -400,7 +400,96 @@ impl<RV: MaybeRV> TypeEnum<RV> {
 /// let func_type: Type = Type::new_function(Signature::new_endo([]));
 /// assert_eq!(func_type.least_upper_bound(), TypeBound::Copyable);
 /// ```
-pub struct TypeBase<RV: MaybeRV>(TypeEnum<RV>, TypeBound);
+pub struct TypeBase<RV: MaybeRV>(TypeStorage<RV>, TypeBound);
+
+/// Storage for a [`TypeBase`]'s structural representation.
+///
+/// Public constant constructors use the inline variant because stable Rust
+/// cannot allocate an [`Arc`] during constant evaluation. Runtime constructors
+/// use shared storage so cloned imported types reuse the same type tree.
+#[derive(Clone)]
+enum TypeStorage<RV: MaybeRV> {
+    Inline(TypeEnum<RV>),
+    Shared(SharedTypeEnum<RV>),
+}
+
+/// An owned shared type tree and the stable pointer used for constant access.
+///
+/// Keeping the pointer separately lets [`TypeBase::as_type_enum`] remain a
+/// `const fn`: stable Rust cannot dereference an [`Arc`] in constant evaluation.
+struct SharedTypeEnum<RV: MaybeRV> {
+    owner: Arc<TypeEnum<RV>>,
+    ptr: *const TypeEnum<RV>,
+}
+
+impl<RV: MaybeRV> SharedTypeEnum<RV> {
+    /// Allocates shared storage for a runtime-created type tree.
+    fn new(value: TypeEnum<RV>) -> Self {
+        let owner = Arc::new(value);
+        let ptr = Arc::as_ptr(&owner);
+        Self { owner, ptr }
+    }
+
+    /// Borrows the value owned by the accompanying [`Arc`].
+    const fn as_ref(&self) -> &TypeEnum<RV> {
+        // SAFETY: `ptr` comes from `owner`. It is refreshed whenever
+        // `Arc::make_mut` changes the allocation and never escapes this borrow.
+        unsafe { &*self.ptr }
+    }
+
+    /// Provides copy-on-write mutable access and refreshes the stable pointer.
+    fn make_mut(&mut self) -> &mut TypeEnum<RV> {
+        let value = Arc::make_mut(&mut self.owner);
+        self.ptr = value;
+        value
+    }
+
+    /// Consumes the owner, avoiding a clone when the allocation is unique.
+    fn into_inner(self) -> TypeEnum<RV> {
+        Arc::try_unwrap(self.owner).unwrap_or_else(|value| value.as_ref().clone())
+    }
+}
+
+impl<RV: MaybeRV> Clone for SharedTypeEnum<RV> {
+    fn clone(&self) -> Self {
+        Self {
+            owner: self.owner.clone(),
+            ptr: self.ptr,
+        }
+    }
+}
+
+// SAFETY: `ptr` only points into `owner`, and access through it is tied to a
+// borrow of this wrapper. Thread-safety therefore matches `TypeEnum<RV>`.
+unsafe impl<RV: MaybeRV + Send + Sync> Send for SharedTypeEnum<RV> {}
+// SAFETY: See the `Send` implementation above.
+unsafe impl<RV: MaybeRV + Send + Sync> Sync for SharedTypeEnum<RV> {}
+
+impl<RV: MaybeRV> TypeStorage<RV> {
+    /// Returns the structural type independent of its storage strategy.
+    const fn as_type_enum(&self) -> &TypeEnum<RV> {
+        match self {
+            Self::Inline(value) => value,
+            Self::Shared(value) => value.as_ref(),
+        }
+    }
+
+    /// Returns a mutable structural type, cloning shared storage when needed.
+    fn make_mut(&mut self) -> &mut TypeEnum<RV> {
+        match self {
+            Self::Inline(value) => value,
+            Self::Shared(value) => value.make_mut(),
+        }
+    }
+
+    /// Consumes the storage and returns its structural type.
+    fn into_type_enum(self) -> TypeEnum<RV> {
+        match self {
+            Self::Inline(value) => value,
+            Self::Shared(value) => value.into_inner(),
+        }
+    }
+}
 
 /// The type of a single value, that can be sent down a wire
 pub type Type = TypeBase<NoRV>;
@@ -425,7 +514,31 @@ impl<RV1: MaybeRV, RV2: MaybeRV> PartialEq<TypeEnum<RV1>> for TypeEnum<RV2> {
 
 impl<RV1: MaybeRV, RV2: MaybeRV> PartialEq<TypeBase<RV1>> for TypeBase<RV2> {
     fn eq(&self, other: &TypeBase<RV1>) -> bool {
-        self.0 == other.0 && self.1 == other.1
+        self.as_type_enum() == other.as_type_enum() && self.1 == other.1
+    }
+}
+
+impl<RV: MaybeRV> Eq for TypeBase<RV> {}
+
+impl<RV: MaybeRV> std::fmt::Debug for TypeBase<RV> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("TypeBase")
+            .field(self.as_type_enum())
+            .field(&self.1)
+            .finish()
+    }
+}
+
+impl<RV: MaybeRV> std::fmt::Display for TypeBase<RV> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_type_enum().fmt(f)
+    }
+}
+
+impl<RV: MaybeRV + std::hash::Hash> std::hash::Hash for TypeBase<RV> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_type_enum().hash(state);
+        self.1.hash(state);
     }
 }
 
@@ -434,11 +547,22 @@ impl<RV: MaybeRV> TypeBase<RV> {
     pub const EMPTY_TYPEROW: TypeRowBase<RV> = TypeRowBase::<RV>::new();
     /// Unit type (empty tuple).
     pub const UNIT: Self = Self(
-        TypeEnum::Sum(SumType::Unit { size: 1 }),
+        TypeStorage::Inline(TypeEnum::Sum(SumType::Unit { size: 1 })),
         TypeBound::Copyable,
     );
 
     const EMPTY_TYPEROW_REF: &'static TypeRowBase<RV> = &Self::EMPTY_TYPEROW;
+
+    /// Returns whether two types reuse the same shared backing allocation.
+    #[cfg(test)]
+    pub(crate) fn shares_storage_with(&self, other: &Self) -> bool {
+        match (&self.0, &other.0) {
+            (TypeStorage::Shared(left), TypeStorage::Shared(right)) => {
+                Arc::ptr_eq(&left.owner, &right.owner)
+            }
+            _ => false,
+        }
+    }
 
     /// Initialize a new function type.
     pub fn new_function(fun_ty: impl Into<FuncValueType>) -> Self {
@@ -469,7 +593,7 @@ impl<RV: MaybeRV> TypeBase<RV> {
     #[must_use]
     pub const fn new_extension(opaque: CustomType) -> Self {
         let bound = opaque.bound();
-        TypeBase(TypeEnum::Extension(opaque), bound)
+        TypeBase(TypeStorage::Inline(TypeEnum::Extension(opaque)), bound)
     }
 
     /// Initialize a new alias.
@@ -480,14 +604,17 @@ impl<RV: MaybeRV> TypeBase<RV> {
 
     pub(crate) fn new(type_e: TypeEnum<RV>) -> Self {
         let bound = type_e.least_upper_bound();
-        Self(type_e, bound)
+        Self(TypeStorage::Shared(SharedTypeEnum::new(type_e)), bound)
     }
 
     /// New `UnitSum` with empty Tuple variants
     #[must_use]
     pub const fn new_unit_sum(size: u8) -> Self {
         // should be the only way to avoid going through SumType::new
-        Self(TypeEnum::Sum(SumType::new_unary(size)), TypeBound::Copyable)
+        Self(
+            TypeStorage::Inline(TypeEnum::Sum(SumType::new_unary(size))),
+            TypeBound::Copyable,
+        )
     }
 
     /// New use (occurrence) of the type variable with specified index.
@@ -496,7 +623,7 @@ impl<RV: MaybeRV> TypeBase<RV> {
     /// than required for the use.
     #[must_use]
     pub const fn new_var_use(idx: usize, bound: TypeBound) -> Self {
-        Self(TypeEnum::Variable(idx, bound), bound)
+        Self(TypeStorage::Inline(TypeEnum::Variable(idx, bound)), bound)
     }
 
     /// Report the least upper [`TypeBound`]
@@ -508,18 +635,18 @@ impl<RV: MaybeRV> TypeBase<RV> {
     /// Report the component `TypeEnum`.
     #[inline(always)]
     pub const fn as_type_enum(&self) -> &TypeEnum<RV> {
-        &self.0
+        self.0.as_type_enum()
     }
 
     /// Report a mutable reference to the component `TypeEnum`.
     #[inline(always)]
     pub fn as_type_enum_mut(&mut self) -> &mut TypeEnum<RV> {
-        &mut self.0
+        self.0.make_mut()
     }
 
     /// Returns the inner [`SumType`] if the type is a sum.
     pub fn as_sum(&self) -> Option<&SumType> {
-        match &self.0 {
+        match self.as_type_enum() {
             TypeEnum::Sum(s) => Some(s),
             _ => None,
         }
@@ -527,7 +654,7 @@ impl<RV: MaybeRV> TypeBase<RV> {
 
     /// Returns the inner [`CustomType`] if the type is from an extension.
     pub fn as_extension(&self) -> Option<&CustomType> {
-        match &self.0 {
+        match self.as_type_enum() {
             TypeEnum::Extension(ct) => Some(ct),
             _ => None,
         }
@@ -551,7 +678,7 @@ impl<RV: MaybeRV> TypeBase<RV> {
     pub(crate) fn validate(&self, var_decls: &[TypeParam]) -> Result<(), SignatureError> {
         // There is no need to check the components against the bound,
         // that is guaranteed by construction (even for deserialization)
-        match &self.0 {
+        match self.as_type_enum() {
             TypeEnum::Sum(SumType::General { rows }) => {
                 rows.iter().try_for_each(|row| row.validate(var_decls))
             }
@@ -573,7 +700,7 @@ impl<RV: MaybeRV> TypeBase<RV> {
     /// * If [`Type::validate`]`(false)` fails, but `(true)` succeeds, this method may (depending on structure of self)
     ///   return a Vec containing any number of [Type]s. These may (or not) pass [`Type::validate`]
     fn substitute(&self, t: &Substitution) -> Vec<Self> {
-        match &self.0 {
+        match self.as_type_enum() {
             TypeEnum::RowVar(rv) => rv.substitute(t),
             TypeEnum::Alias(_) | TypeEnum::Sum(SumType::Unit { .. }) => vec![self.clone()],
             TypeEnum::Variable(idx, bound) => {
@@ -610,7 +737,7 @@ impl<RV: MaybeRV> TypeBase<RV> {
 
 impl<RV: MaybeRV> Transformable for TypeBase<RV> {
     fn transform<T: TypeTransformer>(&mut self, tr: &T) -> Result<bool, T::Err> {
-        match &mut self.0 {
+        match self.as_type_enum_mut() {
             TypeEnum::Alias(_) | TypeEnum::RowVar(_) | TypeEnum::Variable(..) => Ok(false),
             TypeEnum::Extension(custom_type) => {
                 if let Some(nt) = tr.apply_custom(custom_type)? {
@@ -631,7 +758,7 @@ impl<RV: MaybeRV> Transformable for TypeBase<RV> {
             TypeEnum::Function(fty) => fty.transform(tr),
             TypeEnum::Sum(sum_type) => {
                 let ch = sum_type.transform(tr)?;
-                self.1 = self.0.least_upper_bound();
+                self.1 = self.as_type_enum().least_upper_bound();
                 Ok(ch)
             }
         }
@@ -650,7 +777,7 @@ impl TypeRV {
     /// Tells if this Type is a row variable, i.e. could stand for any number >=0 of Types
     #[must_use]
     pub fn is_row_var(&self) -> bool {
-        matches!(self.0, TypeEnum::RowVar(_))
+        matches!(self.as_type_enum(), TypeEnum::RowVar(_))
     }
 
     /// New use (occurrence) of the row variable with specified index.
@@ -662,7 +789,10 @@ impl TypeRV {
     /// [FuncDefn]: crate::ops::FuncDefn
     #[must_use]
     pub const fn new_row_var_use(idx: usize, bound: TypeBound) -> Self {
-        Self(TypeEnum::RowVar(RowVariable(idx, bound)), bound)
+        Self(
+            TypeStorage::Inline(TypeEnum::RowVar(RowVariable(idx, bound))),
+            bound,
+        )
     }
 }
 
@@ -671,17 +801,14 @@ impl<RV: MaybeRV> TypeBase<RV> {
     /// (Fallibly) converts a `TypeBase` (parameterized, so may or may not be able
     /// to contain [`RowVariable`]s) into a [Type] that definitely does not.
     pub fn try_into_type(self) -> Result<Type, RowVariable> {
-        Ok(TypeBase(
-            match self.0 {
-                TypeEnum::Extension(e) => TypeEnum::Extension(e),
-                TypeEnum::Alias(a) => TypeEnum::Alias(a),
-                TypeEnum::Function(f) => TypeEnum::Function(f),
-                TypeEnum::Variable(idx, bound) => TypeEnum::Variable(idx, bound),
-                TypeEnum::RowVar(rv) => Err(rv.as_rv().clone())?,
-                TypeEnum::Sum(s) => TypeEnum::Sum(s),
-            },
-            self.1,
-        ))
+        Ok(TypeBase::new(match self.0.into_type_enum() {
+            TypeEnum::Extension(e) => TypeEnum::Extension(e),
+            TypeEnum::Alias(a) => TypeEnum::Alias(a),
+            TypeEnum::Function(f) => TypeEnum::Function(f),
+            TypeEnum::Variable(idx, bound) => TypeEnum::Variable(idx, bound),
+            TypeEnum::RowVar(rv) => Err(rv.as_rv().clone())?,
+            TypeEnum::Sum(s) => TypeEnum::Sum(s),
+        }))
     }
 }
 
@@ -699,17 +826,14 @@ impl<RV1: MaybeRV> TypeBase<RV1> {
     where
         RV1: Into<RV2>,
     {
-        TypeBase(
-            match self.0 {
-                TypeEnum::Extension(e) => TypeEnum::Extension(e),
-                TypeEnum::Alias(a) => TypeEnum::Alias(a),
-                TypeEnum::Function(f) => TypeEnum::Function(f),
-                TypeEnum::Variable(idx, bound) => TypeEnum::Variable(idx, bound),
-                TypeEnum::RowVar(rv) => TypeEnum::RowVar(rv.into()),
-                TypeEnum::Sum(s) => TypeEnum::Sum(s),
-            },
-            self.1,
-        )
+        TypeBase::new(match self.0.into_type_enum() {
+            TypeEnum::Extension(e) => TypeEnum::Extension(e),
+            TypeEnum::Alias(a) => TypeEnum::Alias(a),
+            TypeEnum::Function(f) => TypeEnum::Function(f),
+            TypeEnum::Variable(idx, bound) => TypeEnum::Variable(idx, bound),
+            TypeEnum::RowVar(rv) => TypeEnum::RowVar(rv.into()),
+            TypeEnum::Sum(s) => TypeEnum::Sum(s),
+        })
     }
 }
 
@@ -768,7 +892,7 @@ impl<'a> Substitution<'a> {
                     panic!("Not a list of types - call validate() ?")
                 })
                 .collect(),
-            Term::Runtime(ty) if matches!(ty.0, TypeEnum::RowVar(_)) => {
+            Term::Runtime(ty) if matches!(ty.as_type_enum(), TypeEnum::RowVar(_)) => {
                 // Standalone "Type" can be used iff its actually a Row Variable not an actual (single) Type
                 vec![ty.clone().into()]
             }
@@ -862,6 +986,30 @@ pub(crate) mod test {
     use crate::std_extensions::collections::list::list_type;
     use crate::types::type_param::TermTypeError;
     use crate::{Extension, hugr::IdentList, type_row};
+
+    /// Public type operations remain usable in downstream constant expressions.
+    const CONST_UNIT_SUM: Type = Type::new_unit_sum(2);
+    const CONST_UNIT_SUM_REF: &Type = &CONST_UNIT_SUM;
+    const CONST_VAR: Type = Type::new_var_use(0, TypeBound::Linear);
+    const CONST_ROW_VAR: TypeRV = TypeRV::new_row_var_use(0, TypeBound::Copyable);
+    const CONST_BOUND: TypeBound = CONST_UNIT_SUM_REF.least_upper_bound();
+    const CONST_COPYABLE: bool = CONST_UNIT_SUM_REF.copyable();
+    const CONST_TYPE_ENUM: &TypeEnum<NoRV> = CONST_UNIT_SUM_REF.as_type_enum();
+
+    #[rstest::rstest]
+    fn const_api() {
+        assert_eq!(std::hint::black_box(CONST_BOUND), TypeBound::Copyable);
+        assert!(std::hint::black_box(CONST_COPYABLE));
+        assert!(matches!(
+            CONST_TYPE_ENUM,
+            TypeEnum::Sum(SumType::Unit { size: 2 })
+        ));
+        assert!(matches!(
+            CONST_VAR.as_type_enum(),
+            TypeEnum::Variable(0, TypeBound::Linear)
+        ));
+        assert!(CONST_ROW_VAR.is_row_var());
+    }
 
     #[test]
     fn construct() {
@@ -971,9 +1119,13 @@ pub(crate) mod test {
         let lin = e.get_type(&LIN).unwrap().instantiate([]).unwrap();
 
         let lin_to_usize = FnTransformer(|ct: &CustomType| (*ct == lin).then_some(usize_t()));
-        let mut t = Type::new_extension(lin.clone());
+        let original = Type::new(TypeEnum::Extension(lin.clone()));
+        let mut t = original.clone();
+        assert!(original.shares_storage_with(&t));
         assert_eq!(t.transform(&lin_to_usize), Ok(true));
         assert_eq!(t, usize_t());
+        assert_eq!(original, Type::new_extension(lin.clone()));
+        assert!(!original.shares_storage_with(&t));
 
         for coln in [
             list_type,

--- a/hugr-core/src/types.rs
+++ b/hugr-core/src/types.rs
@@ -418,6 +418,9 @@ enum TypeStorage<RV: MaybeRV> {
 /// Keeping the pointer separately lets [`TypeBase::as_type_enum`] remain a
 /// `const fn`: stable Rust cannot dereference an [`Arc`] in constant evaluation.
 struct SharedTypeEnum<RV: MaybeRV> {
+    /// The owned `Arc` that keeps the type tree alive.
+    ///
+    /// This should never be mutated directly; use `new`/`make_mut` instead.
     owner: Arc<TypeEnum<RV>>,
     ptr: *const TypeEnum<RV>,
 }
@@ -461,9 +464,9 @@ impl<RV: MaybeRV> Clone for SharedTypeEnum<RV> {
 
 // SAFETY: `ptr` only points into `owner`, and access through it is tied to a
 // borrow of this wrapper. Thread-safety therefore matches `TypeEnum<RV>`.
-unsafe impl<RV: MaybeRV + Send + Sync> Send for SharedTypeEnum<RV> {}
+unsafe impl<RV: MaybeRV + Send + Sync> Send for SharedTypeEnum<RV> where TypeEnum<RV>: Send + Sync {}
 // SAFETY: See the `Send` implementation above.
-unsafe impl<RV: MaybeRV + Send + Sync> Sync for SharedTypeEnum<RV> {}
+unsafe impl<RV: MaybeRV + Send + Sync> Sync for SharedTypeEnum<RV> where TypeEnum<RV>: Send + Sync {}
 
 impl<RV: MaybeRV> TypeStorage<RV> {
     /// Returns the structural type independent of its storage strategy.

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -33,7 +33,7 @@ impl<RV: MaybeRV> From<TypeBase<RV>> for SerSimpleType {
         if value == usize_t() {
             return SerSimpleType::I;
         }
-        match value.0 {
+        match value.0.into_type_enum() {
             TypeEnum::Extension(o) => SerSimpleType::Opaque(o),
             TypeEnum::Alias(a) => SerSimpleType::Alias(a),
             TypeEnum::Function(sig) => SerSimpleType::G(sig),

--- a/hugr-core/src/types/serialize.rs
+++ b/hugr-core/src/types/serialize.rs
@@ -33,6 +33,9 @@ impl<RV: MaybeRV> From<TypeBase<RV>> for SerSimpleType {
         if value == usize_t() {
             return SerSimpleType::I;
         }
+        // NOTE: `into_type_enum` will force cloning of shared types before they are serialized.
+        //
+        // Avoiding this requires rewriting the serialization logic to handle shared storage directly.
         match value.0.into_type_enum() {
             TypeEnum::Extension(o) => SerSimpleType::Opaque(o),
             TypeEnum::Alias(a) => SerSimpleType::Alias(a),


### PR DESCRIPTION
LLM'd backport of #3215.

Use an `Arc` under `Type` to avoid multiple decodings of the same type.

This branch is pre-term unification, so some changes needed to be made to work with it.
We also needed to store a `*const TypeEnum<RV>` in the Type wrapper to avoid un`const`ing functions and breaking the API.