### PR TITLE
feat: Improve extension resolution errors

### DIFF
--- a/hugr-core/src/envelope/reader.rs
+++ b/hugr-core/src/envelope/reader.rs
@@ -105,8 +105,9 @@ impl<R: BufRead> EnvelopeReader<R> {
 
     /// Handle extension resolution errors by recording missing extensions in the description.
     ///
-    /// This function inspects the error and adds any missing extensions to the module description
-    /// without a version.
+    /// This function inspects the error and adds any missing extensions to the module description,
+    /// preserving the required version when one was supplied.
+    #[expect(deprecated)]
     fn handle_resolution_error(desc: &mut ModuleDesc, err: &ExtensionResolutionError) {
         match err {
             ExtensionResolutionError::MissingOpExtension {
@@ -117,6 +118,12 @@ impl<R: BufRead> EnvelopeReader<R> {
             } => desc.extend_used_extensions_resolved([ExtensionDesc::new_unversioned(
                 missing_extension,
             )]),
+            ExtensionResolutionError::UnresolvedOpExtension { description, .. }
+            | ExtensionResolutionError::UnresolvedTypeExtension { description, .. } => desc
+                .extend_used_extensions_resolved([ExtensionDesc::new(
+                    &description.required_extension,
+                    description.required_version.clone(),
+                )]),
             ExtensionResolutionError::InvalidConstTypes {
                 missing_extensions, ..
             } => desc.extend_used_extensions_resolved(
@@ -417,8 +424,11 @@ mod test {
     }
 
     #[test]
+    #[expect(deprecated)]
     fn test_handle_resolution_error() {
         use crate::extension::ExtensionId;
+        use crate::extension::Version;
+        use crate::extension::resolution::ExtensionResolutionErrorDescription;
         use crate::ops::{OpName, constant::ValueName};
         use crate::types::TypeName;
 
@@ -458,6 +468,24 @@ mod test {
         };
         handle_error(&mut desc, &error);
         assert_extensions(&desc, &[&ext_id2]);
+
+        // Versioned resolution errors preserve the required version.
+        desc.used_extensions_resolved = None;
+        let required_version = Version::new(1, 2, 3);
+        let error = ExtensionResolutionError::UnresolvedTypeExtension {
+            node: None,
+            ty: TypeName::new("test.type"),
+            description: Box::new(ExtensionResolutionErrorDescription {
+                required_extension: ext_id2.clone(),
+                required_version: required_version.clone(),
+                available_extensions: vec![(ext_id2.clone(), Version::new(1, 2, 2))],
+            }),
+        };
+        handle_error(&mut desc, &error);
+        assert_eq!(
+            desc.used_extensions_resolved.as_deref(),
+            Some(&[ExtensionDesc::new(&ext_id2, required_version)][..])
+        );
 
         // Test InvalidConstTypes with multiple extensions
         desc.used_extensions_resolved = None;

--- a/hugr-core/src/envelope/reader.rs
+++ b/hugr-core/src/envelope/reader.rs
@@ -107,9 +107,10 @@ impl<R: BufRead> EnvelopeReader<R> {
     ///
     /// This function inspects the error and adds any missing extensions to the module description,
     /// preserving the required version when one was supplied.
-    #[expect(deprecated)]
     fn handle_resolution_error(desc: &mut ModuleDesc, err: &ExtensionResolutionError) {
         match err {
+            // `MissingOpExtension` and `MissingTypeExtension` will be removed in a breaking release.
+            #[expect(deprecated)]
             ExtensionResolutionError::MissingOpExtension {
                 missing_extension, ..
             }

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -333,7 +333,7 @@ impl ExtensionResolutionErrorDescription {
             .collect();
         if available_versions.is_empty() {
             return format!(
-                "extension {} is required, but it was not found. The available extensions are: {}",
+                "Extension {} is required, but it was not found. The available extensions are: {}",
                 self.required(),
                 self.available()
             );
@@ -348,13 +348,13 @@ impl ExtensionResolutionErrorDescription {
             .max()
         {
             return format!(
-                "extension {} is required, but the available version {version} is too old",
+                "Extension {} is required, but the available version {version} is too old",
                 self.required()
             );
         }
 
         format!(
-            "extension {} is required, but the available versions [{}] are incompatible",
+            "Extension {} is required, but the available versions [{}] are incompatible",
             self.required(),
             available_versions.iter().join(", ")
         )

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -312,7 +312,7 @@ impl ExtensionResolutionErrorDescription {
     }
 
     /// Format every available extension as `id@version`.
-    fn available(&self) -> String {
+    fn all_available(&self) -> String {
         self.available_extensions
             .iter()
             .map(|(id, version)| format!("{id}@{version}"))
@@ -335,7 +335,7 @@ impl ExtensionResolutionErrorDescription {
             return format!(
                 "Extension {} is required, but it was not found. The available extensions are: {}",
                 self.required(),
-                self.available()
+                self.all_available()
             );
         }
         if let Some(version) = available_versions
@@ -347,9 +347,18 @@ impl ExtensionResolutionErrorDescription {
             })
             .max()
         {
+            let others = available_versions
+                .iter()
+                .filter(|&&v| v != version)
+                .join(", ");
             return format!(
-                "Extension {} is required, but the available version {version} is too old",
-                self.required()
+                "Extension {} is required, but the available version {version} is too old{}",
+                self.required(),
+                if others.is_empty() {
+                    String::new()
+                } else {
+                    format!(". Other available versions: {others}")
+                }
             );
         }
 

--- a/hugr-core/src/extension/resolution.rs
+++ b/hugr-core/src/extension/resolution.rs
@@ -29,8 +29,9 @@ pub(crate) use types::{collect_op_types_extensions, collect_signature_exts, coll
 pub(crate) use types_mut::TypeExtensionResolver;
 
 use derive_more::{Display, Error, From};
+use itertools::Itertools;
 
-use super::{Extension, ExtensionId, ExtensionRegistry, ExtensionSet};
+use super::{Extension, ExtensionId, ExtensionRegistry, ExtensionSet, Version, semver_compatible};
 use crate::Node;
 use crate::core::HugrNode;
 use crate::ops::constant::ValueName;
@@ -78,7 +79,8 @@ pub enum ExtensionResolutionError<N: HugrNode = Node> {
     #[display("Error resolving opaque operation: {_0}")]
     #[from]
     OpaqueOpError(OpaqueOpError<N>),
-    /// An operation requires an extension that is not in the given registry.
+    /// A legacy unversioned operation requires an extension that is not in the registry.
+    #[deprecated(since = "0.30.2", note = "use `UnresolvedOpExtension` instead")]
     #[display(
         "{op}{} requires extension {missing_extension}, but it could not be found in the extension list used during resolution. The available extensions are: {}",
         node.map(|n| format!(" in {n}")).unwrap_or_default(),
@@ -94,7 +96,8 @@ pub enum ExtensionResolutionError<N: HugrNode = Node> {
         /// A list of available extensions.
         available_extensions: Vec<ExtensionId>,
     },
-    /// A type references an extension that is not in the given registry.
+    /// A legacy unversioned type references an extension that is not in the registry.
+    #[deprecated(since = "0.30.2", note = "use `UnresolvedTypeExtension` instead")]
     #[display(
         "Type {ty}{} requires extension {missing_extension}, but it could not be found in the extension list used during resolution. The available extensions are: {}",
         node.map(|n| format!(" in {n}")).unwrap_or_default(),
@@ -148,10 +151,40 @@ pub enum ExtensionResolutionError<N: HugrNode = Node> {
     #[display("Error collecting extension dependencies: {_0}")]
     #[from]
     ExtensionDependencyError(ExtensionCollectionError<N>),
+    /// A versioned extension required by an operation could not be resolved.
+    #[display(
+        "Could not resolve operation {op}{}: {}",
+        node.map(|n| format!(" in {n}")).unwrap_or_default(),
+        description.failure()
+    )]
+    UnresolvedOpExtension {
+        /// The node that requires the extension.
+        node: Option<N>,
+        /// The operation that requires the extension.
+        op: OpName,
+        /// The required and available extension versions.
+        description: Box<ExtensionResolutionErrorDescription>,
+    },
+    /// A versioned extension required by a type could not be resolved.
+    #[display(
+        "Could not resolve type {ty}{}: {}",
+        node.map(|n| format!(" in {n}")).unwrap_or_default(),
+        description.failure()
+    )]
+    UnresolvedTypeExtension {
+        /// The node that requires the extension.
+        node: Option<N>,
+        /// The type that requires the extension.
+        ty: TypeName,
+        /// The required and available extension versions.
+        description: Box<ExtensionResolutionErrorDescription>,
+    },
 }
 
 impl<N: HugrNode> ExtensionResolutionError<N> {
-    /// Create a new error for missing operation extensions.
+    /// Create an error for a missing legacy unversioned operation extension.
+    #[deprecated(since = "0.30.2", note = "use `unresolved_op_extension` instead")]
+    #[expect(deprecated)]
     pub fn missing_op_extension(
         node: Option<N>,
         op: &OpType,
@@ -166,7 +199,9 @@ impl<N: HugrNode> ExtensionResolutionError<N> {
         }
     }
 
-    /// Create a new error for missing type extensions.
+    /// Create an error for a missing legacy unversioned type extension.
+    #[deprecated(since = "0.30.2", note = "use `unresolved_type_extension` instead")]
+    #[expect(deprecated)]
     pub fn missing_type_extension(
         node: Option<N>,
         ty: &TypeName,
@@ -179,6 +214,150 @@ impl<N: HugrNode> ExtensionResolutionError<N> {
             missing_extension: missing_extension.clone(),
             available_extensions: extensions.ids().cloned().collect(),
         }
+    }
+
+    /// Create an error for a failed versioned operation extension lookup.
+    pub fn unresolved_op_extension(
+        node: Option<N>,
+        op: OpName,
+        required_extension: &ExtensionId,
+        required_version: &Version,
+        extensions: &ExtensionRegistry,
+    ) -> Self {
+        let description = Box::new(ExtensionResolutionErrorDescription::from_registry(
+            required_extension,
+            required_version,
+            extensions,
+        ));
+        Self::UnresolvedOpExtension {
+            node,
+            op,
+            description,
+        }
+    }
+
+    /// Create an error for a failed versioned type extension lookup.
+    pub fn unresolved_type_extension(
+        node: Option<N>,
+        ty: &TypeName,
+        required_extension: &ExtensionId,
+        required_version: &Version,
+        extensions: &WeakExtensionRegistry,
+    ) -> Self {
+        let description = Box::new(ExtensionResolutionErrorDescription::from_weak_registry(
+            required_extension,
+            required_version,
+            extensions,
+        ));
+        Self::UnresolvedTypeExtension {
+            node,
+            ty: ty.clone(),
+            description,
+        }
+    }
+}
+
+/// Version information for an extension that could not be resolved.
+///
+/// The available extensions are stored in registry order so diagnostics are
+/// deterministic. Each entry includes both its id and version, allowing the
+/// description to be shared by missing-extension and version-mismatch errors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ExtensionResolutionErrorDescription {
+    /// The required extension id.
+    pub required_extension: ExtensionId,
+    /// The minimum compatible extension version required by the HUGR.
+    pub required_version: Version,
+    /// The extension versions available during resolution.
+    pub available_extensions: Vec<(ExtensionId, Version)>,
+}
+
+impl ExtensionResolutionErrorDescription {
+    /// Describe a failed lookup in a strong extension registry.
+    fn from_registry(
+        required_extension: &ExtensionId,
+        required_version: &Version,
+        extensions: &ExtensionRegistry,
+    ) -> Self {
+        Self {
+            required_extension: required_extension.clone(),
+            required_version: required_version.clone(),
+            available_extensions: extensions
+                .iter_all()
+                .map(|extension| (extension.name().clone(), extension.version().clone()))
+                .collect(),
+        }
+    }
+
+    /// Describe a failed lookup in a weak extension registry.
+    fn from_weak_registry(
+        required_extension: &ExtensionId,
+        required_version: &Version,
+        extensions: &WeakExtensionRegistry,
+    ) -> Self {
+        Self {
+            required_extension: required_extension.clone(),
+            required_version: required_version.clone(),
+            available_extensions: extensions
+                .iter_all()
+                .map(|(id, version, _)| (id.clone(), version.clone()))
+                .collect(),
+        }
+    }
+
+    /// Format the required extension as `id@version`.
+    fn required(&self) -> String {
+        format!("{}@{}", self.required_extension, self.required_version)
+    }
+
+    /// Format every available extension as `id@version`.
+    fn available(&self) -> String {
+        self.available_extensions
+            .iter()
+            .map(|(id, version)| format!("{id}@{version}"))
+            .join(", ")
+    }
+
+    /// Explain why the extension requirement could not be resolved.
+    ///
+    /// If the extension id is absent, the complete registry contents are
+    /// included. A lower version in the same compatibility group means that
+    /// the requirement is newer than the registry entry. Otherwise, all
+    /// versions registered under the requested extension id are incompatible.
+    fn failure(&self) -> String {
+        let available_versions: Vec<_> = self
+            .available_extensions
+            .iter()
+            .filter_map(|(id, version)| (id == &self.required_extension).then_some(version))
+            .collect();
+        if available_versions.is_empty() {
+            return format!(
+                "extension {} is required, but it was not found. The available extensions are: {}",
+                self.required(),
+                self.available()
+            );
+        }
+        if let Some(version) = available_versions
+            .iter()
+            .copied()
+            .filter(|version| {
+                *version < &self.required_version
+                    && semver_compatible(&self.required_version, version)
+            })
+            .max()
+        {
+            return format!(
+                "extension {} is required, but the available version {version} is too old",
+                self.required()
+            );
+        }
+
+        format!(
+            "extension {} is required, but the available versions [{}] are incompatible",
+            self.required(),
+            available_versions.iter().join(", ")
+        )
     }
 }
 

--- a/hugr-core/src/extension/resolution/ops.rs
+++ b/hugr-core/src/extension/resolution/ops.rs
@@ -76,11 +76,21 @@ pub(crate) fn resolve_op_extensions<'e>(
         unqualified_id: impl AsRef<OpNameRef>,
     ) -> Result<(&'e Arc<OpDef>, &'e Arc<Extension>), ExtensionResolutionError> {
         let Some(extension) = extensions.get_req(ext_id, ext_version) else {
-            return Err(ExtensionResolutionError::MissingOpExtension {
-                node: Some(node),
-                op: qualified_id.as_ref().into(),
-                missing_extension: ext_id.clone(),
-                available_extensions: extensions.ids().cloned().collect(),
+            return Err(match ext_version {
+                Some(version) => ExtensionResolutionError::unresolved_op_extension(
+                    Some(node),
+                    qualified_id.as_ref().into(),
+                    ext_id,
+                    version,
+                    extensions,
+                ),
+                #[expect(deprecated)]
+                None => ExtensionResolutionError::MissingOpExtension {
+                    node: Some(node),
+                    op: qualified_id.as_ref().into(),
+                    missing_extension: ext_id.clone(),
+                    available_extensions: extensions.ids().cloned().collect(),
+                },
             });
         };
         let Some(op_def) = extension.get_op(unqualified_id.as_ref()) else {

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -203,7 +203,7 @@ fn opaque_op_reports_version_mismatch(
             .contains(&format!("{ext_id}@{required_version}"))
     );
     assert!(error.to_string().contains(expected_reason));
-    assert!(!error.to_string().contains("other_ext@9.0.0"));
+    assert!(!error.to_string().contains(&format!("{other_id}@9.0.0")));
 }
 
 #[rstest]

--- a/hugr-core/src/extension/resolution/test.rs
+++ b/hugr-core/src/extension/resolution/test.rs
@@ -12,7 +12,9 @@ use crate::builder::{
 };
 use crate::envelope::{EnvelopeConfig, EnvelopeFormat};
 use crate::extension::prelude::{ConstUsize, bool_t, usize_custom_t, usize_t};
-use crate::extension::resolution::WeakExtensionRegistry;
+use crate::extension::resolution::{
+    ExtensionResolutionError, ExtensionResolutionErrorDescription, WeakExtensionRegistry,
+};
 use crate::extension::resolution::{
     resolve_op_extensions, resolve_type_extensions as resolve_type_extension_refs,
 };
@@ -150,6 +152,162 @@ fn resolve_custom_type_uses_highest_compatible_extension() {
         panic!("expected custom type");
     };
     assert_eq!(custom.extension_version(), Some(&Version::new(0, 2, 5)));
+}
+
+#[rstest]
+#[case::too_new(Version::new(0, 2, 6), "the available version 0.2.5 is too old")]
+#[case::incompatible(
+    Version::new(0, 4, 0),
+    "the available versions [0.2.5, 0.3.0] are incompatible"
+)]
+fn opaque_op_reports_version_mismatch(
+    #[case] required_version: Version,
+    #[case] expected_reason: &str,
+) {
+    let ext_id = ExtensionId::new_unchecked("versioned_ext");
+    let other_id = ExtensionId::new_unchecked("other_ext");
+    let registry = ExtensionRegistry::new([
+        make_versioned_extension(&ext_id, Version::new(0, 2, 5)),
+        make_versioned_extension(&ext_id, Version::new(0, 3, 0)),
+        make_versioned_extension(&other_id, Version::new(9, 0, 0)),
+    ]);
+    let mut op: OpType = OpaqueOp::new(
+        ext_id.clone(),
+        required_version.clone(),
+        "my_op",
+        [],
+        Signature::new_endo([bool_t()]),
+    )
+    .into();
+
+    let node = portgraph::NodeIndex::new(0).into();
+    let error = resolve_op_extensions(node, &mut op, &registry).unwrap_err();
+    let ExtensionResolutionError::UnresolvedOpExtension { description, .. } = &error else {
+        panic!("expected an operation extension version mismatch, got {error:?}");
+    };
+    assert_eq!(
+        description.as_ref(),
+        &ExtensionResolutionErrorDescription {
+            required_extension: ext_id.clone(),
+            required_version: required_version.clone(),
+            available_extensions: vec![
+                (other_id.clone(), Version::new(9, 0, 0)),
+                (ext_id.clone(), Version::new(0, 2, 5)),
+                (ext_id.clone(), Version::new(0, 3, 0)),
+            ],
+        }
+    );
+    assert!(
+        error
+            .to_string()
+            .contains(&format!("{ext_id}@{required_version}"))
+    );
+    assert!(error.to_string().contains(expected_reason));
+    assert!(!error.to_string().contains("other_ext@9.0.0"));
+}
+
+#[rstest]
+#[case::too_new(Version::new(0, 2, 6), "the available version 0.2.5 is too old")]
+#[case::incompatible(
+    Version::new(0, 4, 0),
+    "the available versions [0.2.5, 0.3.0] are incompatible"
+)]
+fn custom_type_reports_version_mismatch(
+    #[case] required_version: Version,
+    #[case] expected_reason: &str,
+) {
+    let ext_id = ExtensionId::new_unchecked("versioned_type_ext");
+    let registry = ExtensionRegistry::new([
+        make_versioned_extension(&ext_id, Version::new(0, 2, 5)),
+        make_versioned_extension(&ext_id, Version::new(0, 3, 0)),
+    ]);
+    let weak_registry = WeakExtensionRegistry::from(&registry);
+    let custom = CustomType::new(
+        "MyType",
+        [],
+        ext_id.clone(),
+        required_version.clone(),
+        TypeBound::Copyable,
+        &Default::default(),
+    );
+
+    let error =
+        resolve_type_extension_refs(&mut Type::new_extension(custom.clone()), &weak_registry)
+            .unwrap_err();
+    let ExtensionResolutionError::UnresolvedTypeExtension { description, .. } = &error else {
+        panic!("expected a type extension version mismatch, got {error:?}");
+    };
+    assert_eq!(
+        description.as_ref(),
+        &ExtensionResolutionErrorDescription {
+            required_extension: ext_id.clone(),
+            required_version: required_version.clone(),
+            available_extensions: vec![
+                (ext_id.clone(), Version::new(0, 2, 5)),
+                (ext_id.clone(), Version::new(0, 3, 0)),
+            ],
+        }
+    );
+    assert!(
+        error
+            .to_string()
+            .contains(&format!("{ext_id}@{required_version}"))
+    );
+    assert!(error.to_string().contains(expected_reason));
+}
+
+#[test]
+fn opaque_op_reports_versioned_missing_extension() {
+    let ext_id = ExtensionId::new_unchecked("missing_ext");
+    let required_version = Version::new(1, 2, 3);
+    let registry = ExtensionRegistry::new([make_versioned_extension(
+        &ExtensionId::new_unchecked("available_ext"),
+        Version::new(2, 0, 0),
+    )]);
+    let mut op: OpType = OpaqueOp::new(
+        ext_id.clone(),
+        required_version.clone(),
+        "my_op",
+        [],
+        Signature::new_endo([bool_t()]),
+    )
+    .into();
+
+    let node = portgraph::NodeIndex::new(0).into();
+    let error = resolve_op_extensions(node, &mut op, &registry).unwrap_err();
+    assert!(matches!(
+        error,
+        ExtensionResolutionError::UnresolvedOpExtension { .. }
+    ));
+    assert!(error.to_string().contains("missing_ext@1.2.3"));
+    assert!(error.to_string().contains("available_ext@2.0.0"));
+}
+
+#[test]
+fn custom_type_reports_versioned_missing_extension() {
+    let ext_id = ExtensionId::new_unchecked("missing_type_ext");
+    let required_version = Version::new(1, 2, 3);
+    let registry = ExtensionRegistry::new([make_versioned_extension(
+        &ExtensionId::new_unchecked("available_ext"),
+        Version::new(2, 0, 0),
+    )]);
+    let weak_registry = WeakExtensionRegistry::from(&registry);
+    let mut typ = Type::new_extension(CustomType::new(
+        "MyType",
+        [],
+        ext_id,
+        required_version,
+        TypeBound::Copyable,
+        &Default::default(),
+    ));
+
+    let error = resolve_type_extension_refs(&mut typ, &weak_registry).unwrap_err();
+    assert!(matches!(
+        error,
+        ExtensionResolutionError::UnresolvedTypeExtension { .. }
+    ));
+    assert!(error.to_string().contains("missing_type_ext@1.2.3"));
+    assert!(error.to_string().contains("available_ext@2.0.0"));
 }
 
 /// Resolving an already-resolved type should preserve its shared storage.

--- a/hugr-core/src/extension/resolution/types_mut.rs
+++ b/hugr-core/src/extension/resolution/types_mut.rs
@@ -201,16 +201,25 @@ impl<'a> TypeExtensionResolver<'a> {
         }
 
         let ext_id = custom.extension();
+        let required_version = custom.extension_version();
         let (version, extension) = self
             .extensions
-            .get_req(ext_id, custom.extension_version())
-            .ok_or_else(|| {
-                ExtensionResolutionError::missing_type_extension(
+            .get_req(ext_id, required_version)
+            .ok_or_else(|| match required_version {
+                Some(version) => ExtensionResolutionError::unresolved_type_extension(
+                    node,
+                    custom.name(),
+                    ext_id,
+                    version,
+                    self.extensions,
+                ),
+                #[expect(deprecated)]
+                None => ExtensionResolutionError::missing_type_extension(
                     node,
                     custom.name(),
                     ext_id,
                     self.extensions,
-                )
+                ),
             })?;
 
         self.used_extensions

--- a/hugr-py/tests/test_cli.py
+++ b/hugr-py/tests/test_cli.py
@@ -169,6 +169,6 @@ def test_failed_describe(hugr_using_ext):
     assert mod.num_nodes == 8  # computed before error
     assert mod.num_edges == 2  # computed before extension resolution error
     assert isinstance(desc.error, str)
-    assert "requires extension ext" in desc.error
+    assert "extension ext@0.1.0 is required" in desc.error
 
     assert desc.uses_extension("ext")

--- a/hugr-py/tests/test_cli.py
+++ b/hugr-py/tests/test_cli.py
@@ -169,6 +169,6 @@ def test_failed_describe(hugr_using_ext):
     assert mod.num_nodes == 8  # computed before error
     assert mod.num_edges == 2  # computed before extension resolution error
     assert isinstance(desc.error, str)
-    assert "extension ext@0.1.0 is required" in desc.error
+    assert "Extension ext@0.1.0 is required" in desc.error
 
     assert desc.uses_extension("ext")


### PR DESCRIPTION
Improves the error message when an op/type cannot be resolved from the set of extensions.

Possible messages include:

- `Could not resolve operation foo.bar: Extension foo@0.1.2 is required, but the available version 0.1.1 is too old`
- `Could not resolve type foo.baz in Node(4): Extension foo@0.1.2 is required, but the available versions [0.0.1, 1.2.3] are incompatible`
- `Could not resolve operation foo.bar: Extension foo@0.1.2 is required, but it was not found. The available extensions are: X@0.0.1, Y@0.1.2`