### PR TITLE
fix(hugr-py): Return newest compatible version when registering an extension in a registry

### DIFF
--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -637,7 +637,9 @@ class ExtensionRegistry:
             self.versioned_extensions[extension.name] = ExtensionVersions(extension)
         else:
             self.versioned_extensions[extension.name].add(extension)
-        return self.versioned_extensions[extension.name][extension.version]
+        return self.versioned_extensions[extension.name].get_compatible(
+            extension.version
+        )
 
     def get_extension(
         self, name: ExtensionId, version: Version | None = None

--- a/hugr-py/src/hugr/ext.py
+++ b/hugr-py/src/hugr/ext.py
@@ -622,13 +622,16 @@ class ExtensionRegistry:
     def register(self, extension: Extension) -> Extension:
         """Add an extension to the registry.
 
-        If a different version of the same extension already exists, keeps both.
+        If a different non semver-compatible version of the same extension already
+        exists, keeps both.
+        If a semver-compatible version of the same extension already exists, keeps the
+        latest one.
 
         Args:
             extension: The extension to add.
 
         Returns:
-            The added extension.
+            The latest extension in the registry compatible with the given one.
 
         Raises:
             ExtensionExists: If an extension with the same name already exists.

--- a/hugr-py/tests/test_used_extensions.py
+++ b/hugr-py/tests/test_used_extensions.py
@@ -530,3 +530,12 @@ def test_packaged_versions_different_than_resolve_from() -> None:
     resolved_ext = used_exts.used_extensions.get_extension("pytest.smoke")
     # There is no op using the newer extension, and the older one is packaged
     assert resolved_ext.version == ext.Version(0, 1, 0)
+
+
+def test_registry_register_keeps_newest() -> None:
+    ext_0_1_0 = ext.Extension("pytest.smoke", ext.Version(0, 1, 0))
+    ext_0_1_1 = ext.Extension("pytest.smoke", ext.Version(0, 1, 1))
+
+    exts = ExtensionRegistry.from_extensions([ext_0_1_1])
+
+    assert exts.register(ext_0_1_0) is ext_0_1_1

--- a/hugr-py/tests/test_used_extensions.py
+++ b/hugr-py/tests/test_used_extensions.py
@@ -1,7 +1,7 @@
 # ruff: noqa: I001
 
 import hugr
-from hugr.ext import UsedExtensionResolver
+from hugr.ext import UsedExtensionResolver, ExtensionRegistry
 from hugr.package import Package
 import hugr.ops as ops
 import hugr.tys as tys
@@ -508,3 +508,25 @@ def test_default_resolution() -> None:
         if isinstance(data.op, ops.Custom):
             assert data.op.extension == extension.name
             assert data.op.op_name == op_def.name
+
+
+def test_packaged_versions_different_than_resolve_from() -> None:
+    """Resolving extensions from a registry housing a newer, but compatible version than
+    the packaged one should not fail.
+
+    Regression test for https://github.com/Quantinuum/hugr/issues/3244."""
+
+    # Two instances of the same extension with compatible versions
+    ext_0_1_0 = ext.Extension("pytest.smoke", ext.Version(0, 1, 0))
+    ext_0_1_1 = ext.Extension("pytest.smoke", ext.Version(0, 1, 1))
+
+    h = Dfg(tys.Bool)
+    h.set_outputs(*h.inputs())
+    package = Package([h.hugr], extensions=[ext_0_1_0])
+
+    exts = ExtensionRegistry.from_extensions([ext_0_1_1])
+
+    used_exts = package.used_extensions(resolve_from=exts)
+    resolved_ext = used_exts.used_extensions.get_extension("pytest.smoke")
+    # There is no op using the newer extension, and the older one is packaged
+    assert resolved_ext.version == ext.Version(0, 1, 0)


### PR DESCRIPTION
Closes #3244