### PR TITLE
chore: Use a supported dependabot strategy for uv ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,19 @@ updates:
     labels:
       - "X-dependabot"
       - "A-python"
-    versioning-strategy: "increase-if-necessary"
+    # Do not bump the minimal version of dependencies.
+    #
+    # Bumping the minimum can be a breaking change for downstream python users,
+    # as they may break their dependency resolution and prevent them from updating.
+    #
+    # Ideally we'd widen the upper bound.
+    # The dependabot documentation indicates this can be done by setting versioning-strategy to "widen",
+    # but this returned errors saying that the value is invalid.
+    # (https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#versioning-strategy--)
+    #
+    # See the uv versioning-strategy issue:
+    # <https://github.com/dependabot/dependabot-core/issues/15290>
+    versioning-strategy: "lockfile-only"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,7 +46,7 @@ updates:
     labels:
       - "X-dependabot"
       - "A-python"
-    versioning-strategy: "widen"
+    versioning-strategy: "increase-if-necessary"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
`widen` is not supported for the `uv` ecosystem yet:
```
The property '#/updates/1/versioning-strategy' value "widen" did not match one of the following values: lockfile-only, auto, increase, increase-if-necessary
```
Thus we use `increase-if-necessary` for now, since that is really similar to `widen`.