### PR TITLE
feat!: Read ext version as optional in ExtensionDesc metadata

### DIFF
--- a/hugr-cli/src/describe.rs
+++ b/hugr-cli/src/describe.rs
@@ -248,15 +248,9 @@ struct SymbolRow {
 
 impl From<ExtensionDesc> for ExtensionRow {
     fn from(desc: ExtensionDesc) -> Self {
-        // TODO: Remove this once `hugr-rs 0.27.0` is released and `ExtensionDesc::version` is made optional.
-        let version = if desc.version == Version::new(0, 0, 0) {
-            None
-        } else {
-            Some(desc.version)
-        };
         Self {
             name: desc.name,
-            version,
+            version: desc.version,
         }
     }
 }

--- a/hugr-cli/tests/describe.rs
+++ b/hugr-cli/tests/describe.rs
@@ -412,13 +412,15 @@ fn test_schema(mut describe_cmd: Command) {
               "type": "string"
             },
             "version": {
-              "description": "Version of the extension.\n\nA version value of `0.0.0` is used for extensions that do not have a version.",
-              "type": "string"
+              "description": "Version of the extension.",
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "required": [
-            "name",
-            "version"
+            "name"
           ]
         },
         "ModuleDesc": {

--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -198,10 +198,14 @@ pub enum ExtensionBreakingError {
     Deserialization(#[from] serde_json::Error),
 }
 
-/// If HUGR metadata contains a list of used extensions, under the key [`USED_EXTENSIONS_KEY`],
-/// and extension is registered in the given registry, check that the
-/// version of the extension in the metadata matches the registered version.
-/// Version compatibility is defined by [`compatible_versions`].
+/// If HUGR metadata contains a list of used extensions, under the key
+/// [`USED_EXTENSIONS_KEY`], and extension is registered in the given registry,
+/// check that the version of the extension in the metadata matches the
+/// registered version. Version compatibility is defined by
+/// [`compatible_versions`].
+///
+/// If an ExtensionDesc does not specify a version, it is assumed to be
+/// compatible with any registered version.
 fn check_breaking_extensions<'e>(
     registry: &ExtensionRegistry,
     used_exts: impl IntoIterator<Item = &'e description::ExtensionDesc>,

--- a/hugr-core/src/envelope.rs
+++ b/hugr-core/src/envelope.rs
@@ -210,14 +210,17 @@ fn check_breaking_extensions<'e>(
         let Some(registered) = registry.get(ext.name.as_str()) else {
             continue; // Extension not registered, ignore
         };
-        if !compatible_versions(registered.version(), &ext.version) {
+        let Some(used) = &ext.version else {
+            continue; // Extension version not specified, compatibility cannot be checked
+        };
+        if !compatible_versions(registered.version(), used) {
             // This is a breaking change, raise an error.
 
             return Err(ExtensionBreakingError::ExtensionVersionMismatch(
                 ExtensionVersionMismatch {
                     name: ext.name.clone(),
                     registered: registered.version().clone(),
-                    used: ext.version.clone(),
+                    used: used.clone(),
                 },
             ));
         }
@@ -537,17 +540,12 @@ pub(crate) mod test {
         hugr.set_metadata::<HugrUsedExtensions>(hugr.module_root(), used_exts);
         assert_matches!(check(&hugr, &registry), Ok(()));
 
-        //  Multiple extensions with one unversioned - should fail
+        // Multiple extensions with one unversioned - should pass
         let used_exts = vec![
             ExtensionDesc::new("test-v0", Version::new(0, 2, 2)),
             ExtensionDesc::new_unversioned("test-v1"),
         ];
         hugr.set_metadata::<HugrUsedExtensions>(hugr.module_root(), used_exts);
-        assert_matches!(check(&hugr, &registry), Err(ExtensionBreakingError::ExtensionVersionMismatch(ExtensionVersionMismatch {
-            name,
-            registered,
-            used
-        })) if name == "test-v1" && registered == Version::new(1, 2, 3) && used == Version::new(0, 0, 0)
-        );
+        assert_matches!(check(&hugr, &registry), Ok(()));
     }
 }

--- a/hugr-core/src/envelope/description.rs
+++ b/hugr-core/src/envelope/description.rs
@@ -133,17 +133,19 @@ impl PackageDesc {
     serde::Serialize,
     schemars::JsonSchema,
 )]
-#[display("Extension {name} v{version}")]
+#[display(
+    "Extension {name}{}",
+    version
+        .as_ref()
+        .map_or_else(String::new, |version| format!(" v{version}"))
+)]
 pub struct ExtensionDesc {
     /// Name of the extension.
     pub name: String,
     /// Version of the extension.
-    ///
-    /// A version value of `0.0.0` is used for extensions that do not have a version.
-    //
-    // TODO: Make this optional in `hugr-rs 0.27.0`.
-    #[schemars(with = "String")]
-    pub version: Version,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
+    pub version: Option<Version>,
 }
 
 impl ExtensionDesc {
@@ -151,7 +153,7 @@ impl ExtensionDesc {
     pub fn new(name: impl ToString, version: impl Into<Version>) -> Self {
         Self {
             name: name.to_string(),
-            version: version.into(),
+            version: Some(version.into()),
         }
     }
 
@@ -159,7 +161,7 @@ impl ExtensionDesc {
     pub fn new_unversioned(name: impl ToString) -> Self {
         Self {
             name: name.to_string(),
-            version: Version::new(0, 0, 0),
+            version: None,
         }
     }
 }
@@ -169,7 +171,7 @@ impl<E: AsRef<crate::Extension>> From<&E> for ExtensionDesc {
         let ext = ext.as_ref();
         Self {
             name: ext.name.to_string(),
-            version: ext.version.clone(),
+            version: Some(ext.version.clone()),
         }
     }
 }
@@ -643,7 +645,21 @@ mod test {
         let version = Version::new(1, 0, 0);
         let extension = ExtensionDesc::new(name, version.clone());
         assert_eq!(extension.name, name);
-        assert_eq!(extension.version, version);
+        assert_eq!(extension.version, Some(version));
+        assert_eq!(extension.to_string(), "Extension test_extension v1.0.0");
+    }
+
+    #[test]
+    fn test_extension_desc_new_unversioned() {
+        let extension = ExtensionDesc::new_unversioned("test_extension");
+
+        assert_eq!(extension.name, "test_extension");
+        assert_eq!(extension.version, None);
+        assert_eq!(extension.to_string(), "Extension test_extension");
+        assert_eq!(
+            serde_json::to_value(extension).unwrap(),
+            serde_json::json!({"name": "test_extension"})
+        );
     }
 
     #[rstest]

--- a/hugr-core/src/envelope/reader.rs
+++ b/hugr-core/src/envelope/reader.rs
@@ -106,7 +106,7 @@ impl<R: BufRead> EnvelopeReader<R> {
     /// Handle extension resolution errors by recording missing extensions in the description.
     ///
     /// This function inspects the error and adds any missing extensions to the module description
-    /// with a default version of 0.0.0.
+    /// without a version.
     fn handle_resolution_error(desc: &mut ModuleDesc, err: &ExtensionResolutionError) {
         match err {
             ExtensionResolutionError::MissingOpExtension {
@@ -433,11 +433,7 @@ mod test {
             for ext_id in expected_ids {
                 assert!(names.contains(&&ext_id.to_string()));
             }
-            assert!(
-                resolved
-                    .iter()
-                    .all(|e| e.version == crate::extension::Version::new(0, 0, 0))
-            );
+            assert!(resolved.iter().all(|e| e.version.is_none()));
         };
 
         // Test MissingOpExtension

--- a/hugr-py/src/hugr/cli.py
+++ b/hugr-py/src/hugr/cli.py
@@ -79,11 +79,7 @@ class ExtensionDesc(BaseModel):
     """
 
     name: str
-    # TODO: `hugr-rs <=0.26.1` expects this field to be present.
-    #
-    # This value should be set to "0.0.0" for backwards compatibility, until the
-    # next major hugr-rs version.
-    version: str | None
+    version: str | None = None
 
 
 class ModuleDesc(BaseModel):

--- a/hugr-py/src/hugr/envelope.py
+++ b/hugr-py/src/hugr/envelope.py
@@ -446,15 +446,10 @@ class ExtensionDesc:
         """Encodes the extension as a dictionary of native types that can be
         serialized by `json.dump`.
         """
-        return {
-            "name": self.name,
-            # TODO: We set a valid version here for backwards compatibility with
-            # `hugr-rs <=0.26.1`.
-            #
-            # This should be left as None once we use hugr-rs >=0.26.2 everywhere
-            # or after the next breaking release.
-            "version": str(self.version) if self.version is not None else "0.0.0",
-        }
+        value = {"name": self.name}
+        if self.version is not None:
+            value["version"] = str(self.version)
+        return value
 
     @classmethod
     def from_json(cls, value: Any) -> ExtensionDesc:

--- a/hugr-py/tests/test_metadata.py
+++ b/hugr-py/tests/test_metadata.py
@@ -93,7 +93,7 @@ def test_metadata_roundtrip() -> None:
     assert raw[HugrGenerator.KEY] == {"name": "hugr-py-test", "version": "1.2.3"}
     assert raw[HugrUsedExtensions.KEY] == [
         {"name": "ext.a", "version": "0.1.0"},
-        {"name": "ext.b", "version": "0.0.0"},
+        {"name": "ext.b"},
     ]
     assert raw["custom.metadata"] == custom_payload
 


### PR DESCRIPTION
Pre-breaking release cleanup.

This was left as a breaking TODO when first implemented.

BREAKING CHANGE: `ExtensionDesc::version` is now an optional version.

Not a python breaking release
BEGIN_COMMIT_OVERRIDE
feat: Read ext version as optional in ExtensionDesc metadata (#3231)
END_COMMIT_OVERRIDE