### PR TITLE
perf: Cache extension type helpers

### DIFF
--- a/hugr-core/src/extension/prelude.rs
+++ b/hugr-core/src/extension/prelude.rs
@@ -170,20 +170,24 @@ pub(crate) fn qb_custom_t(extension_ref: &Weak<Extension>) -> CustomType {
     )
 }
 
+static QB_T: LazyLock<Type> = LazyLock::new(|| qb_custom_t(&Arc::downgrade(&PRELUDE)).into());
+static USIZE_T: LazyLock<Type> = LazyLock::new(|| usize_custom_t(&Arc::downgrade(&PRELUDE)).into());
+static BOOL_T: LazyLock<Type> = LazyLock::new(|| Type::new_unit_sum(2));
+
 /// Qubit type.
 #[must_use]
 pub fn qb_t() -> Type {
-    qb_custom_t(&Arc::downgrade(&PRELUDE)).into()
+    QB_T.clone()
 }
 /// Unsigned size type.
 #[must_use]
 pub fn usize_t() -> Type {
-    usize_custom_t(&Arc::downgrade(&PRELUDE)).into()
+    USIZE_T.clone()
 }
 /// Boolean type - Sum of two units.
 #[must_use]
 pub fn bool_t() -> Type {
-    Type::new_unit_sum(2)
+    BOOL_T.clone()
 }
 
 /// Name of the prelude `MakeError` operation.
@@ -237,10 +241,13 @@ fn string_custom_type(extension_ref: &Weak<Extension>) -> CustomType {
     )
 }
 
+static STRING_TYPE: LazyLock<Type> =
+    LazyLock::new(|| string_custom_type(&Arc::downgrade(&PRELUDE)).into());
+
 /// String type.
 #[must_use]
 pub fn string_type() -> Type {
-    string_custom_type(&Arc::downgrade(&PRELUDE)).into()
+    STRING_TYPE.clone()
 }
 
 #[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
@@ -294,10 +301,13 @@ fn error_custom_type(extension_ref: &Weak<Extension>) -> CustomType {
     )
 }
 
+static ERROR_TYPE: LazyLock<Type> =
+    LazyLock::new(|| error_custom_type(&Arc::downgrade(&PRELUDE)).into());
+
 /// Unspecified opaque error type.
 #[must_use]
 pub fn error_type() -> Type {
-    error_custom_type(&Arc::downgrade(&PRELUDE)).into()
+    ERROR_TYPE.clone()
 }
 
 /// The string name of the error type.
@@ -996,6 +1006,13 @@ mod test {
     };
 
     use crate::hugr::views::HugrView;
+
+    #[test]
+    fn common_types_share_storage() {
+        for make_type in [qb_t, usize_t, bool_t, string_type, error_type] {
+            assert!(make_type().shares_storage_with(&make_type()));
+        }
+    }
 
     #[test]
     fn test_make_tuple() {

--- a/hugr-core/src/std_extensions/arithmetic/float_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/float_types.rs
@@ -32,10 +32,13 @@ pub fn float64_custom_type(extension_ref: &Weak<Extension>) -> CustomType {
     )
 }
 
+static FLOAT64_TYPE: LazyLock<Type> =
+    LazyLock::new(|| float64_custom_type(&Arc::downgrade(&EXTENSION)).into());
+
 /// 64-bit IEEE 754-2019 floating-point type (as [Type])
 #[must_use]
 pub fn float64_type() -> Type {
-    float64_custom_type(&Arc::downgrade(&EXTENSION)).into()
+    FLOAT64_TYPE.clone()
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -119,6 +122,11 @@ pub static EXTENSION: LazyLock<Arc<Extension>> = LazyLock::new(|| {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn float_type_shares_storage() {
+        assert!(float64_type().shares_storage_with(&float64_type()));
+    }
 
     #[test]
     fn test_float_types_extension() {

--- a/hugr-core/src/std_extensions/arithmetic/int_types.rs
+++ b/hugr-core/src/std_extensions/arithmetic/int_types.rs
@@ -43,13 +43,24 @@ pub fn int_custom_type(
 ///
 /// Constructed from [`int_custom_type`].
 pub fn int_type(width_arg: impl Into<TypeArg>) -> Type {
-    int_custom_type(width_arg.into(), &Arc::<Extension>::downgrade(&EXTENSION)).into()
+    let width_arg = width_arg.into();
+    match get_log_width(&width_arg) {
+        Ok(log_width) => INT_TYPES[usize::from(log_width)].clone(),
+        Err(_) => new_int_type(width_arg),
+    }
+}
+
+/// Initialize a integer type of a given bit width.
+///
+/// Does not attempt to use cached integer types.
+fn new_int_type(width_arg: TypeArg) -> Type {
+    int_custom_type(width_arg, &Arc::<Extension>::downgrade(&EXTENSION)).into()
 }
 
 /// Array of valid integer types, indexed by log width of the integer.
 pub static INT_TYPES: LazyLock<[Type; LOG_WIDTH_BOUND as usize]> = LazyLock::new(|| {
     (0..LOG_WIDTH_BOUND)
-        .map(|i| int_type(Term::from(u64::from(i))))
+        .map(|i| new_int_type(Term::from(u64::from(i))))
         .collect::<Vec<_>>()
         .try_into()
         .unwrap()
@@ -224,6 +235,16 @@ mod test {
     use cool_asserts::assert_matches;
 
     use super::*;
+
+    #[test]
+    fn concrete_int_types_share_storage() {
+        for log_width in 0..LOG_WIDTH_BOUND {
+            assert!(
+                int_type(TypeArg::BoundedNat(u64::from(log_width)))
+                    .shares_storage_with(&INT_TYPES[usize::from(log_width)])
+            );
+        }
+    }
 
     #[test]
     fn test_int_types_extension() {


### PR DESCRIPTION
Caches the `qb_t` / `bool_t` / etc. type helpers so they don't create a fresh `Arc` each time they get called.